### PR TITLE
Fix getRequestParams function of schemaUtils

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -329,22 +329,23 @@ module.exports = {
    */
   getRequestParams: function(operationParam, pathParam, components, options) {
     options = _.merge({}, defaultOptions, options);
-    if (!_.isEmpty(pathParam)) {
-      // if pathParams exist, resolve refs
-      pathParam.forEach((param, index, arr) => {
-        if (param.hasOwnProperty('$ref')) {
-          arr[index] = this.getRefObject(param.$ref, components, options);
-        }
-      });
+    if (!Array.isArray(operationParam)) {
+      operationParam = [];
     }
-    if (!_.isEmpty(operationParam)) {
-      // if operationParams exist, resolve references
-      operationParam.forEach((param, index, arr) => {
-        if (param.hasOwnProperty('$ref')) {
-          arr[index] = this.getRefObject(param.$ref, components, options);
-        }
-      });
+    if (!Array.isArray(pathParam)) {
+      pathParam = [];
     }
+    pathParam.forEach((param, index, arr) => {
+      if (param.hasOwnProperty('$ref')) {
+        arr[index] = this.getRefObject(param.$ref, components, options);
+      }
+    });
+
+    operationParam.forEach((param, index, arr) => {
+      if (param.hasOwnProperty('$ref')) {
+        arr[index] = this.getRefObject(param.$ref, components, options);
+      }
+    });
 
     if (_.isEmpty(pathParam)) {
       return operationParam;
@@ -360,7 +361,10 @@ module.exports = {
     var reqParam = operationParam.slice();
     pathParam.forEach((param) => {
       var dupParam = operationParam.find(function(element) {
-        return element.name === param.name && element.in === param.in;
+        return element.name === param.name && element.in === param.in &&
+        // the below two conditions because undefined === undefined returns true
+          element.name && param.name &&
+          element.in && param.in;
       });
       if (!dupParam) {
         // if there's no duplicate param in operationParam,

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1469,12 +1469,12 @@ module.exports = {
     // must have min. 2 segments after "#/components"
     if (savedSchema.length < 3) {
       console.warn(`ref ${$ref} not found.`);
-      return null;
+      return { value: `reference ${$ref} not found in the given specification` };
     }
 
     if (savedSchema[0] !== 'components' && savedSchema[0] !== 'paths') {
       console.warn(`Error reading ${$ref}. Can only use references from components and paths`);
-      return null;
+      return { value: `Error reading ${$ref}. Can only use references from components and paths` };
     }
 
     // at this point, savedSchema is similar to ['components', 'schemas','Address']
@@ -1483,7 +1483,7 @@ module.exports = {
 
     if (!refObj) {
       console.warn(`ref ${$ref} not found.`);
-      return null;
+      return { value: `reference ${$ref} not found in the given specification` };
     }
 
     if (refObj.$ref) {

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -267,6 +267,66 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
       expect(retVal[1].name).to.equal('variable');
       expect(retVal[1].description).to.equal('hello again');
     });
+
+    it('should return pathParam(array) if operationParam is not of type array', function () {
+      var operationParam = { name: 'limit', in: 'query', description: 'hello' },
+        pathParam = [
+          { name: 'limit', in: 'query', description: '' }
+        ],
+        retVal = SchemaUtils.getRequestParams(operationParam, pathParam, {});
+      expect(retVal).to.eql(pathParam);
+    });
+
+    it('should return operationParam(array) if pathParam is not of type array', function () {
+      var pathParam = { name: 'limit', in: 'query', description: 'hello' },
+        operationParam = [
+          { name: 'limit', in: 'query', description: '' }
+        ],
+        retVal = SchemaUtils.getRequestParams(operationParam, pathParam, {});
+      expect(retVal).to.eql(operationParam);
+    });
+
+    it('should return empty array if pathParam and operationParam are not of type array', function () {
+      var operationParam = { name: 'limit', in: 'query', description: 'hello' },
+        pathParam = { name: 'limit', in: 'query', description: '' },
+        retVal = SchemaUtils.getRequestParams(operationParam, pathParam, {});
+      expect(retVal).to.eql([]);
+    });
+
+    it('should not throw error if a parameter with invalid $ref is passed', function () {
+      var operationParam = [
+          { name: 'limit', in: 'query', $ref: '#/invalid/ref/1' }
+        ],
+        pathParam = [
+          { $ref: '#/components/schemas/searchParam' }
+        ],
+        componentsAndPaths = {
+          components: {
+            schemas: {
+              searchParam: {
+                name: 'search',
+                in: 'query',
+                schema: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        },
+        retVal = SchemaUtils.getRequestParams(operationParam, pathParam, componentsAndPaths);
+      expect(retVal).to.deep.equal([
+        {
+          value: 'Error reading #/invalid/ref/1. Can only use references from components and paths'
+        },
+        {
+          name: 'search',
+          in: 'query',
+          schema: {
+            type: 'string'
+          }
+        }
+      ]);
+    });
   });
 
   describe('generateTrieFromPaths Function ', function() {


### PR DESCRIPTION
getRequestparams function expects 4 arguments:
- operationParams: operation level params array
- pathParams: path level params array
- components: components and paths object
- options: preference options object

1. The function expects operationParam and pathParam as an array. As described in the OpenAPI specification [here](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#fixed-fields-8), parameters should be an array of objects. But if the schema defined is wrong in some way such that it sends a non-array type argument, the function throws an error stating operationParam.forEach is not a function, same for pathParam.forEach. Thus, we should check for array type before looping over it.

2. If any parameter has references defined vis `$ref`, we resolve them via `getRefObject` function. Now, this function used to return null when supplied with an invalid ref. This causes the following line to break while removing duplicate params:
```
pathParam.forEach((param) => {
      var dupParam = operationParam.find(function(element) {
        return element.name === param.name && element.in === param.in;
      });
``` 
To solve this, modify the `getRefObject` function to not return null, but a dummy object with value set as some indicative error message.