### PR TITLE
$ref param is a URI string so should be decoded

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1202,7 +1202,7 @@ module.exports = {
 
     // $ref is a URI and so maybe encoded eg ODATA system options like "%24filter" -> "$filter"
     $ref = decodeURIComponent($ref);
-    
+
     savedSchema = $ref.split('/').slice(1).map((elem) => {
       // https://swagger.io/docs/specification/using-ref#escape
       // since / is the default delimiter, slashes are escaped with ~1

--- a/lib/util.js
+++ b/lib/util.js
@@ -1200,7 +1200,7 @@ module.exports = {
   getRefObject: function($ref) {
     var refObj, savedSchema;
 
-    //$ref is a URI and so maybe encoded eg ODATA system options like "%24filter" -> "$filter"
+    // $ref is a URI and so maybe encoded eg ODATA system options like "%24filter" -> "$filter"
     $ref = decodeURIComponent($ref);
     
     savedSchema = $ref.split('/').slice(1).map((elem) => {

--- a/lib/util.js
+++ b/lib/util.js
@@ -1193,13 +1193,16 @@ module.exports = {
   },
 
   /**
-   * @param {*} $ref reference object
+   * @param {*} $ref reference URI string
    * @returns {Object} reference object from the saved components
    * @no-unit-tests
    */
   getRefObject: function($ref) {
     var refObj, savedSchema;
 
+    //$ref is a URI and so maybe encoded eg ODATA system options like "%24filter" -> "$filter"
+    $ref = decodeURIComponent($ref);
+    
     savedSchema = $ref.split('/').slice(1).map((elem) => {
       // https://swagger.io/docs/specification/using-ref#escape
       // since / is the default delimiter, slashes are escaped with ~1


### PR DESCRIPTION
[swagger docs](https://swagger.io/docs/specification/using-ref/) spec $ref as a URI. So we should decode URI be fore use to allow for reserved characters in the [RFC986](https://tools.ietf.org/html/rfc3986) spec. This allows refs to things like ODATA system options like $filter, $orderby etc that must be encoded to %24filter.