### PR TITLE
Handling missing body properties

### DIFF
--- a/lib/trie.js
+++ b/lib/trie.js
@@ -15,7 +15,7 @@ function Node (options) {
   // stores all direct folder descendants of this node
   this.children = {};
 
-  this.requests = options ? options.requests : []; // request will be an array of objects
+  this.requests = []; // request will always be an array of objects
 
   this.addChildren = function (child, value) {
     this.children[child] = value;

--- a/lib/util.js
+++ b/lib/util.js
@@ -280,7 +280,7 @@ module.exports = {
       // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#pathItemObject
       getPathMethods = function(pathKeys) {
         var methods = [];
-        pathKeys.forEach(function(element) {
+        pathKeys && pathKeys.forEach(function(element) {
           if (METHODS.includes(element)) {
             methods.push(element);
           }
@@ -321,8 +321,6 @@ module.exports = {
             currentNode.addChildren(currentPath[i], new Node({
               name: currentPath[i],
               requestCount: 0,
-              requests: [],
-              children: {},
               type: 'item-group'
             }));
           }
@@ -1012,7 +1010,7 @@ module.exports = {
             type: typeof value
           };
           params = this.convertParamsWithStyle(encoding[key], value);
-          params.forEach((element) => {
+          params && params.forEach((element) => {
             if (typeof element.value === 'object') { element.value = JSON.stringify(element.value); }
             // element.value = JSON.stringify(element.value);
             delete element.description;
@@ -1387,7 +1385,7 @@ module.exports = {
       item.request.body = pmBody.body;
       item.request.addHeader(pmBody.contentHeader);
       // extra form headers if encoding is present in request Body.
-      pmBody.formHeaders.forEach((element) => {
+      pmBody.formHeaders && pmBody.formHeaders.forEach((element) => {
         item.request.addHeader(element);
       });
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -280,6 +280,7 @@ module.exports = {
       // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#pathItemObject
       getPathMethods = function(pathKeys) {
         var methods = [];
+        // TODO: Show warning for incorrect schema if !pathKeys
         pathKeys && pathKeys.forEach(function(element) {
           if (METHODS.includes(element)) {
             methods.push(element);
@@ -1010,6 +1011,7 @@ module.exports = {
             type: typeof value
           };
           params = this.convertParamsWithStyle(encoding[key], value);
+          // TODO: Show warning for incorrect schema if !params
           params && params.forEach((element) => {
             if (typeof element.value === 'object') { element.value = JSON.stringify(element.value); }
             // element.value = JSON.stringify(element.value);
@@ -1385,6 +1387,7 @@ module.exports = {
       item.request.body = pmBody.body;
       item.request.addHeader(pmBody.contentHeader);
       // extra form headers if encoding is present in request Body.
+      // TODO: Show warning for incorrect schema if !pmBody.formHeaders
       pmBody.formHeaders && pmBody.formHeaders.forEach((element) => {
         item.request.addHeader(element);
       });

--- a/test/data/valid_openapi/wrong-body.yaml
+++ b/test/data/valid_openapi/wrong-body.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.0
+info:
+    description:
+        Test Service
+    version: 0.1
+    title: Test Service Name
+servers:
+    -   url: https://test.com
+        description: Test API
+paths:
+    /entity:
+        put:
+            summary: Update entity
+            operationId: updateEntity
+            requestBody:
+                schema: object # This is wrong,
+                # but the converter should just ignore the formHeaders if not present
+            responses:
+                200:
+                    description: 200 OK

--- a/test/unit/convert.temp.js
+++ b/test/unit/convert.temp.js
@@ -24,9 +24,10 @@ describe('The converter must generate a collection conforming to the schema', fu
           expect(err).to.be.null;
 
           let collection = conversionResult.output[0].data;
-          // eslint-disable-next-line no-console
-          // console.log(JSON.stringify(collection, null, 2));
-          fs.writeFileSync('./temp/temp-collection.json', JSON.stringify(collection, null, 2));
+          fs.writeFileSync(
+            path.join(__dirname, '../data/.temp/temp-collection.json'),
+            JSON.stringify(collection, null, 2)
+          );
           done();
         });
     });


### PR DESCRIPTION
This handles cases where a method's body is incorrectly specified. In such scenarios, we prefer to ignore areas of the spec we can't convert.