### PR TITLE
Manually stringifying query param values that are faked as booleans

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -753,7 +753,7 @@ module.exports = {
         safeSchemaFaker(param.schema, this.components, SCHEMA_FORMATS.DEFAULT) : '';
       // paramType = param.schema.type;
 
-      if (typeof paramValue === 'number') {
+      if (typeof paramValue === 'number' || typeof paramValue === 'boolean') {
         // the SDK will keep the number-ness,
         // which will be rejected by the collection v2 schema
         // converting to string to prevent issues like

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -820,6 +820,21 @@ describe('UTILITY FUNCTION TESTS ', function () {
       expect(pmParam[0].value).to.equal('10'); // '10', not 10
       done();
     });
+    it('Should convert queryParam (boolean) to a query param with a string value', function (done) {
+      var param = {
+        name: 'X-Header-One',
+        in: 'query',
+        description: 'query param',
+        schema: {
+          type: 'boolean',
+          default: true
+        }
+      };
+      Utils.options.schemaFaker = true;
+      let pmParam = Utils.convertToPmQueryParameters(param);
+      expect(pmParam[0].value).to.equal('true'); // 'true', not true
+      done();
+    });
     describe('Should convert queryParam with schema {type:array, ', function() {
       describe('style:form, ', function() {
         describe('explode:true} to pm param ', function () {


### PR DESCRIPTION
Mimics https://github.com/postmanlabs/openapi-to-postman/pull/63 for booleans.
Relates to issue https://github.com/postmanlabs/postman-app-support/issues/6500
With the current implementation upload of converted file fails when a boolean parameter has a default value.