### PR TITLE
Add path variable handling for special cases

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1500,26 +1500,26 @@ module.exports = {
     return refObj;
   },
 
-  /** Finds all the possible path variables in a given url string
-   * @param {string} url URL
+  /** Finds all the possible path variables in a given path string
+   * @param {string} path Path string : /pets/{petId}
    * @returns {array} Array of path variables.
    */
-  findPathVariablesFromUrl: function (url) {
+  findPathVariablesFromPath: function (path) {
 
-    // /{{path}}/{{file}}.{{format}}/{{hello}} return [ 'path', 'hello' ]
+    // /{{path}}/{{file}}.{{format}}/{{hello}} return [ '{{path}}', '{{hello}}' ]
     // https://regex101.com/r/XGL4Gh/1
-    return url.match(/(\/\{\{[^\/\{\}]+\}\})(?=\/|$)/g);
+    return path.match(/(\/\{\{[^\/\{\}]+\}\})(?=\/|$)/g);
   },
 
-  /** Finds all the possible collection variables in a given url string
-   * @param {string} url URL
+  /** Finds all the possible collection variables in a given path string
+   * @param {string} path Path string : /pets/{petId}
    * @returns {array} Array of collection variables.
    */
-  findCollectionVariablesFromUrl: function (url) {
+  findCollectionVariablesFromPath: function (path) {
 
     // /:path/{{file}}.{{format}}/:hello => only {{file}} and {{format}} will match
     // https://regex101.com/r/XGL4Gh/2
-    return url.match(/(\{\{[^\/\{\}]+\}\})/g);
+    return path.match(/(\{\{[^\/\{\}]+\}\})/g);
   },
 
   /** Separates outs collection and path variables from the reqUrl
@@ -1535,7 +1535,7 @@ module.exports = {
 
     // converts all the of the following:
     // /{{path}}/{{file}}.{{format}}/{{hello}} => /:path/{{file}}.{{format}}/:hello
-    matches = this.findPathVariablesFromUrl(reqUrl);
+    matches = this.findPathVariablesFromPath(reqUrl);
     if (matches) {
       matches.forEach((match) => {
         const replaceWith = match.replace(/{{/g, ':').replace(/}}/g, '');
@@ -1544,7 +1544,7 @@ module.exports = {
     }
 
     // Separates pathVars array and collectionVars.
-    matches = this.findCollectionVariablesFromUrl(reqUrl);
+    matches = this.findCollectionVariablesFromPath(reqUrl);
     if (matches) {
       matches.forEach((match) => {
         const collVar = match.replace(/{{/g, '').replace(/}}/g, '');
@@ -1597,7 +1597,6 @@ module.exports = {
       globalServers = _.get(operationItem, 'servers');
 
     // handling path templating in request url if any
-
     // convert all {anything} to {{anything}}
     reqUrl = this.fixPathVariablesInUrl(reqUrl);
 

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1493,6 +1493,50 @@ module.exports = {
     return refObj;
   },
 
+  /** Separates outs collection and path variables from the reqUrl
+   *
+   * @param {string} reqUrl Request Url
+   * @param {Array} pathVars Path variables
+   *
+   * @returns {Object} reqUrl, updated path Variables array and collection Variables.
+   */
+  sanitizeUrlPathParams: function (reqUrl, pathVars) {
+    var matches,
+      collectionVars = [];
+
+    // matches all the of the following:
+    // /{{path}} => /:path
+    // /{{path}}/{{another-path}} => /:path/:another-path
+    // /file.{{format}} => /file.{{format}} : unchanged.
+    // /{{filename}}.{{format}} => /{{filename}}.{{format}} ; unchanged
+
+    matches = reqUrl.match(/(\/\{\{[^\/\{\}]+\}\})(?!\.)/g);
+    if (matches) {
+      matches.forEach((match) => {
+        const replaceWith = match.replace(/{{/g, ':').replace(/}}/g, '');
+        reqUrl = reqUrl.replace(match, replaceWith);
+      });
+    }
+
+    // Matches all with {{1$}}
+    // Removes it from pathVars array and adds it to collectionVars.
+    matches = reqUrl.match(/(\{\{[^\/\{\}]+\}\})/g);
+    if (matches) {
+      matches.forEach((match) => {
+        const collVar = match.replace(/{{/g, '').replace(/}}/g, '');
+
+        pathVars = pathVars.filter((item) => {
+          if (item.name === collVar) {
+            collectionVars.push(item);
+          }
+          return !(item.name === collVar);
+        });
+      });
+    }
+
+    return { reqUrl, pathVars, collectionVars };
+  },
+
   /**
    * function to convert an openapi path item to postman item
   * @param {*} openapi openapi object with root properties
@@ -1525,10 +1569,23 @@ module.exports = {
       localServers = _.get(operationItem, 'properties.servers'),
       exampleRequestBody,
       originalRequestHeaders = [],
+      sanitizeResult,
       globalServers = _.get(operationItem, 'servers');
 
     // handling path templating in request url if any
-    reqUrl = reqUrl.replace(/{/g, ':').replace(/}/g, '');
+
+    // convert all {anything} to {{anything}}
+    reqUrl = this.fixPathVariablesInUrl(reqUrl);
+
+    // convert all /{{one}}/{{two}} to /:one/:two
+    // Doesn't touch /{{file}}.{{format}}
+    sanitizeResult = this.sanitizeUrlPathParams(reqUrl, reqParams.path);
+
+    // Updated reqUrl
+    reqUrl = sanitizeResult.reqUrl;
+
+    // Updated reqParams.path
+    reqParams.path = sanitizeResult.pathVars;
 
     // accounting for the overriding of the root level and path level servers object if present at the operation level
 

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1505,12 +1505,9 @@ module.exports = {
       collectionVars = [];
 
     // matches all the of the following:
-    // /{{path}} => /:path
-    // /{{path}}/{{another-path}} => /:path/:another-path
-    // /file.{{format}} => /file.{{format}} : unchanged.
-    // /{{filename}}.{{format}} => /{{filename}}.{{format}} ; unchanged
-
-    matches = reqUrl.match(/(\/\{\{[^\/\{\}]+\}\})(?!\.)/g);
+    // /{{path}}/{{file}}.{{format}}/{{hello}} => /:path/{{file}}.{{format}}/:hello
+    // https://regex101.com/r/XGL4Gh/1
+    matches = reqUrl.match(/(\/\{\{[^\/\{\}]+\}\})(?=\/|$)/g);
     if (matches) {
       matches.forEach((match) => {
         const replaceWith = match.replace(/{{/g, ':').replace(/}}/g, '');
@@ -1518,8 +1515,9 @@ module.exports = {
       });
     }
 
-    // Matches all with {{1$}}
-    // Removes it from pathVars array and adds it to collectionVars.
+    // Separates pathVars array and collectionVars.
+    // https://regex101.com/r/XGL4Gh/2
+    // /:path/{{file}}.{{format}}/:hello => only {{file}} and {{format}} will match
     matches = reqUrl.match(/(\{\{[^\/\{\}]+\}\})/g);
     if (matches) {
       matches.forEach((match) => {

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -589,10 +589,11 @@ module.exports = {
    * resolve references while generating params.
    * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
    * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
+   * @param {object} variableStore - array for storing collection variables
    * @returns {*} Postman itemGroup or request
    * @no-unit-test
    */
-  convertChildToItemGroup: function (openapi, child, components, options, schemaCache) {
+  convertChildToItemGroup: function (openapi, child, components, options, schemaCache, variableStore) {
     options = _.merge({}, defaultOptions, options);
 
     var resource = child,
@@ -620,14 +621,14 @@ module.exports = {
           resourceSubChild = resource.children[subChild];
 
         resourceSubChild.name = resource.name + '/' + resourceSubChild.name;
-        return this.convertChildToItemGroup(openapi, resourceSubChild, components, options, schemaCache);
+        return this.convertChildToItemGroup(openapi, resourceSubChild, components, options, schemaCache, variableStore);
       }
       /* eslint-enable */
       // recurse over child leaf nodes
       // and add as children to this folder
       for (i = 0, requestCount = resource.requests.length; i < requestCount; i++) {
         itemGroup.items.add(
-          this.convertRequestToItem(openapi, resource.requests[i], components, options, schemaCache)
+          this.convertRequestToItem(openapi, resource.requests[i], components, options, schemaCache, variableStore)
         );
       }
 
@@ -637,7 +638,8 @@ module.exports = {
       for (subChild in resource.children) {
         if (resource.children.hasOwnProperty(subChild) && resource.children[subChild].requestCount > 0) {
           itemGroup.items.add(
-            this.convertChildToItemGroup(openapi, resource.children[subChild], components, options, schemaCache)
+            this.convertChildToItemGroup(openapi, resource.children[subChild], components, options, schemaCache,
+              variableStore)
           );
         }
       }
@@ -648,14 +650,15 @@ module.exports = {
 
     // 2. it has only 1 direct request of its own
     if (resource.requests.length === 1) {
-      return this.convertRequestToItem(openapi, resource.requests[0], components, options, schemaCache);
+      return this.convertRequestToItem(openapi, resource.requests[0], components, options, schemaCache, variableStore);
     }
 
     // 3. it's a folder that has no child request
     // but one request somewhere in its child folders
     for (subChild in resource.children) {
       if (resource.children.hasOwnProperty(subChild) && resource.children[subChild].requestCount === 1) {
-        return this.convertChildToItemGroup(openapi, resource.children[subChild], components, options, schemaCache);
+        return this.convertChildToItemGroup(openapi, resource.children[subChild], components, options, schemaCache,
+          variableStore);
       }
     }
   },
@@ -1547,10 +1550,11 @@ module.exports = {
    * resolve references while generating params.
    * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
   * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
+  * @param {array} variableStore - array
   * @returns {Object} postman request Item
   * @no-unit-test
   */
-  convertRequestToItem: function(openapi, operationItem, components, options, schemaCache) {
+  convertRequestToItem: function(openapi, operationItem, components, options, schemaCache, variableStore) {
     options = _.merge({}, defaultOptions, options);
     var reqName,
       pathVariables = openapi.baseUrlVariables,
@@ -1588,6 +1592,14 @@ module.exports = {
     // Updated reqParams.path
     reqParams.path = sanitizeResult.pathVars;
 
+    // Add collection variables to the variableStore.
+    sanitizeResult.collectionVars.forEach((element) => {
+      variableStore.push(new sdk.Variable({
+        id: element.name,
+        value: element.default || '',
+        description: element.description
+      }));
+    });
     // accounting for the overriding of the root level and path level servers object if present at the operation level
 
     if (Array.isArray(localServers) && localServers.length) {

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1594,11 +1594,14 @@ module.exports = {
 
     // Add collection variables to the variableStore.
     sanitizeResult.collectionVars.forEach((element) => {
-      variableStore.push(new sdk.Variable({
-        id: element.name,
-        value: element.default || '',
-        description: element.description
-      }));
+      if (!variableStore[element.name]) {
+        variableStore[element.name] = {
+          id: element.name,
+          value: element.default || '',
+          description: element.description,
+          type: 'collection'
+        };
+      }
     });
     // accounting for the overriding of the root level and path level servers object if present at the operation level
 

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1500,6 +1500,28 @@ module.exports = {
     return refObj;
   },
 
+  /** Finds all the possible path variables in a given url string
+   * @param {string} url URL
+   * @returns {array} Array of path variables.
+   */
+  findPathVariablesFromUrl: function (url) {
+
+    // /{{path}}/{{file}}.{{format}}/{{hello}} return [ 'path', 'hello' ]
+    // https://regex101.com/r/XGL4Gh/1
+    return url.match(/(\/\{\{[^\/\{\}]+\}\})(?=\/|$)/g);
+  },
+
+  /** Finds all the possible collection variables in a given url string
+   * @param {string} url URL
+   * @returns {array} Array of collection variables.
+   */
+  findCollectionVariablesFromUrl: function (url) {
+
+    // /:path/{{file}}.{{format}}/:hello => only {{file}} and {{format}} will match
+    // https://regex101.com/r/XGL4Gh/2
+    return url.match(/(\{\{[^\/\{\}]+\}\})/g);
+  },
+
   /** Separates outs collection and path variables from the reqUrl
    *
    * @param {string} reqUrl Request Url
@@ -1511,10 +1533,9 @@ module.exports = {
     var matches,
       collectionVars = [];
 
-    // matches all the of the following:
+    // converts all the of the following:
     // /{{path}}/{{file}}.{{format}}/{{hello}} => /:path/{{file}}.{{format}}/:hello
-    // https://regex101.com/r/XGL4Gh/1
-    matches = reqUrl.match(/(\/\{\{[^\/\{\}]+\}\})(?=\/|$)/g);
+    matches = this.findPathVariablesFromUrl(reqUrl);
     if (matches) {
       matches.forEach((match) => {
         const replaceWith = match.replace(/{{/g, ':').replace(/}}/g, '');
@@ -1523,9 +1544,7 @@ module.exports = {
     }
 
     // Separates pathVars array and collectionVars.
-    // https://regex101.com/r/XGL4Gh/2
-    // /:path/{{file}}.{{format}}/:hello => only {{file}} and {{format}} will match
-    matches = reqUrl.match(/(\{\{[^\/\{\}]+\}\})/g);
+    matches = this.findCollectionVariablesFromUrl(reqUrl);
     if (matches) {
       matches.forEach((match) => {
         const collVar = match.replace(/{{/g, '').replace(/}}/g, '');

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -296,7 +296,7 @@ class SchemaPack {
     // it returns a version property with value set as undefined
     // this fails validation against v2.1 collection schema definition.
     delete collectionJSON.info.version;
-    fs.writeFileSync('collectionVariable.json', JSON.stringify(collectionJSON, null, 2));
+
     return callback(null, {
       result: true,
       output: [{

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -37,7 +37,8 @@ const COLLECTION_NAME = 'Converted from OpenAPI',
   generateCollection = function (specWrapper, generatedStore, components, options, schemaCache) {
     var folderTree = specWrapper.tree, // this is the trie we generate (as a scaffold to the collection)
       openapi = specWrapper.spec, // this is the JSON-version of the openAPI spec
-      child;
+      child,
+      variableStore = [];
 
     for (child in folderTree.root.children) {
       // A Postman request or folder is added if atleast one request is present in that sub-child's tree
@@ -45,10 +46,13 @@ const COLLECTION_NAME = 'Converted from OpenAPI',
       if (folderTree.root.children.hasOwnProperty(child) && folderTree.root.children[child].requestCount > 0) {
         generatedStore.collection.items.add(
           schemaUtils.convertChildToItemGroup(openapi, folderTree.root.children[child],
-            components, options, schemaCache)
+            components, options, schemaCache, variableStore)
         );
       }
     }
+    variableStore.forEach((item) => {
+      generatedStore.collection.variables.add(item);
+    });
   };
 
 
@@ -292,7 +296,7 @@ class SchemaPack {
     // it returns a version property with value set as undefined
     // this fails validation against v2.1 collection schema definition.
     delete collectionJSON.info.version;
-
+    fs.writeFileSync('collectionVariable.json', JSON.stringify(collectionJSON, null, 2));
     return callback(null, {
       result: true,
       output: [{

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -38,7 +38,8 @@ const COLLECTION_NAME = 'Converted from OpenAPI',
     var folderTree = specWrapper.tree, // this is the trie we generate (as a scaffold to the collection)
       openapi = specWrapper.spec, // this is the JSON-version of the openAPI spec
       child,
-      variableStore = [];
+      key,
+      variableStore = {};
 
     for (child in folderTree.root.children) {
       // A Postman request or folder is added if atleast one request is present in that sub-child's tree
@@ -50,9 +51,14 @@ const COLLECTION_NAME = 'Converted from OpenAPI',
         );
       }
     }
-    variableStore.forEach((item) => {
-      generatedStore.collection.variables.add(item);
-    });
+    for (key in variableStore) {
+      // variableStore contains all the kinds of variable created.
+      // Add only the variables with type 'collection' to generatedStore.collection.variables
+      if (variableStore[key].type === 'collection') {
+        const collectionVar = new sdk.Variable(variableStore[key]);
+        generatedStore.collection.variables.add(collectionVar);
+      }
+    }
   };
 
 

--- a/test/data/valid_openapi/issue#133.json
+++ b/test/data/valid_openapi/issue#133.json
@@ -1,0 +1,171 @@
+{
+	"openapi": "3.0.0",
+	"info": {
+		"version": "1.0.0",
+		"title": "Path Variable issues",
+		"license": {
+			"name": "MIT"
+		}
+	},
+	"servers": [
+		{
+			"url": "http://petstore.swagger.io/v1"
+		}
+	],
+	"paths": {
+		"/send-sms.{format}": {
+			"get": {
+				"summary": "List all pets",
+				"operationId": "listPets",
+				"tags": [
+					"pets"
+				],
+				"parameters": [
+					{
+						"name": "format",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+					}
+				]
+			}
+    },
+    "/some/{path}": {
+			"get": {
+				"summary": "List all pets",
+				"operationId": "listPets",
+				"tags": [
+					"pets"
+				],
+				"parameters": [
+					{
+						"name": "path",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+					}
+				]
+			}
+    },
+    "/new/{path}.{new-path-variable}": {
+			"get": {
+				"summary": "List all pets",
+				"operationId": "listPets",
+				"tags": [
+					"pets"
+				],
+				"parameters": [
+					{
+						"name": "path",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+          },
+          {
+						"name": "new-path-variable",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+					}
+				]
+			}
+		},
+		"/next/{path}/{new-path-variable}": {
+			"get": {
+				"summary": "List all pets",
+				"operationId": "listPets",
+				"tags": [
+					"pets"
+				],
+				"parameters": [
+					{
+						"name": "path",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+          },
+          {
+						"name": "new-path-variable",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+					}
+				]
+			}
+		},
+		"/anotherpath/{path}/{new-path-variable}.{onemore}": {
+			"get": {
+				"summary": "List all pets",
+				"operationId": "listPets",
+				"tags": [
+					"pets"
+				],
+				"parameters": [
+					{
+						"name": "path",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+          },
+          {
+						"name": "new-path-variable",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+					},
+					{
+						"name": "onemore",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+					}
+				]
+			}
+		}
+	}
+}

--- a/test/data/valid_openapi/issue#133.json
+++ b/test/data/valid_openapi/issue#133.json
@@ -166,6 +166,50 @@
 					}
 				]
 			}
+		},
+		"/{path}({new-path-variable}={onemore})": {
+			"get": {
+				"summary": "List all pets",
+				"operationId": "listPets",
+				"tags": [
+					"pets"
+				],
+				"parameters": [
+					{
+						"name": "path",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+          },
+          {
+						"name": "new-path-variable",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+					},
+					{
+						"name": "onemore",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+					}
+				]
+			}
 		}
 	}
 }

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -11,6 +11,7 @@ describe('CONVERT FUNCTION TESTS ', function() {
 
     var testSpec = path.join(__dirname, VALID_OPENAPI_PATH + '/test.json'),
       testSpec1 = path.join(__dirname, VALID_OPENAPI_PATH + '/test1.json'),
+      issue133 = path.join(__dirname, VALID_OPENAPI_PATH + '/issue#133.json'),
       serverOverRidingSpec = path.join(__dirname, VALID_OPENAPI_PATH + '/server_overriding.json'),
       infoHavingContactOnlySpec = path.join(__dirname, VALID_OPENAPI_PATH + '/info_having_contact_only.json'),
       infoHavingDescriptionOnlySpec = path.join(__dirname, VALID_OPENAPI_PATH + '/info_having_description_only.json'),
@@ -42,6 +43,21 @@ describe('CONVERT FUNCTION TESTS ', function() {
         done();
       });
     });
+
+    it(' Fix for GITHUB#133: Should generate collection with proper Path and Collection variables', function(done) {
+      var openapi = fs.readFileSync(issue133, 'utf8');
+      Converter.convert({ type: 'string', data: openapi }, { schemaFaker: true }, (err, conversionResult) => {
+        // console.log(conversionResult.output[0].data);
+        expect(err).to.be.null;
+        expect(conversionResult.result).to.equal(true);
+        expect(conversionResult.output.length).to.equal(1);
+        expect(conversionResult.output[0].type).to.equal('collection');
+        expect(conversionResult.output[0].data).to.have.property('info');
+        expect(conversionResult.output[0].data).to.have.property('item');
+        done();
+      });
+    });
+
     it('Should generate collection conforming to schema for and fail if not valid ' +
       testSpec1, function(done) {
       Converter.convert({ type: 'file', data: testSpec1 }, { requestNameSource: 'url' }, (err, conversionResult) => {

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -47,7 +47,7 @@ describe('CONVERT FUNCTION TESTS ', function() {
     it(' Fix for GITHUB#133: Should generate collection with proper Path and Collection variables', function(done) {
       var openapi = fs.readFileSync(issue133, 'utf8');
       Converter.convert({ type: 'string', data: openapi }, { schemaFaker: true }, (err, conversionResult) => {
-        // console.log(conversionResult.output[0].data);
+
         expect(err).to.be.null;
         expect(conversionResult.result).to.equal(true);
         expect(conversionResult.output.length).to.equal(1);

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -55,6 +55,11 @@ describe('CONVERT FUNCTION TESTS ', function() {
         expect(conversionResult.output[0].type).to.equal('collection');
         expect(conversionResult.output[0].data).to.have.property('info');
         expect(conversionResult.output[0].data).to.have.property('item');
+        expect(conversionResult.output[0].data).to.have.property('variable');
+        expect(conversionResult.output[0].data.variable).to.be.an('array');
+        expect(conversionResult.output[0].data.variable[1].id).to.equal('format');
+        expect(conversionResult.output[0].data.variable[2].id).to.equal('path');
+        expect(conversionResult.output[0].data.variable[3].id).to.equal('new-path-variable');
         done();
       });
     });

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -2050,6 +2050,35 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
     });
   });
 
+  describe('sanitize function', function() {
+    it('should convert a url with scheme and path variables', function(done) {
+      var pathParams = [{ name: 'path',
+          in: 'path',
+          description: 'description',
+          required: true,
+          schema: { type: 'string', pattern: 'json|xml', example: 'json' } },
+        { name: 'new-path-variable',
+          in: 'path',
+          description: 'description',
+          required: true,
+          schema: { type: 'string', pattern: 'json|xml', example: 'json' } },
+        { name: 'onemore',
+          in: 'path',
+          description: 'description',
+          required: true,
+          schema: { type: 'string', pattern: 'json|xml', example: 'json' } }],
+        resultObj = SchemaUtils.sanitizeUrlPathParams('/anotherpath/{{path}}/{{new-path-variable}}.{{onemore}}',
+          pathParams);
+
+      expect(resultObj).to.have.property('reqUrl');
+      expect(resultObj.reqUrl).to.equal('/anotherpath/:path/{{new-path-variable}}.{{onemore}}');
+      expect(resultObj).to.have.property('pathVars');
+      expect(resultObj).to.have.property('collectionVars');
+
+      done();
+    });
+  });
+
 });
 
 describe('Get header family function ', function() {

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -2015,6 +2015,41 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
       done();
     });
   });
+
+  describe('findPathVariablesFromPath function', function() {
+    it('should convert a url with scheme and path variables', function(done) {
+      var pathVars = SchemaUtils.findPathVariablesFromPath('/some/{{path}}');
+      expect(pathVars[0]).to.equal('/{{path}}');
+
+      pathVars = SchemaUtils.findPathVariablesFromPath('/next/{{path}}/{{new-path-variable}}');
+      expect(pathVars[0]).to.equal('/{{path}}');
+      expect(pathVars[1]).to.equal('/{{new-path-variable}}');
+
+      pathVars = SchemaUtils.findPathVariablesFromPath('/anotherpath/{{path}}/{{new-path-variable}}.{{onemore}');
+      expect(pathVars[0]).to.equal('/{{path}}');
+
+      pathVars = SchemaUtils.findPathVariablesFromPath('/send-sms.{{format}}');
+      expect(pathVars).to.equal(null);
+      done();
+    });
+  });
+  describe('findCollectionVariablesFromPath function', function() {
+    it('should convert a url with scheme and path variables', function(done) {
+
+      var collVars = SchemaUtils.findCollectionVariablesFromPath('/send-sms.{{format}}');
+      expect(collVars[0]).to.equal('{{format}}');
+
+      collVars = SchemaUtils.findCollectionVariablesFromPath('/next/:path/:new-path-variable');
+      expect(collVars).to.equal(null);
+
+      collVars = SchemaUtils.findCollectionVariablesFromPath('/anotherpath/:path/{{new-path-variable}}.{{onemore}}');
+      expect(collVars[0]).to.equal('{{new-path-variable}}');
+      expect(collVars[1]).to.equal('{{onemore}}');
+
+      done();
+    });
+  });
+
 });
 
 describe('Get header family function ', function() {


### PR DESCRIPTION
`/send-sms.{format}` was being resolved to `/send-sms.:format` which wasn't recognized in postman as a path variable. 
After the changes.
`/path/{pathId}` => `/path/:pathId` > `pathId` added as a path variable in postman
`/path.{pathId}` => `/path.{{pathId}}` > `pathId` added as a collection variable in postman.
`/somePath=({key}.{value})` => `/somePath=({{key}}.{{value}})`