### PR TITLE
Fix incorrect headers issue in example request in responses

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1524,7 +1524,6 @@ module.exports = {
       swagResponse,
       localServers = _.get(operationItem, 'properties.servers'),
       exampleRequestBody,
-      originalRequestHeaders = [],
       globalServers = _.get(operationItem, 'servers');
 
     // handling path templating in request url if any
@@ -1683,6 +1682,7 @@ module.exports = {
       let thisOriginalRequest = {},
         convertedResponse;
       _.forOwn(operation.responses, (response, code) => {
+        let originalRequestHeaders = [];
         swagResponse = response;
         if (response.$ref) {
           swagResponse = this.getRefObject(response.$ref, components, options);

--- a/test/data/valid_openapi/issue#173.yml
+++ b/test/data/valid_openapi/issue#173.yml
@@ -1,0 +1,30 @@
+openapi: "3.0.0"
+
+info:
+  version: "1.0.0"
+  title: "Sample API"
+
+paths:
+  /path1:
+    post:
+      parameters:
+        - in: header
+          name: access_token
+          description: Access token
+          schema:
+            type: string
+            example: X-access-token
+
+      responses:
+        200:
+          description: 200 Success
+        400:
+          description: 400 Bad Request
+        401:
+          description: 401 Unauthorized
+        403:
+         description: 403 Forbidden
+        404:
+          description: 404 Not Found
+        500:
+          description: 500 Internal Server Error

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -27,7 +27,8 @@ describe('CONVERT FUNCTION TESTS ', function() {
       zeroDefaultValueSpec = path.join(__dirname, VALID_OPENAPI_PATH + '/zero_in_default_value.json'),
       requiredInParams = path.join(__dirname, VALID_OPENAPI_PATH, '/required_in_parameters.json'),
       multipleRefs = path.join(__dirname, VALID_OPENAPI_PATH, '/multiple_refs.json'),
-      issue150 = path.join(__dirname, VALID_OPENAPI_PATH + '/issue#150.yml');
+      issue150 = path.join(__dirname, VALID_OPENAPI_PATH + '/issue#150.yml'),
+      issue173 = path.join(__dirname, VALID_OPENAPI_PATH, '/issue#173.yml');
 
     it('Should generate collection conforming to schema for and fail if not valid ' +
      testSpec, function(done) {
@@ -447,6 +448,28 @@ describe('CONVERT FUNCTION TESTS ', function() {
         expect(conversionResult.output[0].type).to.equal('collection');
         expect(conversionResult.output[0].data).to.have.property('info');
         expect(conversionResult.output[0].data).to.have.property('item');
+        done();
+      });
+    });
+
+    it('[Github #173] - should add headers correctly to sample request in examples(responses)', function (done) {
+      var openapi = fs.readFileSync(issue173, 'utf8');
+      Converter.convert({ type: 'string', data: openapi }, {}, (err, conversionResult) => {
+        let responseArray;
+        expect(err).to.be.null;
+        responseArray = conversionResult.output[0].data.item[0].response;
+        expect(responseArray).to.be.an('array');
+        responseArray.forEach((response) => {
+          let headerArray = response.originalRequest.header;
+          expect(headerArray).to.be.an('array').that.is.not.empty;
+          expect(headerArray).to.eql([
+            {
+              key: 'access_token',
+              value: 'X-access-token',
+              description: 'Access token'
+            }
+          ]);
+        });
         done();
       });
     });


### PR DESCRIPTION
Fixes #173 
1. request headers declaration as an empty array was present outside the loop of responses. Thus, for every response, the request headers are pushed to the same array, causing the last example to have as many headers as the number of responses.
2. The headers not being populated in the first five responses is due to a bug in postman-collection SDK. If the same `originalRequest` is passed in all the responses(and thus the same header array), it removes the header from the header list passed in the `originalRequest`. Thus, as a workaround, we calculate the headers everytime in a new array and pass it to collection SDK.