### PR TITLE
Handling cases where query have no description property

### DIFF
--- a/examples/sampleswagger.yaml
+++ b/examples/sampleswagger.yaml
@@ -8,7 +8,7 @@ info:
     irc.freenode.net, #swagger.  For this sample, you can use the api key
     "special-key" to test the authorization filters
   version: 1.0.0
-  title: Ye Teja Teja Kya hai ?
+  title: Sample title
   termsOfService: 'http://helloreverb.com/terms/'
   contact:
     email: apiteam@wordnik.com

--- a/lib/util.js
+++ b/lib/util.js
@@ -1417,7 +1417,7 @@ module.exports = {
       });
     });
     item.request.url.query.members.forEach((query) => {
-      query.description = query.description.content;
+      query.description = _.get(query, 'description.content', '');
       query.value = (typeof query.value === 'object') ? JSON.stringify(query.value) : query.value;
     });
     item.request.url.variables.clear();

--- a/test/data/valid_openapi/sampleswagger.yaml
+++ b/test/data/valid_openapi/sampleswagger.yaml
@@ -8,7 +8,7 @@ info:
     irc.freenode.net, #swagger.  For this sample, you can use the api key
     "special-key" to test the authorization filters
   version: 1.0.0
-  title: Ye Teja Teja Kya hai ?
+  title: Sample title
   termsOfService: 'http://helloreverb.com/terms/'
   contact:
     email: apiteam@wordnik.com

--- a/test/data/valid_openapi/swagger_without_query_desc.yaml
+++ b/test/data/valid_openapi/swagger_without_query_desc.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+servers:
+  - url: 'http://petstore.swagger.io/v2'
+info:
+  description: >-
+    This is a sample server Petstore server.  You can find out more about
+    Swagger at http://swagger.io or on
+    irc.freenode.net, #swagger.  For this sample, you can use the api key
+    "special-key" to test the authorization filters
+  version: 1.0.0
+  title: Sample title
+  termsOfService: 'http://helloreverb.com/terms/'
+  contact:
+    email: apiteam@wordnik.com
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+paths:
+  # the params part will be converted to a path variable
+  # that will get added to the query.members of the SDK
+  # (but without a .descriptions property)
+  /pet/findByStatus?{params}:
+    get:
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma seperated strings
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query

--- a/test/unit/convert.temp.js
+++ b/test/unit/convert.temp.js
@@ -7,7 +7,7 @@ var expect = require('chai').expect,
   Converter = require('../../index.js'),
   fs = require('fs'),
   path = require('path'),
-  VALID_OPENAPI_PATH = '../data/.temp';
+  VALID_OPENAPI_PATH = '../data/.temp/specs';
 
 describe('The converter must generate a collection conforming to the schema', function () {
   var pathPrefix = VALID_OPENAPI_PATH,


### PR DESCRIPTION
This can happen if the SDK URL is generated from a string, instead of having query params added to it.

In the https://github.com/postmanlabs/swagger2-postman2/ project, a path with `?{params}` at the end is converted to `?:params`, which is a separate issue. However, this breaks the converter because the query param has no description. This fix introduces a safe check.