### PR TITLE
Support falsy values as default

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -160,7 +160,7 @@ module.exports = {
       schema.minItems = 2;
       schema.items = this.resolveRefs(schema.items, components, stack);
     }
-    else if (!schema.default) {
+    else if (schema.default === undefined) {
       if (schema.hasOwnProperty('type')) {
         if (!schema.hasOwnProperty('format')) {
           schema.default = '<' + schema.type + '>';


### PR DESCRIPTION
"falsy" values as default are currently interpreted as if there is no default value. The "&lt;type&gt;" is then used as default in the request.