### PR TITLE
Ignore resolving circular references

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -55,21 +55,22 @@ module.exports = {
    * @param {*} components components in openapi spec.
    * @param {object} schemaResolutionCache stores already resolved references
    * @param {*} stack counter which keeps a tab on nested schemas
+   * @param {*} seenRef References that are repeated. Used to identify circular references.
    * @returns {*} schema - schema that adheres to all individual schemas in schemaArr
    */
-  resolveAllOf: function (schemaArr, parameterSourceOption, components, schemaResolutionCache, stack = 0) {
+  resolveAllOf: function (schemaArr, parameterSourceOption, components, schemaResolutionCache, stack = 0, seenRef) {
     if (!(schemaArr instanceof Array)) {
       return null;
     }
 
     if (schemaArr.length === 1) {
       // for just one entry in allOf, don't need to enforce type: object restriction
-      return this.resolveRefs(schemaArr[0], parameterSourceOption, components, schemaResolutionCache, stack);
+      return this.resolveRefs(schemaArr[0], parameterSourceOption, components, schemaResolutionCache, stack, seenRef);
     }
 
     // generate one object for each schema
     let indivObjects = schemaArr.map((schema) => {
-        return this.resolveRefs(schema, parameterSourceOption, components, schemaResolutionCache, stack);
+        return this.resolveRefs(schema, parameterSourceOption, components, schemaResolutionCache, stack, seenRef);
       }).filter((schema) => {
         return schema.type === 'object';
       }),

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -120,20 +120,21 @@ module.exports = {
 
     if (schema.anyOf) {
       return this.resolveRefs(schema.anyOf[0], parameterSourceOption, components, schemaResolutionCache, stack,
-        seenRef);
+        _.cloneDeep(seenRef));
     }
     if (schema.oneOf) {
       return this.resolveRefs(schema.oneOf[0], parameterSourceOption, components, schemaResolutionCache, stack,
-        seenRef);
+        _.cloneDeep(seenRef));
     }
     if (schema.allOf) {
-      return this.resolveAllOf(schema.allOf, parameterSourceOption, components, schemaResolutionCache, stack, seenRef);
+      return this.resolveAllOf(schema.allOf, parameterSourceOption, components, schemaResolutionCache, stack,
+        _.cloneDeep(seenRef));
     }
     if (schema.$ref) {
       let refKey = schema.$ref;
 
       // if this reference is seen before, ignore and move on.
-      if (seenRef[refKey] < stack) {
+      if (seenRef[refKey]) {
         return { value: '<Circular reference to ' + refKey + ' detected>' };
       }
       // add to seen array if not encountered before.
@@ -158,7 +159,7 @@ module.exports = {
 
       if (resolvedSchema) {
         let refResolvedSchema = this.resolveRefs(resolvedSchema, parameterSourceOption,
-          components, schemaResolutionCache, stack, seenRef);
+          components, schemaResolutionCache, stack, _.cloneDeep(seenRef));
         schemaResolutionCache[refKey] = refResolvedSchema;
         return refResolvedSchema;
       }
@@ -185,7 +186,7 @@ module.exports = {
             }
             /* eslint-enable */
             tempSchema.properties[prop] = this.resolveRefs(property,
-              parameterSourceOption, components, schemaResolutionCache, stack, seenRef);
+              parameterSourceOption, components, schemaResolutionCache, stack, _.cloneDeep(seenRef));
           }
         }
         return tempSchema;
@@ -204,7 +205,7 @@ module.exports = {
       // without this, schemas with circular references aren't faked correctly
       let tempSchema = _.omit(schema, 'items');
       tempSchema.items = this.resolveRefs(schema.items, parameterSourceOption,
-        components, schemaResolutionCache, stack, seenRef);
+        components, schemaResolutionCache, stack, _.cloneDeep(seenRef));
       return tempSchema;
     }
     else if (!schema.hasOwnProperty('default')) {

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -133,12 +133,11 @@ module.exports = {
       let refKey = schema.$ref;
 
       // if this reference is seen before, ignore and move on.
-      if (seenRef[refKey]) {
-        seenRef[refKey] = seenRef[refKey]++;
+      if (seenRef[refKey] < stack) {
         return { value: '<Cicular reference to ' + refKey + ' detected>' };
       }
       // add to seen array if not encountered before.
-      seenRef[refKey] = 1;
+      seenRef[refKey] = stack;
 
       // points to an existing location
       // .split will return [#, components, schemas, schemaName]

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -134,7 +134,7 @@ module.exports = {
 
       // if this reference is seen before, ignore and move on.
       if (seenRef[refKey] < stack) {
-        return { value: '<Cicular reference to ' + refKey + ' detected>' };
+        return { value: '<Circular reference to ' + refKey + ' detected>' };
       }
       // add to seen array if not encountered before.
       seenRef[refKey] = stack;

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -24,6 +24,26 @@ const _ = require('lodash'),
 
 module.exports = {
   /**
+   * @param {Object} object
+   * @param {string} $ref - Circular reference to be checked.
+   */
+
+  findCircularReference: function (object, $ref) {
+    for (var property in object) {
+      if (object.hasOwnProperty(property)) {
+        if (typeof object[property] === 'object') {
+          object[property] = this.findCircularReference(object[property], $ref);
+        }
+        else if (object[property] === $ref) {
+          object = { value: 'Circular reference' };
+          return object;
+        }
+      }
+    }
+    return object;
+  },
+
+  /**
    * @param {*} rootObject - the object from which you're trying to read a property
    * @param {*} pathArray - each element in this array a property of the previous object
    * @param {*} defValue - what to return if the required path is not found
@@ -147,12 +167,7 @@ module.exports = {
 
       // we will ignore any circular references encountered at the next immediate level
       if (resolvedSchema && resolvedSchema.hasOwnProperty('properties')) {
-        for (prop in resolvedSchema.properties) {
-          if (resolvedSchema.properties[prop].hasOwnProperty('$ref') &&
-          resolvedSchema.properties[prop].$ref === schema.$ref) {
-            resolvedSchema.properties[prop] = { value: 'Circular Reference detected' };
-          }
-        }
+        resolvedSchema.properties = this.findCircularReference(resolvedSchema.properties, schema.$ref);
       }
       if (resolvedSchema) {
         let refResolvedSchema = this.resolveRefs(resolvedSchema, parameterSourceOption,

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -24,26 +24,6 @@ const _ = require('lodash'),
 
 module.exports = {
   /**
-   * @param {Object} object
-   * @param {string} $ref - Circular reference to be checked.
-   */
-
-  findCircularReference: function (object, $ref) {
-    for (var property in object) {
-      if (object.hasOwnProperty(property)) {
-        if (typeof object[property] === 'object') {
-          object[property] = this.findCircularReference(object[property], $ref);
-        }
-        else if (object[property] === $ref) {
-          object = { value: 'Circular reference' };
-          return object;
-        }
-      }
-    }
-    return object;
-  },
-
-  /**
    * @param {*} rootObject - the object from which you're trying to read a property
    * @param {*} pathArray - each element in this array a property of the previous object
    * @param {*} defValue - what to return if the required path is not found
@@ -127,9 +107,10 @@ module.exports = {
    * @param {*} components components in openapi spec.
    * @param {object} schemaResolutionCache stores already resolved references
    * @param {*} stack counter which keeps a tab on nested schemas
+   * @param {*} seenRef - References that are repeated. Used to identify circular references.
    * @returns {*} schema satisfying JSON-schema-faker.
    */
-  resolveRefs: function (schema, parameterSourceOption, components, schemaResolutionCache, stack = 0) {
+  resolveRefs: function (schema, parameterSourceOption, components, schemaResolutionCache, stack = 0, seenRef = {}) {
     var resolvedSchema, prop, splitRef;
     stack++;
     schemaResolutionCache = schemaResolutionCache || {};
@@ -138,16 +119,27 @@ module.exports = {
     }
 
     if (schema.anyOf) {
-      return this.resolveRefs(schema.anyOf[0], parameterSourceOption, components, schemaResolutionCache, stack);
+      return this.resolveRefs(schema.anyOf[0], parameterSourceOption, components, schemaResolutionCache, stack,
+        seenRef);
     }
     if (schema.oneOf) {
-      return this.resolveRefs(schema.oneOf[0], parameterSourceOption, components, schemaResolutionCache, stack);
+      return this.resolveRefs(schema.oneOf[0], parameterSourceOption, components, schemaResolutionCache, stack,
+        seenRef);
     }
     if (schema.allOf) {
-      return this.resolveAllOf(schema.allOf, parameterSourceOption, components, schemaResolutionCache, stack);
+      return this.resolveAllOf(schema.allOf, parameterSourceOption, components, schemaResolutionCache, stack, seenRef);
     }
     if (schema.$ref) {
       let refKey = schema.$ref;
+
+      // if this reference is seen before, ignore and move on.
+      if (seenRef[refKey]) {
+        seenRef[refKey] = seenRef[refKey]++;
+        return { value: '<Cicular reference to ' + refKey + ' detected>' };
+      }
+      // add to seen array if not encountered before.
+      seenRef[refKey] = 1;
+
       // points to an existing location
       // .split will return [#, components, schemas, schemaName]
       splitRef = refKey.split('/');
@@ -165,13 +157,9 @@ module.exports = {
       // not using _.get here because that fails if there's a . in the property name (Pagination.Envelope, for example)
       resolvedSchema = this._getEscaped(components, splitRef.slice(1));
 
-      // we will ignore any circular references encountered at the next immediate level
-      if (resolvedSchema && resolvedSchema.hasOwnProperty('properties')) {
-        resolvedSchema.properties = this.findCircularReference(resolvedSchema.properties, schema.$ref);
-      }
       if (resolvedSchema) {
         let refResolvedSchema = this.resolveRefs(resolvedSchema, parameterSourceOption,
-          components, schemaResolutionCache, stack);
+          components, schemaResolutionCache, stack, seenRef);
         schemaResolutionCache[refKey] = refResolvedSchema;
         return refResolvedSchema;
       }
@@ -198,7 +186,7 @@ module.exports = {
             }
             /* eslint-enable */
             tempSchema.properties[prop] = this.resolveRefs(property,
-              parameterSourceOption, components, schemaResolutionCache, stack);
+              parameterSourceOption, components, schemaResolutionCache, stack, seenRef);
           }
         }
         return tempSchema;
@@ -217,7 +205,7 @@ module.exports = {
       // without this, schemas with circular references aren't faked correctly
       let tempSchema = _.omit(schema, 'items');
       tempSchema.items = this.resolveRefs(schema.items, parameterSourceOption,
-        components, schemaResolutionCache, stack);
+        components, schemaResolutionCache, stack, seenRef);
       return tempSchema;
     }
     else if (!schema.hasOwnProperty('default')) {

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -144,6 +144,16 @@ module.exports = {
       // splitRef.slice(1) will return ['components', 'schemas', 'PaginationEnvelope', 'properties', 'page']
       // not using _.get here because that fails if there's a . in the property name (Pagination.Envelope, for example)
       resolvedSchema = this._getEscaped(components, splitRef.slice(1));
+
+      // we will ignore any circular references encountered at the next immediate level
+      if (resolvedSchema && resolvedSchema.hasOwnProperty('properties')) {
+        for (prop in resolvedSchema.properties) {
+          if (resolvedSchema.properties[prop].hasOwnProperty('$ref') &&
+          resolvedSchema.properties[prop].$ref === schema.$ref) {
+            resolvedSchema.properties[prop] = { value: 'Circular Reference detected' };
+          }
+        }
+      }
       if (resolvedSchema) {
         let refResolvedSchema = this.resolveRefs(resolvedSchema, parameterSourceOption,
           components, schemaResolutionCache, stack);

--- a/test/data/valid_openapi/unique_items_schema.json
+++ b/test/data/valid_openapi/unique_items_schema.json
@@ -22,7 +22,7 @@
         "tags": [
           "Folder tree"
         ],
-        "summary": "List folder tree",
+        "summary": "folder tree",
         "description": "Returns a list of folders in a nested, tree structure.",
         "operationId": "listFolderTree",
         "parameters": [
@@ -87,7 +87,7 @@
         "tags": [
           "circular reference"
         ],
-        "summary": "circular reference",
+        "summary": "circular reference 2",
         "description": "circular reference",
         "operationId": "circularReference",
         "parameters": [],

--- a/test/data/valid_openapi/unique_items_schema.json
+++ b/test/data/valid_openapi/unique_items_schema.json
@@ -58,6 +58,29 @@
           }
         }
       }
+    },
+    "/new-path-with-many-circular-refs": {
+      "get": {
+        "tags": [
+          "circular reference"
+        ],
+        "summary": "circular reference",
+        "description": "circular reference",
+        "operationId": "circularReference",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Circular Reference",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/circularReferences"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "servers": [
@@ -72,6 +95,37 @@
   ],
   "components": {
     "schemas": {
+      "circularReferences": {
+        "type": "object",
+        "properties": {
+          "nextReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/circular"
+            }
+          }
+        },
+        "xml": {
+          "name": "circularReferences"
+        }
+      },
+      "circular": {
+        "type": "object",
+        "properties": {
+          "firstCircular": {
+            "$ref": "#/components/schemas/circular"
+          },
+          "nextCircular": {
+            "$ref": "#/components/schemas/circularReferences"
+          },
+          "anotherCircular": {
+            "$ref": "#/components/schemas/circularReferences"
+          }
+        },
+        "xml": {
+          "name": "circular"
+        }
+      },
       "FolderTree": {
         "type": "object",
         "properties": {

--- a/test/data/valid_openapi/unique_items_schema.json
+++ b/test/data/valid_openapi/unique_items_schema.json
@@ -81,6 +81,29 @@
           }
         }
       }
+    },
+    "/new-passth-with-many-circular-refs": {
+      "get": {
+        "tags": [
+          "circular reference"
+        ],
+        "summary": "circular reference",
+        "description": "circular reference",
+        "operationId": "circularReference",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Circular Reference",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/b"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "servers": [
@@ -144,7 +167,43 @@
             }
           }
         }
-      }
+      },
+      "b": {
+        "type": "object",
+        "properties": {
+          "b": {
+            "properties": {
+              "c": {
+                "$ref": "#/components/schemas/a"
+              }
+            }
+          },
+          "a": {
+            "$ref": "#/components/schemas/a"
+          }
+        },
+        "xml": {
+          "name": "circular"
+        }
+      },
+      "a": {
+				"required": [
+					"id",
+					"name"
+				],
+				"properties": {
+					"id": {
+						"type": "integer",
+						"format": "int64"
+					},
+					"name": {
+						"type": "string"
+					},
+					"tag": {
+						"type": "string"
+					}
+				}
+			}
     }
   }
 }

--- a/test/data/valid_openapi/unique_items_schema.json
+++ b/test/data/valid_openapi/unique_items_schema.json
@@ -1,0 +1,96 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "description": "Sample API",
+    "version": "v1",
+    "title": "Sample API",
+    "termsOfService": "http://www.example.com/termsOfService",
+    "contact": {
+      "name": "Sample",
+      "url": "http://sample.com/",
+      "email": "sample@sample.com"
+    }
+  },
+  "tags": [
+    {
+      "name": "Folder tree"
+    }
+  ],
+  "paths": {
+    "/folder-tree": {
+      "get": {
+        "tags": [
+          "Folder tree"
+        ],
+        "summary": "List folder tree",
+        "description": "Returns a list of folders in a nested, tree structure.",
+        "operationId": "listFolderTree",
+        "parameters": [
+          {
+            "name": "myParam",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "Auth token.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "token='{{token}}'"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FolderTree"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://{host}/sample/api",
+      "variables": {
+        "host": {
+          "default": "unknown"
+        }
+      }
+    }
+  ],
+  "components": {
+    "schemas": {
+      "FolderTree": {
+        "type": "object",
+        "properties": {
+          "foobar": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string"
+            }
+          },
+          "children": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "$ref": "#/components/schemas/FolderTree"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -60,7 +60,7 @@ describe('CONVERT FUNCTION TESTS ', function() {
     it('Should not get stuck while resolving circular references' +
     unique_items_schema, function(done) {
       Converter.convert({ type: 'file', data:
-      unique_items_schema }, { requestNameSource: 'url' }, (err, conversionResult) => {
+      unique_items_schema }, {}, (err, conversionResult) => {
         expect(err).to.be.null;
         expect(conversionResult.result).to.equal(true);
         expect(conversionResult.output.length).to.equal(1);

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -8,9 +8,10 @@ var expect = require('chai').expect,
 describe('CONVERT FUNCTION TESTS ', function() {
   // these two covers remaining part of util.js
   describe('The convert Function', function() {
-
+    this.timeout(5000);
     var testSpec = path.join(__dirname, VALID_OPENAPI_PATH + '/test.json'),
       testSpec1 = path.join(__dirname, VALID_OPENAPI_PATH + '/test1.json'),
+      unique_items_schema = path.join(__dirname, VALID_OPENAPI_PATH + '/unique_items_schema.json'),
       serverOverRidingSpec = path.join(__dirname, VALID_OPENAPI_PATH + '/server_overriding.json'),
       infoHavingContactOnlySpec = path.join(__dirname, VALID_OPENAPI_PATH + '/info_having_contact_only.json'),
       infoHavingDescriptionOnlySpec = path.join(__dirname, VALID_OPENAPI_PATH + '/info_having_description_only.json'),
@@ -43,7 +44,7 @@ describe('CONVERT FUNCTION TESTS ', function() {
       });
     });
     it('Should generate collection conforming to schema for and fail if not valid ' +
-      testSpec1, function(done) {
+    testSpec1, function(done) {
       Converter.convert({ type: 'file', data: testSpec1 }, { requestNameSource: 'url' }, (err, conversionResult) => {
         expect(err).to.be.null;
         expect(conversionResult.result).to.equal(true);
@@ -55,6 +56,22 @@ describe('CONVERT FUNCTION TESTS ', function() {
         done();
       });
     });
+
+    it('Should not get stuck for a circular reference' +
+    unique_items_schema, function(done) {
+      Converter.convert({ type: 'file', data:
+      unique_items_schema }, { requestNameSource: 'url' }, (err, conversionResult) => {
+        expect(err).to.be.null;
+        expect(conversionResult.result).to.equal(true);
+        expect(conversionResult.output.length).to.equal(1);
+        expect(conversionResult.output[0].type).to.equal('collection');
+        expect(conversionResult.output[0].data).to.have.property('info');
+        expect(conversionResult.output[0].data).to.have.property('item');
+
+        done();
+      });
+    });
+
     it('Should generate collection with collapsing unnecessary folders ' +
     multipleFoldersSpec, function(done) {
       var openapi = fs.readFileSync(multipleFoldersSpec, 'utf8');

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -8,7 +8,7 @@ var expect = require('chai').expect,
 describe('CONVERT FUNCTION TESTS ', function() {
   // these two covers remaining part of util.js
   describe('The convert Function', function() {
-    this.timeout(5000);
+
     var testSpec = path.join(__dirname, VALID_OPENAPI_PATH + '/test.json'),
       testSpec1 = path.join(__dirname, VALID_OPENAPI_PATH + '/test1.json'),
       unique_items_schema = path.join(__dirname, VALID_OPENAPI_PATH + '/unique_items_schema.json'),

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -57,7 +57,7 @@ describe('CONVERT FUNCTION TESTS ', function() {
       });
     });
 
-    it('Should not get stuck for a circular reference' +
+    it('Should not get stuck while resolving circular references' +
     unique_items_schema, function(done) {
       Converter.convert({ type: 'file', data:
       unique_items_schema }, { requestNameSource: 'url' }, (err, conversionResult) => {

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -72,7 +72,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
       done();
     });
 
-    it('should resolve circular structures', function(done) {
+    it('should not resolve circular references', function(done) {
       let schema = {
           '$ref': '#/components/schemas/a'
         },
@@ -98,10 +98,10 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         resolveTo = 'schema',
 
         result = SchemaUtils.safeSchemaFaker(schema, resolveTo, parameterSource, { components }),
-        tooManyLevelsString = result[0].c[0].c[0].c[0].c[0].c.value;
+        tooManyLevelsString = result[0].c.value;
 
       expect(result).to.not.equal(null);
-      expect(tooManyLevelsString).to.equal('<Error: Too many levels of nesting to fake this schema>');
+      expect(tooManyLevelsString).to.equal('<Cicular reference to #/components/schemas/a detected>');
       done();
     });
 

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -101,7 +101,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         tooManyLevelsString = result[0].c.value;
 
       expect(result).to.not.equal(null);
-      expect(tooManyLevelsString).to.equal('<Cicular reference to #/components/schemas/a detected>');
+      expect(tooManyLevelsString).to.equal('<Circular reference to #/components/schemas/a detected>');
       done();
     });
 


### PR DESCRIPTION
Ignore resolving circular references

Non-circular: 
```
b: 
  a: $ref - stack level 2
  a: $ref - stack level 2

```
Circular: 
```
a: stack level 1
   c: 
      a: $ref - stack level 3
```