### PR TITLE
Fix variable name to log correct warning when schema faker throws an exception

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -167,7 +167,7 @@ function safeSchemaFaker(oldSchema, resolveTo, parameterSourceOption, components
   }
   catch (e) {
     console.warn(
-      'Error faking a schema. Not faking this schema. Schema:', schema,
+      'Error faking a schema. Not faking this schema. Schema:', resolvedSchema,
       'Error', e
     );
     return null;


### PR DESCRIPTION
This PR fixes #162 .
When caching code was introduced in `safeSchemaFaker` function, the variable name that holds the resolved schema was changed from`schema` to `resolvedSchema`. This change was not reflected in the warning that we log when json-schema-faker throws an exception