### PR TITLE
Feature/fix response body language

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -107,7 +107,9 @@ module.exports = {
           default: 'schema type not provided'
         };
       }
-      schema.type = 'string';
+      if (!schema.type) {
+        schema.type = 'string';
+      }
       delete schema.format;
     }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1073,7 +1073,8 @@ module.exports = {
     var responseHeaders = [],
       previewLanguage = 'text',
       responseBodyWrapper,
-      header;
+      header,
+      sdkResponse;
 
     if (!response) {
       return null;
@@ -1101,6 +1102,9 @@ module.exports = {
       if (responseBodyWrapper.contentTypeHeader === APP_JSON) {
         previewLanguage = 'json';
       }
+      else if (responseBodyWrapper.contentTypeHeader === APP_XML) {
+        previewLanguage = 'xml';
+      }
     }
     else if (response.content && Object.keys(response.content).length > 0) {
       responseHeaders.push({ key: 'Content-Type', value: Object.keys(response.content)[0] });
@@ -1116,14 +1120,16 @@ module.exports = {
     }
     code = code.replace(/X/g, '0');
 
-    return new sdk.Response({
+    sdkResponse = new sdk.Response({
       name: response.description,
       code: code === 'default' ? 500 : Number(code),
       header: responseHeaders,
       body: responseBodyWrapper.responseBody,
-      originalRequest: originalRequest,
-      _postman_previewlanguage: previewLanguage
+      originalRequest: originalRequest
     });
+    sdkResponse._postman_previewlanguage = previewLanguage;
+
+    return sdkResponse;
   },
 
   /**

--- a/test/unit/deref.test.js
+++ b/test/unit/deref.test.js
@@ -34,7 +34,7 @@ describe('DEREF FUNCTION TESTS ', function() {
       output = deref.resolveRefs(schema, components);
     expect(output).to.deep.include({ type: 'object',
       required: ['id'],
-      properties: { id: { default: '<long>', type: 'string' } } });
+      properties: { id: { default: '<long>', type: 'integer' } } });
     done();
   });
 });

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -1315,7 +1315,7 @@ describe('UTILITY FUNCTION TESTS ', function () {
         pmResponseBody = Utils.convertToPmResponseBody(contentObj).responseBody;
         expect(pmResponseBody).to.equal(
           [
-            '<Person id="(string)">',
+            '<Person id="(integer)">',
             ' <sample:name xmlns:sample="http://example.com/schema/sample">(string)</sample:name>',
             ' <hobbies>',
             '  <hobbies>(string)</hobbies>',

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -1341,7 +1341,7 @@ describe('UTILITY FUNCTION TESTS ', function () {
   });
 
   describe('convertToPmResponse function', function() {
-    it('should convert response with content field', function(done) {
+    it('should convert response with JSON content field', function(done) {
       var response = {
           'description': 'A list of pets.',
           'content': {
@@ -1373,12 +1373,52 @@ describe('UTILITY FUNCTION TESTS ', function () {
       responseBody = JSON.parse(pmResponse.body);
       expect(pmResponse.name).to.equal(response.description);
       expect(pmResponse.code).to.equal(200);
+      expect(pmResponse._postman_previewlanguage).to.equal('json');
       expect(pmResponse.header).to.deep.include({
         'key': 'Content-Type',
         'value': 'application/json'
       });
       expect(responseBody.id).to.equal('<long>');
       expect(responseBody.name).to.equal('<string>');
+      done();
+    });
+    it('should convert response with XML content field', function(done) {
+      var response = {
+          'description': 'A list of pets.',
+          'content': {
+            'application/xml': {
+              'schema': {
+                'type': 'object',
+                'required': [
+                  'id',
+                  'name'
+                ],
+                'properties': {
+                  id: {
+                    type: 'integer',
+                    format: 'int64'
+                  },
+                  name: {
+                    type: 'string'
+                  }
+                }
+              }
+            }
+          }
+        },
+        code = '20X',
+        pmResponse;
+
+      Utils.options.schemaFaker = true;
+      pmResponse = Utils.convertToPmResponse(response, code).toJSON();
+      expect(pmResponse.body).to.equal('<element>\n <id>(integer)</id>\n <name>(string)</name>\n</element>');
+      expect(pmResponse.name).to.equal(response.description);
+      expect(pmResponse.code).to.equal(200);
+      expect(pmResponse._postman_previewlanguage).to.equal('xml');
+      expect(pmResponse.header).to.deep.include({
+        'key': 'Content-Type',
+        'value': 'application/xml'
+      });
       done();
     });
     it('sholud convert response without content field', function(done) {


### PR DESCRIPTION
1. _postman_previewlanguage is set correctly while saving response bodies
2. non-string property types aren't overriden during schema faking