### PR TITLE
Fix crash of the converter if openapi specs contain a root endpoint (path: `/`)

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -298,11 +298,13 @@ module.exports = {
         }
 
         // split the path into indiv. segments for trie generation
-        currentPath = path.split('/').filter((pathItem) => {
+        // unless path it the root endpoint
+        currentPath = path === '' ? [''] : path.split('/').filter((pathItem) => {
           // remove any empty pathItems that might have cropped in
           // due to trailing or double '/' characters
           return pathItem !== '';
         });
+
         pathLength = currentPath.length;
 
         // get method names available for this path

--- a/lib/util.js
+++ b/lib/util.js
@@ -299,7 +299,7 @@ module.exports = {
 
         // split the path into indiv. segments for trie generation
         // unless path it the root endpoint
-        currentPath = path === '' ? [''] : path.split('/').filter((pathItem) => {
+        currentPath = path === '' ? ['(root)'] : path.split('/').filter((pathItem) => {
           // remove any empty pathItems that might have cropped in
           // due to trailing or double '/' characters
           return pathItem !== '';

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -357,14 +357,7 @@ describe('UTILITY FUNCTION TESTS ', function () {
                 'operationId': 'listPets',
                 'responses': {
                   '200': {
-                    'description': 'An paged array of pets',
-                    'content': {
-                      'application/json': {
-                        'schema': {
-                          '$ref': '#/components/schemas/Pets'
-                        }
-                      }
-                    }
+                    'description': 'An paged array of pets'
                   }
                 }
               }

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -367,9 +367,9 @@ describe('UTILITY FUNCTION TESTS ', function () {
         output = Utils.generateTrieFromPaths(openapi),
         root = output.tree.root;
 
-      expect(root.children).to.be.an('object').that.has.all.keys('');
-      expect(root.children[''].requestCount).to.equal(1);
-      expect(root.children[''].requests.length).to.equal(1);
+      expect(root.children).to.be.an('object').that.has.all.keys('(root)');
+      expect(root.children['(root)'].requestCount).to.equal(1);
+      expect(root.children['(root)'].requests.length).to.equal(1);
 
       done();
     });

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -333,6 +333,53 @@ describe('UTILITY FUNCTION TESTS ', function () {
       expect(collectionVariables).to.have.key('petUrl');
       done();
     });
+
+    // https://github.com/postmanlabs/openapi-to-postman/issues/80
+    it('should generate trie taking swagger specs with root endpoint declaration as input.', function (done) {
+      var openapi = {
+          'openapi': '3.0.0',
+          'info': {
+            'version': '1.0.0',
+            'title': 'Swagger Petstore',
+            'license': {
+              'name': 'MIT'
+            }
+          },
+          'servers': [
+            {
+              'url': 'http://petstore.swagger.io/{v1}'
+            }
+          ],
+          'paths': {
+            '/': {
+              'get': {
+                'summary': 'List all pets',
+                'operationId': 'listPets',
+                'responses': {
+                  '200': {
+                    'description': 'An paged array of pets',
+                    'content': {
+                      'application/json': {
+                        'schema': {
+                          '$ref': '#/components/schemas/Pets'
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        output = Utils.generateTrieFromPaths(openapi),
+        root = output.tree.root;
+
+      expect(root.children).to.be.an('object').that.has.all.keys('');
+      expect(root.children[''].requestCount).to.equal(1);
+      expect(root.children[''].requests.length).to.equal(1);
+
+      done();
+    });
   });
 
   describe('convertPathVariables', function() {


### PR DESCRIPTION
I also added a unit test for this case