### PR TITLE
Support to cache resolved and faked schema

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -54,22 +54,23 @@ module.exports = {
    * @param {array} schemaArr - array of schemas, all of which must be valid in the returned object
    * @param {string} parameterSourceOption tells that the schema object is of request or response
    * @param {*} components components in openapi spec.
+   * @param {object} schemaResolutionCache stores already resolved references
    * @param {*} stack counter which keeps a tab on nested schemas
    * @returns {*} schema - schema that adheres to all individual schemas in schemaArr
    */
-  resolveAllOf: function (schemaArr, parameterSourceOption, components, stack = 0) {
+  resolveAllOf: function (schemaArr, parameterSourceOption, components, schemaResolutionCache, stack = 0) {
     if (!(schemaArr instanceof Array)) {
       return null;
     }
 
     if (schemaArr.length === 1) {
       // for just one entry in allOf, don't need to enforce type: object restriction
-      return this.resolveRefs(schemaArr[0], parameterSourceOption, components, stack);
+      return this.resolveRefs(schemaArr[0], parameterSourceOption, components, schemaResolutionCache, stack);
     }
 
     // generate one object for each schema
     let indivObjects = schemaArr.map((schema) => {
-        return this.resolveRefs(schema, parameterSourceOption, components, stack);
+        return this.resolveRefs(schema, parameterSourceOption, components, schemaResolutionCache, stack);
       }).filter((schema) => {
         return schema.type === 'object';
       }),
@@ -105,33 +106,38 @@ module.exports = {
    * @param {*} schema (openapi) to resolve references.
    * @param {string} parameterSourceOption tells that the schema object is of request or response
    * @param {*} components components in openapi spec.
+   * @param {object} schemaResolutionCache stores already resolved references
    * @param {*} stack counter which keeps a tab on nested schemas
    * @returns {*} schema satisfying JSON-schema-faker.
    */
-  resolveRefs: function (schema, parameterSourceOption, components, stack = 0) {
+  resolveRefs: function (schema, parameterSourceOption, components, schemaResolutionCache, stack = 0) {
     var resolvedSchema, prop, splitRef;
     stack++;
-
+    schemaResolutionCache = schemaResolutionCache || {};
     if (stack > 20) {
       return { value: '<Error: Too many levels of nesting to fake this schema>' };
     }
 
     if (schema.anyOf) {
-      return this.resolveRefs(schema.anyOf[0], parameterSourceOption, components, stack);
+      return this.resolveRefs(schema.anyOf[0], parameterSourceOption, components, schemaResolutionCache, stack);
     }
     if (schema.oneOf) {
-      return this.resolveRefs(schema.oneOf[0], parameterSourceOption, components, stack);
+      return this.resolveRefs(schema.oneOf[0], parameterSourceOption, components, schemaResolutionCache, stack);
     }
     if (schema.allOf) {
-      return this.resolveAllOf(schema.allOf, parameterSourceOption, components, stack);
+      return this.resolveAllOf(schema.allOf, parameterSourceOption, components, schemaResolutionCache, stack);
     }
     if (schema.$ref) {
+      let refKey = schema.$ref;
       // points to an existing location
       // .split will return [#, components, schemas, schemaName]
-      splitRef = schema.$ref.split('/');
+      splitRef = refKey.split('/');
 
       if (splitRef.length < 4) {
-        throw new openApiErr(`Invalid schema reference: ${schema.$ref}`);
+        throw new openApiErr(`Invalid schema reference: ${refKey}`);
+      }
+      if (schemaResolutionCache[refKey]) {
+        return schemaResolutionCache[refKey];
       }
 
       // something like #/components/schemas/PaginationEnvelope/properties/page
@@ -140,9 +146,12 @@ module.exports = {
       // not using _.get here because that fails if there's a . in the property name (Pagination.Envelope, for example)
       resolvedSchema = this._getEscaped(components, splitRef.slice(1));
       if (resolvedSchema) {
-        return this.resolveRefs(resolvedSchema, parameterSourceOption, components, stack);
+        let refResolvedSchema = this.resolveRefs(resolvedSchema, parameterSourceOption,
+          components, schemaResolutionCache, stack);
+        schemaResolutionCache[refKey] = refResolvedSchema;
+        return refResolvedSchema;
       }
-      return { value: 'reference ' + schema.$ref + ' not found in the api spec' };
+      return { value: 'reference ' + refKey + ' not found in the api spec' };
     }
     if (schema.type === 'object' || schema.hasOwnProperty('properties')) {
       // go through all props
@@ -165,7 +174,7 @@ module.exports = {
             }
             /* eslint-enable */
             tempSchema.properties[prop] = this.resolveRefs(property,
-              parameterSourceOption, components, stack);
+              parameterSourceOption, components, schemaResolutionCache, stack);
           }
         }
         return tempSchema;
@@ -183,7 +192,8 @@ module.exports = {
       // so that the original schema.items object will not change
       // without this, schemas with circular references aren't faked correctly
       let tempSchema = _.omit(schema, 'items');
-      tempSchema.items = this.resolveRefs(schema.items, parameterSourceOption, components, stack);
+      tempSchema.items = this.resolveRefs(schema.items, parameterSourceOption,
+        components, schemaResolutionCache, stack);
       return tempSchema;
     }
     else if (!schema.hasOwnProperty('default')) {

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -121,7 +121,7 @@ function safeSchemaFaker(oldSchema, resolveTo, parameterSourceOption, components
     });
   }
   else if (resolveTo === 'example') {
-    key += 'resolveToExample ' + key;
+    key = 'resolveToExample ' + key;
     schemaFaker.option({
       useExamplesValue: true
     });

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -114,18 +114,21 @@ function safeSchemaFaker(oldSchema, resolveTo, parameterSourceOption, components
   resolvedSchema = deref.resolveRefs(oldSchema, parameterSourceOption, components, schemaResolutionCache);
   key = JSON.stringify(resolvedSchema);
 
-  if (schemaFakerCache[key]) {
-    return schemaFakerCache[key];
-  }
   if (resolveTo === 'schema') {
+    key = 'resolveToSchema ' + key;
     schemaFaker.option({
       useExamplesValue: false
     });
   }
   else if (resolveTo === 'example') {
+    key += 'resolveToExample ' + key;
     schemaFaker.option({
       useExamplesValue: true
     });
+  }
+
+  if (schemaFakerCache[key]) {
+    return schemaFakerCache[key];
   }
 
   if (resolvedSchema.properties) {

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -77,7 +77,8 @@ const async = require('async'),
     'boolean': (d) => d === 'true' || d === 'false',
     'array': (d) => Array.isArray(d),
     'object': (d) => typeof d === 'object' && !Array.isArray(d)
-  };
+  },
+  crypto = require('crypto');
   /* eslint-enable */
 
 // See https://github.com/json-schema-faker/json-schema-faker/tree/master/docs#available-options
@@ -91,6 +92,15 @@ schemaFaker.option({
   useDefaultValue: true,
   ignoreMissingRefs: true
 });
+
+/**
+ *
+ * @param {*} input - input string that needs to be hashed
+ * @returns {*} sha1 hash of the string
+ */
+function hash(input) {
+  return crypto.createHash('sha1').update(input).digest('base64');
+}
 
 /**
 * Safe wrapper for schemaFaker that resolves references and
@@ -127,6 +137,7 @@ function safeSchemaFaker(oldSchema, resolveTo, parameterSourceOption, components
     });
   }
 
+  key = hash(key);
   if (schemaFakerCache[key]) {
     return schemaFakerCache[key];
   }

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -102,12 +102,21 @@ schemaFaker.option({
 * @param {*} components list of predefined components (with schemas)
 * @param {string} schemaFormat default or xml
 * @param {string} indentCharacter char for 1 unit of indentation
+* @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
 * @returns {object} fakedObject
 */
-function safeSchemaFaker(oldSchema, resolveTo, parameterSourceOption, components, schemaFormat, indentCharacter) {
-  var prop,
-    schema = deref.resolveRefs(oldSchema, parameterSourceOption, components);
+function safeSchemaFaker(oldSchema, resolveTo, parameterSourceOption, components,
+  schemaFormat, indentCharacter, schemaCache) {
+  var prop, key, resolvedSchema, fakedSchema,
+    schemaResolutionCache = _.get(schemaCache, 'schemaResolutionCache', {}),
+    schemaFakerCache = _.get(schemaCache, 'schemaFakerCache', {});
 
+  resolvedSchema = deref.resolveRefs(oldSchema, parameterSourceOption, components, schemaResolutionCache);
+  key = JSON.stringify(resolvedSchema);
+
+  if (schemaFakerCache[key]) {
+    return schemaFakerCache[key];
+  }
   if (resolveTo === 'schema') {
     schemaFaker.option({
       useExamplesValue: false
@@ -119,13 +128,13 @@ function safeSchemaFaker(oldSchema, resolveTo, parameterSourceOption, components
     });
   }
 
-  if (schema.properties) {
+  if (resolvedSchema.properties) {
     // If any property exists with format:binary (and type: string) schemaFaker crashes
     // we just delete based on format=binary
-    for (prop in schema.properties) {
-      if (schema.properties.hasOwnProperty(prop)) {
-        if (schema.properties[prop].format === 'binary') {
-          delete schema.properties[prop].format;
+    for (prop in resolvedSchema.properties) {
+      if (resolvedSchema.properties.hasOwnProperty(prop)) {
+        if (resolvedSchema.properties[prop].format === 'binary') {
+          delete resolvedSchema.properties[prop].format;
         }
       }
     }
@@ -133,10 +142,14 @@ function safeSchemaFaker(oldSchema, resolveTo, parameterSourceOption, components
 
   try {
     if (schemaFormat === SCHEMA_FORMATS.XML) {
-      return xmlFaker(null, schema, indentCharacter);
+      fakedSchema = xmlFaker(null, resolvedSchema, indentCharacter);
+      schemaFakerCache[key] = fakedSchema;
+      return fakedSchema;
     }
     // for JSON, the indentCharacter will be applied in the JSON.stringify step later on
-    return schemaFaker(schema);
+    fakedSchema = schemaFaker(resolvedSchema);
+    schemaFakerCache[key] = fakedSchema;
+    return fakedSchema;
   }
   catch (e) {
     console.warn(
@@ -494,9 +507,13 @@ module.exports = {
    * method: request(operation)-level, root: spec-level,  param: url-level
    * @param {Array<object>} providedPathVars - Array of path variables
    * @param {object|array} commonPathVars - Object of path variables taken from the specification
+   * @param {object} components - components defined in the OAS spec. These are used to
+   * resolve references while generating params.
+  * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
+  * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @returns {Array<object>} returns an array of sdk.Variable
    */
-  convertPathVariables: function(type, providedPathVars, commonPathVars, components, options) {
+  convertPathVariables: function(type, providedPathVars, commonPathVars, components, options, schemaCache) {
     options = _.merge({}, defaultOptions, options);
 
     var variables = providedPathVars;
@@ -519,7 +536,8 @@ module.exports = {
           key: variable.name,
           // we only fake the schema for param-level pathVars
           value: options.schemaFaker ?
-            safeSchemaFaker(variable.schema || {}, components, SCHEMA_FORMATS.DEFAULT) : '',
+            safeSchemaFaker(variable.schema || {}, 'schema', components, 'REQUEST',
+              SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache) : '',
           description: variable.description || ''
         });
       });
@@ -552,10 +570,15 @@ module.exports = {
    * otherwise return postman request
    * @param {*} openapi object with root-level data like pathVariables baseurl
    * @param {*} child object is of type itemGroup or request
+   * resolve references while generating params.
+   * @param {object} components - components defined in the OAS spec. These are used to
+   * resolve references while generating params.
+   * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
+   * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @returns {*} Postman itemGroup or request
    * @no-unit-test
    */
-  convertChildToItemGroup: function (openapi, child, components, options) {
+  convertChildToItemGroup: function (openapi, child, components, options, schemaCache) {
     options = _.merge({}, defaultOptions, options);
 
     var resource = child,
@@ -583,14 +606,14 @@ module.exports = {
           resourceSubChild = resource.children[subChild];
 
         resourceSubChild.name = resource.name + '/' + resourceSubChild.name;
-        return this.convertChildToItemGroup(openapi, resourceSubChild, components, options);
+        return this.convertChildToItemGroup(openapi, resourceSubChild, components, options, schemaCache);
       }
       /* eslint-enable */
       // recurse over child leaf nodes
       // and add as children to this folder
       for (i = 0, requestCount = resource.requests.length; i < requestCount; i++) {
         itemGroup.items.add(
-          this.convertRequestToItem(openapi, resource.requests[i], components, options)
+          this.convertRequestToItem(openapi, resource.requests[i], components, options, schemaCache)
         );
       }
 
@@ -600,7 +623,7 @@ module.exports = {
       for (subChild in resource.children) {
         if (resource.children.hasOwnProperty(subChild) && resource.children[subChild].requestCount > 0) {
           itemGroup.items.add(
-            this.convertChildToItemGroup(openapi, resource.children[subChild], components, options)
+            this.convertChildToItemGroup(openapi, resource.children[subChild], components, options, schemaCache)
           );
         }
       }
@@ -611,14 +634,14 @@ module.exports = {
 
     // 2. it has only 1 direct request of its own
     if (resource.requests.length === 1) {
-      return this.convertRequestToItem(openapi, resource.requests[0], components, options);
+      return this.convertRequestToItem(openapi, resource.requests[0], components, options, schemaCache);
     }
 
     // 3. it's a folder that has no child request
     // but one request somewhere in its child folders
     for (subChild in resource.children) {
       if (resource.children.hasOwnProperty(subChild) && resource.children[subChild].requestCount === 1) {
-        return this.convertChildToItemGroup(openapi, resource.children[subChild], components, options);
+        return this.convertChildToItemGroup(openapi, resource.children[subChild], components, options, schemaCache);
       }
     }
   },
@@ -675,9 +698,13 @@ module.exports = {
    * from the body is returned as well
    * @param {*} contentObj response content - this is the content property of the response body
    * https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#responseObject
+   * @param {object} components - components defined in the OAS spec. These are used to
+   * resolve references while generating params.
+  * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
+  * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @return {object} responseBody, contentType header needed
    */
-  convertToPmResponseBody: function(contentObj, components, options) {
+  convertToPmResponseBody: function(contentObj, components, options, schemaCache) {
     options = _.merge({}, defaultOptions, options);
 
     var responseBody, cTypeHeader, hasComputedType, cTypes;
@@ -716,7 +743,7 @@ module.exports = {
       }
     }
     responseBody = this.convertToPmBodyData(contentObj[cTypeHeader], REQUEST_TYPE.EXAMPLE, cTypeHeader,
-      PARAMETER_SOURCE.RESPONSE, options.indentCharacter, components, options);
+      PARAMETER_SOURCE.RESPONSE, options.indentCharacter, components, options, schemaCache);
     if (this.getHeaderFamily(cTypeHeader) === HEADER_TYPE.JSON) {
       responseBody = JSON.stringify(responseBody, null, options.indentCharacter);
     }
@@ -794,8 +821,13 @@ module.exports = {
    * converts one of the eamples or schema in Media Type object to postman data
    * @param {*} bodyObj is MediaTypeObject
    * @param {*} requestType - Specifies whether the request body is of example request or root request
-   * @param {string} indentCharacter is needed for XML/JSON bodies only
+   * @param {*} contentType - content type header
    * @param {string} parameterSourceOption tells that the schema object is of request or response
+   * @param {string} indentCharacter is needed for XML/JSON bodies only
+   * @param {object} components - components defined in the OAS spec. These are used to
+   * resolve references while generating params.
+  * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
+  * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @returns {*} postman body data
    */
   // TODO: We also need to accept the content type
@@ -803,7 +835,7 @@ module.exports = {
   // right now, even if the content-type was XML, we'll generate
   // a JSON example/schema
   convertToPmBodyData: function(bodyObj, requestType, contentType, parameterSourceOption,
-    indentCharacter, components, options) {
+    indentCharacter, components, options, schemaCache) {
 
     options = _.merge({}, defaultOptions, options);
     var bodyData = '',
@@ -844,7 +876,7 @@ module.exports = {
           schemaType = SCHEMA_FORMATS.XML;
         }
         bodyData = safeSchemaFaker(bodyObj.schema || {}, resolveTo, parameterSourceOption,
-          components, schemaType, indentCharacter);
+          components, schemaType, indentCharacter, schemaCache);
       }
       else {
         // do not fake if the option is false
@@ -887,9 +919,13 @@ module.exports = {
    * convert param with in='query' to string considering style and type
    * @param {*} param with in='query'
    * @param {*} requestType Specifies whether the request body is of example request or root request
+   * @param {object} components - components defined in the OAS spec. These are used to
+   * resolve references while generating params.
+  * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
+  * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @returns {array} converted queryparam
    */
-  convertToPmQueryParameters: function(param, requestType, components, options) {
+  convertToPmQueryParameters: function(param, requestType, components, options, schemaCache) {
     options = _.merge({}, defaultOptions, options);
     var pmParams = [],
       paramValue,
@@ -904,7 +940,7 @@ module.exports = {
       // fake data generated
       paramValue = options.schemaFaker ?
         safeSchemaFaker(param.schema, resolveTo, PARAMETER_SOURCE.REQUEST,
-          components, SCHEMA_FORMATS.DEFAULT) : '';
+          components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache) : '';
       // paramType = param.schema.type;
 
       if (typeof paramValue === 'number' || typeof paramValue === 'boolean') {
@@ -1088,9 +1124,14 @@ module.exports = {
    * converts params with in='header' to a Postman header object
    * @param {*} header param with in='header'
    * @param {*} requestType Specifies whether the request body is of example request or root request
+   * @param  {*} parameterSource — Specifies whether the schema being faked is from a request or response.
+   * @param {object} components - components defined in the OAS spec. These are used to
+   * resolve references while generating params.
+  * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
+  * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @returns {Object} instance of a Postman SDK Header
    */
-  convertToPmHeader: function(header, requestType, parameterSource, components, options) {
+  convertToPmHeader: function(header, requestType, parameterSource, components, options, schemaCache) {
     options = _.merge({}, defaultOptions, options);
 
     var fakeData,
@@ -1104,7 +1145,7 @@ module.exports = {
       }
       else {
         fakeData = safeSchemaFaker(header.schema || {}, resolveTo, parameterSource,
-          components, SCHEMA_FORMATS.DEFAULT);
+          components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache);
 
         // for schema.type=string or number,
         // adding JSON.stringify will add unnecessary extra double quotes around the value
@@ -1130,9 +1171,13 @@ module.exports = {
    * converts operation item requestBody to a Postman request body
    * @param {*} requestBody in operationItem
    * @param {*} requestType - Specifies whether the request body is of example request or root request
+   * @param {object} components - components defined in the OAS spec. These are used to
+   * resolve references while generating params.
+  * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
+  * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @returns {Object} - Postman requestBody and Content-Type Header
    */
-  convertToPmBody: function(requestBody, requestType, components, options) {
+  convertToPmBody: function(requestBody, requestType, components, options, schemaCache) {
     options = _.merge({}, defaultOptions, options);
     var contentObj, // content is required
       bodyData,
@@ -1167,7 +1212,7 @@ module.exports = {
         contentObj[URLENCODED].schema = this.getRefObject(contentObj[URLENCODED].schema.$ref, components, options);
       }
       bodyData = this.convertToPmBodyData(contentObj[URLENCODED], requestType, URLENCODED,
-        PARAMETER_SOURCE.REQUEST, '', components, options);
+        PARAMETER_SOURCE.REQUEST, options.indentCharacter, components, options, schemaCache);
       encoding = contentObj[URLENCODED].encoding ? contentObj[URLENCODED].encoding : {};
       // create query parameters and add it to the request body object
       _.forOwn(bodyData, (value, key) => {
@@ -1219,7 +1264,7 @@ module.exports = {
     else if (contentObj.hasOwnProperty(FORM_DATA)) {
       rDataMode = 'formdata';
       bodyData = this.convertToPmBodyData(contentObj[FORM_DATA], requestType, FORM_DATA,
-        PARAMETER_SOURCE.REQUEST, '', components, options);
+        PARAMETER_SOURCE.REQUEST, options.indentCharacter, components, options, schemaCache);
       encoding = contentObj[FORM_DATA].encoding ? contentObj[FORM_DATA].encoding : {};
       // create the form parameters and add it to the request body object
       _.forOwn(bodyData, (value, key) => {
@@ -1232,7 +1277,7 @@ module.exports = {
               encoding[key].headers[key].name = key;
               // this is only for ROOT request because we are adding the headers for example request later
               formHeaders.push(this.convertToPmHeader(encoding[key].headers[key],
-                REQUEST_TYPE.ROOT, PARAMETER_SOURCE.REQUEST, components, options));
+                REQUEST_TYPE.ROOT, PARAMETER_SOURCE.REQUEST, components, options, schemaCache));
             }
           });
         }
@@ -1278,7 +1323,7 @@ module.exports = {
       }
 
       bodyData = this.convertToPmBodyData(contentObj[bodyType], requestType, bodyType,
-        PARAMETER_SOURCE.REQUEST, options.indentCharacter, components, options);
+        PARAMETER_SOURCE.REQUEST, options.indentCharacter, components, options, schemaCache);
 
       updateOptions = {
         mode: rDataMode,
@@ -1304,9 +1349,13 @@ module.exports = {
    * @param {*} response in operationItem responses
    * @param {*} code - response Code
    * @param {*} originalRequest - the request for the example
+   * @param {object} components - components defined in the OAS spec. These are used to
+   * resolve references while generating params.
+  * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
+  * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @returns {Object} postman response
    */
-  convertToPmResponse: function(response, code, originalRequest, components, options) {
+  convertToPmResponse: function(response, code, originalRequest, components, options, schemaCache) {
     options = _.merge({}, defaultOptions, options);
     var responseHeaders = [],
       previewLanguage = 'text',
@@ -1329,11 +1378,11 @@ module.exports = {
         }
         header.name = key;
         responseHeaders.push(this.convertToPmHeader(header, REQUEST_TYPE.EXAMPLE,
-          PARAMETER_SOURCE.RESPONSE, components, options));
+          PARAMETER_SOURCE.RESPONSE, components, options, schemaCache));
       }
     });
 
-    responseBodyWrapper = this.convertToPmResponseBody(response.content, components, options);
+    responseBodyWrapper = this.convertToPmResponseBody(response.content, components, options, schemaCache);
 
     if (responseBodyWrapper.contentTypeHeader) {
       // we could infer the content-type header from the body
@@ -1421,10 +1470,14 @@ module.exports = {
    * function to convert an openapi path item to postman item
   * @param {*} openapi openapi object with root properties
   * @param {*} operationItem path operationItem from tree structure
+  * @param {object} components - components defined in the OAS spec. These are used to
+   * resolve references while generating params.
+   * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
+  * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
   * @returns {Object} postman request Item
   * @no-unit-test
   */
-  convertRequestToItem: function(openapi, operationItem, components, options) {
+  convertRequestToItem: function(openapi, operationItem, components, options, schemaCache) {
     options = _.merge({}, defaultOptions, options);
     var reqName,
       pathVariables = openapi.baseUrlVariables,
@@ -1457,7 +1510,7 @@ module.exports = {
       baseUrl = serverObj.url.replace(/{/g, ':').replace(/}/g, '');
       baseUrl += reqUrl;
       if (serverObj.variables) {
-        pathVarArray = this.convertPathVariables('method', [], serverObj.variables, components, options);
+        pathVarArray = this.convertPathVariables('method', [], serverObj.variables, components, options, schemaCache);
       }
     }
     else {
@@ -1481,7 +1534,7 @@ module.exports = {
           displayUrl = '{{baseUrl}}' + reqUrl;
         }
       }
-      pathVarArray = this.convertPathVariables('root', [], pathVariables, components, options);
+      pathVarArray = this.convertPathVariables('root', [], pathVariables, components, options, schemaCache);
     }
 
     switch (options.requestNameSource) {
@@ -1532,14 +1585,14 @@ module.exports = {
     else if (authHelper && authHelper.type === 'api-key') {
       if (authHelper.properties.in === 'header') {
         item.request.addHeader(this.convertToPmHeader(authHelper.properties,
-          REQUEST_TYPE.ROOT, PARAMETER_SOURCE.REQUEST, components, options));
+          REQUEST_TYPE.ROOT, PARAMETER_SOURCE.REQUEST, components, options, schemaCache));
         item.request.auth = {
           type: 'noauth'
         };
       }
       else if (authHelper.properties.in === 'query') {
         this.convertToPmQueryParameters(authHelper.properties, REQUEST_TYPE.ROOT,
-          components, options).forEach((pmParam) => {
+          components, options, schemaCache).forEach((pmParam) => {
           item.request.url.addQueryParams(pmParam);
         });
         item.request.auth = {
@@ -1553,9 +1606,10 @@ module.exports = {
 
     // adding query params to postman request url.
     _.forEach(reqParams.query, (queryParam) => {
-      this.convertToPmQueryParameters(queryParam, REQUEST_TYPE.ROOT, components, options).forEach((pmParam) => {
-        item.request.url.addQueryParams(pmParam);
-      });
+      this.convertToPmQueryParameters(queryParam, REQUEST_TYPE.ROOT, components, options, schemaCache)
+        .forEach((pmParam) => {
+          item.request.url.addQueryParams(pmParam);
+        });
     });
     item.request.url.query.members.forEach((query) => {
       query.description = _.get(query, 'description.content', '');
@@ -1563,7 +1617,7 @@ module.exports = {
     });
     item.request.url.variables.clear();
     item.request.url.variables.assimilate(this.convertPathVariables('param', pathVarArray, reqParams.path,
-      components, options));
+      components, options, schemaCache));
 
     // Making sure description never goes out as an object
     // App / Collection transformer fail with the object syntax
@@ -1579,7 +1633,7 @@ module.exports = {
     // adding headers to request from reqParam
     _.forEach(reqParams.header, (header) => {
       item.request.addHeader(this.convertToPmHeader(header, REQUEST_TYPE.ROOT, PARAMETER_SOURCE.REQUEST,
-        components, options));
+        components, options, schemaCache));
     });
 
     // adding Request Body and Content-Type header
@@ -1587,7 +1641,7 @@ module.exports = {
       if (reqBody.$ref) {
         reqBody = this.getRefObject(reqBody.$ref, components, options);
       }
-      pmBody = this.convertToPmBody(reqBody, REQUEST_TYPE.ROOT, components, options);
+      pmBody = this.convertToPmBody(reqBody, REQUEST_TYPE.ROOT, components, options, schemaCache);
       item.request.body = pmBody.body;
       item.request.addHeader(pmBody.contentHeader);
       // extra form headers if encoding is present in request Body.
@@ -1614,17 +1668,17 @@ module.exports = {
         // setting query params
         thisOriginalRequest.url += '?';
         thisOriginalRequest.url += this.convertToPmQueryArray(reqParams, REQUEST_TYPE.EXAMPLE, components,
-          options).join('&');
+          options, schemaCache).join('&');
         // setting headers
         _.forEach(reqParams.header, (header) => {
           originalRequestHeaders.push(this.convertToPmHeader(header, REQUEST_TYPE.EXAMPLE,
-            PARAMETER_SOURCE.REQUEST, components, options));
+            PARAMETER_SOURCE.REQUEST, components, options, schemaCache));
         });
         thisOriginalRequest.header = originalRequestHeaders;
         // setting request body
         try {
           exampleRequestBody = this.convertToPmBody(operationItem.properties.requestBody,
-            REQUEST_TYPE.EXAMPLE, components, options);
+            REQUEST_TYPE.EXAMPLE, components, options, schemaCache);
           thisOriginalRequest.body = exampleRequestBody.body ? exampleRequestBody.body.toJSON() : {};
         }
         catch (e) {
@@ -1632,7 +1686,8 @@ module.exports = {
           // 'Exception:', e);
           thisOriginalRequest.body = {};
         }
-        convertedResponse = this.convertToPmResponse(swagResponse, code, thisOriginalRequest, components, options);
+        convertedResponse = this.convertToPmResponse(swagResponse, code, thisOriginalRequest,
+          components, options, schemaCache);
         convertedResponse && item.responses.add(convertedResponse);
       });
     }
@@ -1644,13 +1699,17 @@ module.exports = {
    * function to convert an openapi query params object to array of query params
   * @param {*} reqParams openapi query params object
   * @param {*} requestType Specifies whether the request body is of example request or root request
+  * @param {object} components - components defined in the OAS spec. These are used to
+   * resolve references while generating params.
+  * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
+  * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
   * @returns {*} array of all query params
   */
-  convertToPmQueryArray: function(reqParams, requestType, components, options) {
+  convertToPmQueryArray: function(reqParams, requestType, components, options, schemaCache) {
     options = _.merge({}, defaultOptions, options);
     let requestQueryParams = [];
     _.forEach(reqParams.query, (queryParam) => {
-      this.convertToPmQueryParameters(queryParam, requestType, components, options).forEach((pmParam) => {
+      this.convertToPmQueryParameters(queryParam, requestType, components, options, schemaCache).forEach((pmParam) => {
         requestQueryParams.push(pmParam.key + '=' + pmParam.value);
       });
     });

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1956,6 +1956,7 @@ module.exports = {
    * @param {*} schemaPath the applicable pathItem defined at the schema level
    * @param {*} components the components + paths from the OAS spec that need to be used to resolve $refs
    * @param {*} options OAS options
+   * @param {*} schemaResolutionCache cache used to store resolved schemas
    * @param {*} callback Callback
    * @returns {array} mismatches (in the callback)
    */
@@ -1965,6 +1966,7 @@ module.exports = {
     schemaPath,
     components,
     options,
+    schemaResolutionCache,
     callback) {
 
     // schema path should have all parameters needed
@@ -2014,7 +2016,7 @@ module.exports = {
           pathVar.key,
           pathVar.value,
           schemaPathVar.pathPrefix + '[?(@.name==\'' + schemaPathVar.name + '\')]',
-          deref.resolveRefs(schemaPathVar.schema, 'request', components),
+          deref.resolveRefs(schemaPathVar.schema, 'request', components, schemaResolutionCache),
           components, options, cb);
       }, 0);
     }, (err, res) => {
@@ -2042,7 +2044,8 @@ module.exports = {
     });
   },
 
-  checkQueryParams(requestUrl, transactionPathPrefix, schemaPath, components, options, callback) {
+  checkQueryParams(requestUrl, transactionPathPrefix, schemaPath, components, options,
+    schemaResolutionCache, callback) {
     let parsedUrl = require('url').parse(requestUrl),
       schemaParams = _.filter(schemaPath.parameters, (param) => { return param.in === 'query'; }),
       requestQueryArray = [],
@@ -2101,7 +2104,7 @@ module.exports = {
           pQuery.key,
           pQuery.value,
           schemaParam.pathPrefix + '[?(@.name==\'' + schemaParam.name + '\')]',
-          deref.resolveRefs(schemaParam.schema, 'request', components),
+          deref.resolveRefs(schemaParam.schema, 'request', components, schemaResolutionCache),
           components, options,
           cb
         );
@@ -2123,7 +2126,8 @@ module.exports = {
     });
   },
 
-  checkRequestHeaders: function (headers, transactionPathPrefix, schemaPath, components, options, callback) {
+  checkRequestHeaders: function (headers, transactionPathPrefix, schemaPath, components, options,
+    schemaResolutionCache, callback) {
     let schemaHeaders = _.filter(schemaPath.parameters, (param) => { return param.in === 'header'; }),
       mismatchProperty = 'HEADER';
 
@@ -2161,7 +2165,7 @@ module.exports = {
           pHeader.key,
           pHeader.value,
           schemaHeader.pathPrefix + '[?(@.name==\'' + schemaHeader.name + '\')]',
-          deref.resolveRefs(schemaHeader.schema, 'request', components),
+          deref.resolveRefs(schemaHeader.schema, 'request', components, schemaResolutionCache),
           components, options,
           cb
         );
@@ -2184,7 +2188,7 @@ module.exports = {
   },
 
   checkResponseHeaders: function (schemaResponse, headers, transactionPathPrefix, schemaPathPrefix,
-    components, options, callback) {
+    components, options, schemaResolutionCache, callback) {
     // 0. Need to find relevant response from schemaPath.responses
     let schemaHeaders,
       mismatchProperty = 'RESPONSE_HEADER';
@@ -2230,7 +2234,7 @@ module.exports = {
           pHeader.key,
           pHeader.value,
           schemaPathPrefix + '.headers[' + pHeader.key + ']',
-          deref.resolveRefs(schemaHeader.schema, 'response', components),
+          deref.resolveRefs(schemaHeader.schema, 'response', components, schemaResolutionCache),
           components,
           options,
           cb
@@ -2258,7 +2262,7 @@ module.exports = {
 
   // Only application/json is validated for now
   checkRequestBody: function (requestBody, transactionPathPrefix, schemaPathPrefix, schemaPath,
-    components, options, callback) {
+    components, options, schemaResolutionCache, callback) {
     // check for body modes
     // TODO: The application/json can be anything that's application/*+json
     let jsonSchemaBody = _.get(schemaPath, ['requestBody', 'content', 'application/json', 'schema']),
@@ -2278,7 +2282,7 @@ module.exports = {
 
       try {
         ajv = new Ajv({ unknownFormats: ['int32', 'int64'], allErrors: true });
-        validate = ajv.compile(deref.resolveRefs(jsonSchemaBody, 'request', components));
+        validate = ajv.compile(deref.resolveRefs(jsonSchemaBody, 'request', components, schemaResolutionCache));
         res = validate(JSON.parse(requestBody.raw));
       }
       catch (e) {
@@ -2313,7 +2317,7 @@ module.exports = {
   },
 
   checkResponseBody: function (schemaResponse, body, transactionPathPrefix, schemaPathPrefix,
-    components, options, callback) {
+    components, options, schemaResolutionCache, callback) {
     let schemaContent = _.get(schemaResponse, ['content', 'application/json', 'schema']),
       mismatchProperty = 'RESPONSE_BODY';
 
@@ -2341,7 +2345,7 @@ module.exports = {
         null, // no param name for the request body
         body,
         schemaPathPrefix + '.content[application/json].schema',
-        deref.resolveRefs(schemaContent, 'response', components),
+        deref.resolveRefs(schemaContent, 'response', components, schemaResolutionCache),
         components,
         _.extend({}, options, { shortValidationErrors: true }),
         callback
@@ -2349,7 +2353,8 @@ module.exports = {
     }, 0);
   },
 
-  checkResponses: function (responses, transactionPathPrefix, schemaPathPrefix, schemaPath, components, options, cb) {
+  checkResponses: function (responses, transactionPathPrefix, schemaPathPrefix, schemaPath,
+    components, options, schemaResolutionCache, cb) {
     // responses is an array of repsonses recd. for one Postman request
     // we've already determined the schemaPath against which all responses need to be validated
     // loop through all responses
@@ -2375,13 +2380,13 @@ module.exports = {
           headers: (cb) => {
             this.checkResponseHeaders(thisSchemaResponse, response.header,
               transactionPathPrefix + '[' + response.id + ']header',
-              schemaPathPrefix + '.responses.' + responsePathPrefix, components, options, cb);
+              schemaPathPrefix + '.responses.' + responsePathPrefix, components, options, schemaResolutionCache, cb);
           },
           body: (cb) => {
             // assume it's JSON at this point
             this.checkResponseBody(thisSchemaResponse, response.body,
               transactionPathPrefix + '[' + response.id + ']body',
-              schemaPathPrefix + '.responses.' + responsePathPrefix, components, options, cb);
+              schemaPathPrefix + '.responses.' + responsePathPrefix, components, options, schemaResolutionCache, cb);
           }
         }, (err, result) => {
           return responseCallback(null, {

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -25,9 +25,10 @@ const COLLECTION_NAME = 'Converted from OpenAPI',
    * @param {object} components - components defined in the OAS spec. These are used to
    * resolve references while generating params.
   * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
+  * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @returns {void} - generatedStore is modified in-place
    */
-  generateCollection = function (specWrapper, generatedStore, components, options) {
+  generateCollection = function (specWrapper, generatedStore, components, options, schemaCache) {
     var folderTree = specWrapper.tree, // this is the trie we generate (as a scaffold to the collection)
       openapi = specWrapper.spec, // this is the JSON-version of the openAPI spec
       child;
@@ -37,7 +38,8 @@ const COLLECTION_NAME = 'Converted from OpenAPI',
       // requestCount is a property added to each node (folder/request) while constructing the trie
       if (folderTree.root.children.hasOwnProperty(child) && folderTree.root.children[child].requestCount > 0) {
         generatedStore.collection.items.add(
-          schemaUtils.convertChildToItemGroup(openapi, folderTree.root.children[child], components, options)
+          schemaUtils.convertChildToItemGroup(openapi, folderTree.root.children[child],
+            components, options, schemaCache)
         );
       }
     }
@@ -52,6 +54,8 @@ class SchemaPack {
     this.validationResult = null;
     this.definedOptions = getOptions();
     this.computedOptions = null;
+    this.schemaFakerCache = {};
+    this.schemaResolutionCache = {};
 
     this.computedOptions = utils.mergeOptions(
       // predefined options
@@ -203,7 +207,10 @@ class SchemaPack {
       }, generatedStore, {
         components: openapi.components,
         paths: openapi.paths
-      }, this.computedOptions);
+      }, this.computedOptions, {
+        schemaResolutionCache: this.schemaResolutionCache,
+        schemaFakerCache: this.schemaFakerCache
+      });
     }
     catch (e) {
       return callback(e);

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -243,7 +243,9 @@ class SchemaPack {
   validateTransaction(transactions, callback) {
     let schema = this.openapi,
       componentsAndPaths,
-      options = this.computedOptions;
+      options = this.computedOptions,
+      schemaResolutionCache = this.schemaFakerCache;
+
 
     if (!this.validated) {
       return callback(new OpenApiErr('The schema must be validated before attempting conversion'));
@@ -303,23 +305,23 @@ class SchemaPack {
             async.parallel({
               path: function(cb) {
                 schemaUtils.checkPathVariables(matchedPath.pathVariables, '$.request.url', matchedPath.path,
-                  componentsAndPaths, options, cb);
+                  componentsAndPaths, options, schemaResolutionCache, cb);
               },
               queryparams: function(cb) {
                 schemaUtils.checkQueryParams(requestUrl, '$.request.url.query', matchedPath.path,
-                  componentsAndPaths, options, cb);
+                  componentsAndPaths, options, schemaResolutionCache, cb);
               },
               headers: function(cb) {
                 schemaUtils.checkRequestHeaders(transaction.request.header, '$.request.header', matchedPath.path,
-                  componentsAndPaths, options, cb);
+                  componentsAndPaths, options, schemaResolutionCache, cb);
               },
               requestBody: function(cb) {
                 schemaUtils.checkRequestBody(transaction.request.body, '$.request.body', matchedPath.jsonPath,
-                  matchedPath.path, componentsAndPaths, options, cb);
+                  matchedPath.path, componentsAndPaths, options, schemaResolutionCache, cb);
               },
               responses: function (cb) {
                 schemaUtils.checkResponses(transaction.response, '$.responses', matchedPath.jsonPath,
-                  matchedPath.path, componentsAndPaths, options, cb);
+                  matchedPath.path, componentsAndPaths, options, schemaResolutionCache, cb);
               }
             }, (err, result) => {
               let allMismatches = _.concat(result.queryparams, result.headers, result.path, result.requestBody),

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -244,7 +244,7 @@ class SchemaPack {
     let schema = this.openapi,
       componentsAndPaths,
       options = this.computedOptions,
-      schemaResolutionCache = this.schemaFakerCache;
+      schemaResolutionCache = this.schemaResolutionCache;
 
 
     if (!this.validated) {

--- a/test/data/valid_openapi/multiple_refs.json
+++ b/test/data/valid_openapi/multiple_refs.json
@@ -1,0 +1,94 @@
+{
+	"openapi": "3.0.0",
+	"info": {
+		"version": "1.0.0",
+		"title": "Swagger Petstore",
+		"license": {
+			"name": "MIT"
+		}
+	},
+	"servers": [
+		{
+			"url": "http://petstore.swagger.io/v1"
+		}
+	],
+	"paths": {
+		"/pets": {
+			"get": {
+				"summary": "List all pets",
+				"operationId": "listPets",
+				"requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "key1": {
+                    "$ref":"#/components/schemas/RequestBody"
+                  },
+                  "key2": {
+                    "$ref":"#/components/schemas/RequestBody"
+                  }
+                }
+              }
+            }
+          }
+        },
+				"responses": {
+					"200": {
+						"description": "An paged array of pets",
+						"content": {
+							"application/json": {
+								"schema": {
+                  "properties":{
+                    "key1": {
+                      "$ref": "#/components/schemas/ResponseBody"
+                    },
+                    "key2": {
+                      "$ref": "#/components/schemas/ResponseBody"
+                    }
+                  }
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	},
+	"components": {
+		"schemas": {
+			"RequestBody": {
+				"required": [
+					"id",
+					"name"
+				],
+				"properties": {
+					"requestId": {
+						"type": "integer",
+						"format": "int64"
+					},
+					"requestName": {
+						"type": "string"
+					}
+				}
+      },
+      "ResponseBody": {
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "responseId": {
+            "type": "integer",
+            "format": "int64",
+            "example": "234"
+          },
+          "responseName": {
+            "type":"string",
+            "example": "200 OK Response"
+          }
+        }
+      }
+		}
+	}
+}

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -24,7 +24,8 @@ describe('CONVERT FUNCTION TESTS ', function() {
       examplesOutsideSchema = path.join(__dirname, VALID_OPENAPI_PATH + '/examples_outside_schema.json'),
       exampleOutsideSchema = path.join(__dirname, VALID_OPENAPI_PATH + '/example_outside_schema.json'),
       descriptionInBodyParams = path.join(__dirname, VALID_OPENAPI_PATH + '/description_in_body_params.json'),
-      zeroDefaultValueSpec = path.join(__dirname, VALID_OPENAPI_PATH + '/zero_in_default_value.json');
+      zeroDefaultValueSpec = path.join(__dirname, VALID_OPENAPI_PATH + '/zero_in_default_value.json'),
+      multipleRefs = path.join(__dirname, VALID_OPENAPI_PATH, '/multiple_refs.json');
 
     it('Should generate collection conforming to schema for and fail if not valid ' +
      testSpec, function(done) {
@@ -263,6 +264,39 @@ describe('CONVERT FUNCTION TESTS ', function() {
         expect(err).to.be.null;
         expect(descriptionOne).to.equal('Description of Pet ID');
         expect(descriptionTwo).to.equal('Description of Pet name');
+        done();
+      });
+    });
+    it('should convert to the expected schema with use of schemaFaker and schemaResolution caches', function(done) {
+      Converter.convert({ type: 'file', data: multipleRefs }, {}, (err, conversionResult) => {
+        expect(err).to.be.null;
+        expect(conversionResult.result).to.equal(true);
+        let items = conversionResult.output[0].data.item,
+          request = items[0].request,
+          response = items[0].response,
+          requestBody = JSON.parse(request.body.raw),
+          responseBody = JSON.parse(response[0].body);
+        expect(requestBody).to.deep.equal({
+          key1: {
+            requestId: '<long>',
+            requestName: '<string>'
+          },
+          key2: {
+            requestId: '<long>',
+            requestName: '<string>'
+          }
+        });
+        expect(responseBody).to.deep.equal({
+          key1: {
+            responseId: '234',
+            responseName: '200 OK Response'
+          },
+          key2: {
+            responseId: '234',
+            responseName: '200 OK Response'
+          }
+        });
+
         done();
       });
     });

--- a/test/unit/deref.test.js
+++ b/test/unit/deref.test.js
@@ -103,6 +103,43 @@ describe('DEREF FUNCTION TESTS ', function() {
     done();
   });
 
+  it('should populate schemaResolutionCache having key as the ref provided', function (done) {
+    var schema = {
+        $ref: '#/components/schema/request'
+      },
+      componentsAndPaths = {
+        components: {
+          schema: {
+            request: {
+              properties: {
+                name: {
+                  type: 'string',
+                  example: 'example name'
+                }
+              }
+            }
+          }
+        }
+      },
+      parameterSource = 'REQUEST',
+      schemaResolutionCache = {},
+      resolvedSchema = deref.resolveRefs(schema, parameterSource, componentsAndPaths, schemaResolutionCache);
+    expect(schemaResolutionCache).to.deep.equal({
+      '#/components/schema/request': resolvedSchema
+    });
+    expect(resolvedSchema).to.deep.equal({
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          example: 'example name',
+          default: '<string>'
+        }
+      }
+    });
+    done();
+  });
+
   describe('_getEscaped should', function() {
     var rootObject = {
       person: {

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -2,7 +2,11 @@ var expect = require('chai').expect,
   _ = require('lodash'),
   SchemaUtils = require('../../lib/schemaUtils.js'),
   Utils = require('../../lib/utils.js'),
-  deref = require('../../lib/deref.js');
+  deref = require('../../lib/deref.js'),
+  crypto = require('crypto'),
+  hash = (input) => {
+    return crypto.createHash('sha1').update(input).digest('base64');
+  };
 
 /* Utility function Unit tests */
 describe('UTILITY FUNCTION TESTS', function() {
@@ -159,7 +163,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           schemaFakerCache: {},
           schemaResolutionCache: {}
         },
-        key = 'resolveToSchema ' + JSON.stringify(resolvedSchema),
+        key = hash('resolveToSchema ' + JSON.stringify(resolvedSchema)),
         fakedSchema = SchemaUtils.safeSchemaFaker(schema, resolveTo, parameterSource,
           { components }, 'default', '  ', schemaCache);
 
@@ -195,7 +199,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           schemaResolutionCache: {}
         },
         resolvedSchema = deref.resolveRefs(schema, parameterSource, { components }, schemaCache.schemaResolutionCache),
-        key = 'resolveToExample ' + JSON.stringify(resolvedSchema),
+        key = hash('resolveToExample ' + JSON.stringify(resolvedSchema)),
         fakedSchema = SchemaUtils.safeSchemaFaker(schema, resolveTo, parameterSource,
           { components }, 'default', '  ', schemaCache);
 


### PR DESCRIPTION
Issue:
- Whenever we need to fake a schema, we call the function `safeSchemaFaker`. It resolves the schema(removing all the $refs) and then pass it to json-schema-faker.
- Thus, the same resolved schema would be faked a 100 times if it is being used at a 100 places in the OpeanAPI spec. Solution: **schemaFakerCache**

- safeSchemaFaker in turn calls `resolveRefs` function, which does the job of resolving a schema, i.e. resolve all the $refs present in that schema, to make it compatible for json-schema-faker. 
- Thus, it would lead to resolving the same schema 100 times if it is being referenced at 100 places in the OpenAPI spec. Solution: **schemaResolutionCache**