### PR TITLE
Fix errors for empty input specification

### DIFF
--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -101,6 +101,13 @@ class SchemaPack {
       };
       return this.validationResult;
     }
+    if (_.isEmpty(json)) {
+      this.validationResult = {
+        result: false,
+        reason: 'Empty input schema provided.'
+      };
+      return this.validationResult;
+    }
 
     specParseResult = schemaUtils.parseSpec(json);
 

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -375,7 +375,7 @@ describe('INTERFACE FUNCTION TESTS ', function () {
   describe('The converter should not throw error for empty spec', function () {
     var emptySpec = path.join(__dirname, INVALID_OPENAPI_PATH + '/empty-spec.yaml');
     it('should return `empty schema provided` error for input type string', function() {
-      Converter.convert({
+      Converter.validate({
         type: 'string',
         data: ''
       }, {}, (err, res) => {
@@ -386,7 +386,7 @@ describe('INTERFACE FUNCTION TESTS ', function () {
     });
 
     it('should return `empty schema provided` error for input type json', function() {
-      Converter.convert({
+      Converter.validate({
         type: 'json',
         data: {}
       }, {}, (err, res) => {
@@ -397,7 +397,7 @@ describe('INTERFACE FUNCTION TESTS ', function () {
     });
 
     it('should return `empty schema provided` error for input type file', function() {
-      Converter.convert({
+      Converter.validate({
         type: 'file',
         data: emptySpec
       }, {}, (err, res) => {

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -371,4 +371,40 @@ describe('INTERFACE FUNCTION TESTS ', function () {
       });
     });
   });
+
+  describe('The converter should not throw error for empty spec', function () {
+    var emptySpec = path.join(__dirname, INVALID_OPENAPI_PATH + '/empty-spec.yaml');
+    it('should return `empty schema provided` error for input type string', function() {
+      Converter.convert({
+        type: 'string',
+        data: ''
+      }, {}, (err, res) => {
+        expect(err).to.be.null;
+        expect(res.result).to.be.false;
+        expect(res.reason).to.equal('Empty input schema provided.');
+      });
+    });
+
+    it('should return `empty schema provided` error for input type json', function() {
+      Converter.convert({
+        type: 'json',
+        data: {}
+      }, {}, (err, res) => {
+        expect(err).to.be.null;
+        expect(res.result).to.be.false;
+        expect(res.reason).to.equal('Empty input schema provided.');
+      });
+    });
+
+    it('should return `empty schema provided` error for input type file', function() {
+      Converter.convert({
+        type: 'file',
+        data: emptySpec
+      }, {}, (err, res) => {
+        expect(err).to.be.null;
+        expect(res.result).to.be.false;
+        expect(res.reason).to.equal('Empty input schema provided.');
+      });
+    });
+  });
 });


### PR DESCRIPTION
If an empty spec is provided as input, the converter would throw an error stating `Uncaught TypeError: Cannot read property 'hasOwnProperty' of undefined`. This was thrown from validateRoot function, which expects an openapi object.