### PR TITLE
Update sample to read as string not buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ function (err, result) {
 ```javascript
 var fs = require('fs'),
   Converter = require('openapi-to-postmanv2'),
-  openapiData = fs.readFileSync('sample-spec.yaml');
+  openapiData = fs.readFileSync('sample-spec.yaml', {encoding: 'UTF8'});
 
- Converter.convert({ type: 'string', data: specPath },
+ Converter.convert({ type: 'string', data: openapiData },
   {}, (err, conversionResult) => {
     if (!conversionResult.result) {
       console.log('Could not convert', conversionResult.reason);


### PR DESCRIPTION
Thanks for the great work on this tool. Just a quick samples update to help out new users...
If the encoding option is not specified in the readFileSync method, then the return type is an ArrayBuffer not a string. Also change the convert param to the use return value of the readFileSync method.