### PR TITLE
TypeError: Cannot read property 'example' of null at Object.convertToPmBodyData

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -857,7 +857,7 @@ module.exports = {
       resolveTo = this.resolveToExampleOrSchema(requestType, options.requestParametersResolution,
         options.exampleParametersResolution);
 
-    if (bodyObj.example && (resolveTo === 'example' || !bodyObj.schema)) {
+    if (bodyObj && bodyObj.example && (resolveTo === 'example' || !bodyObj.schema)) {
       if (bodyObj.example.hasOwnProperty('$ref')) {
         bodyObj.example = this.getRefObject(bodyObj.example.$ref, components, options);
         if (this.getHeaderFamily(contentType) === HEADER_TYPE.JSON) {
@@ -877,11 +877,11 @@ module.exports = {
         bodyData = bodyData.value;
       }
     }
-    else if (!_.isEmpty(bodyObj.examples) && (resolveTo === 'example' || !bodyObj.schema)) {
+    else if (bodyObj && !_.isEmpty(bodyObj.examples) && (resolveTo === 'example' || !bodyObj.schema)) {
       // take one of the examples as the body and not all
       bodyData = this.getExampleData(bodyObj.examples, components, options);
     }
-    else if (bodyObj.schema) {
+    else if (bodyObj && bodyObj.schema) {
       if (bodyObj.schema.hasOwnProperty('$ref')) {
         bodyObj.schema = this.getRefObject(bodyObj.schema.$ref, components, options);
       }


### PR DESCRIPTION
Line 850 produces the following error:
```
C:\Users\anonymous\Downloads>openapi2postmanv2 -s api-docs.json -o postman.json
Input file:  C:\Users\anonymous\Downloads\api-docs.json
TypeError: Cannot read property 'example' of null
    at Object.convertToPmBodyData (C:\Users\rpolanco\AppData\Roaming\npm\node_modules\openapi-to-postmanv2\lib\schemaUtils.js:860:17)
    at Object.convertToPmResponseBody (C:\Users\rpolanco\AppData\Roaming\npm\node_modules\openapi-to-postmanv2\lib\schemaUtils.js:759:25)
    at Object.convertToPmResponse (C:\Users\rpolanco\AppData\Roaming\npm\node_modules\openapi-to-postmanv2\lib\schemaUtils.js:1416:32)
    at C:\Users\rpolanco\AppData\Roaming\npm\node_modules\openapi-to-postmanv2\lib\schemaUtils.js:1720:34
    at C:\Users\rpolanco\AppData\Roaming\npm\node_modules\openapi-to-postmanv2\node_modules\lodash\lodash.js:4905:15
    at baseForOwn (C:\Users\rpolanco\AppData\Roaming\npm\node_modules\openapi-to-postmanv2\node_modules\lodash\lodash.js:2990:24)
    at Function.forOwn (C:\Users\rpolanco\AppData\Roaming\npm\node_modules\openapi-to-postmanv2\node_modules\lodash\lodash.js:13014:24)
    at Object.convertRequestToItem (C:\Users\rpolanco\AppData\Roaming\npm\node_modules\openapi-to-postmanv2\lib\schemaUtils.js:1688:9)
    at Object.convertChildToItemGroup (C:\Users\rpolanco\AppData\Roaming\npm\node_modules\openapi-to-postmanv2\lib\schemaUtils.js:651:19)
    at Object.convertChildToItemGroup (C:\Users\rpolanco\AppData\Roaming\npm\node_modules\openapi-to-postmanv2\lib\schemaUtils.js:640:18)
```