### PR TITLE
Fix #90 - Ensure paths are added to operations with custom servers

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1248,7 +1248,7 @@ module.exports = {
       itemParams = operationItem.properties.parameters,
       reqParams = this.getParametersForPathItem(itemParams),
       baseUrl = openapi.baseUrl,
-      pathVarArray,
+      pathVarArray = [],
       authHelper,
       item,
       serverObj,
@@ -1265,6 +1265,8 @@ module.exports = {
     if (operationItem.properties.hasOwnProperty('servers')) {
       serverObj = operationItem.properties.servers[0];
       baseUrl = serverObj.url.replace(/{/g, ':').replace(/}/g, '');
+      baseUrl += reqUrl;
+
       if (serverObj.variables) {
         pathVarArray = this.convertPathVariables('method', [], serverObj.variables);
       }


### PR DESCRIPTION
Closes #90.

Ensures that the path of a request is appended to a custom base URL for those operations that have different servers specified.

Additionally, because pathVarArray is not necessarily initialised for a custom server, we instead initialize it with an empty array to prevent further errors.

Lacks tests as I didn’t see any specific tests for this function. I’m not sure where to add these.