### PR TITLE
Fix typos and indentation in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ npm install openapi-to-postmanv2
 In order to use the convert in your node application, you need to import the package using `require`.
 
 ```javascript
-var openapi-converter = require('openapi-to-postmanv2')
+var Converter = require('openapi-to-postmanv2')
 ```
 
 The converter provides the following functions:
@@ -106,10 +106,11 @@ function (err, result) {
 ### Sample Usage:
 ```javascript
 var fs = require('fs'),
-  Converter = require('openapi-to-postmanv2'),
-  openapiData = fs.readFileSync('sample-spec.yaml', {encoding: 'UTF8'});
 
- Converter.convert({ type: 'string', data: openapiData },
+Converter = require('openapi-to-postmanv2'),
+openapiData = fs.readFileSync('sample-spec.yaml', {encoding: 'UTF8'});
+
+Converter.convert({ type: 'string', data: openapiData },
   {}, (err, conversionResult) => {
     if (!conversionResult.result) {
       console.log('Could not convert', conversionResult.reason);


### PR DESCRIPTION
This PR makes a small change to the README to address the typo in the `import` example and indentation in `Sample Usage`.

I've renamed the var used for the import to match the sample usage examples too. 