### PR TITLE
Store only resolved schema in cache.

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -110,11 +110,13 @@ module.exports = {
    * @returns {*} schema satisfying JSON-schema-faker.
    */
   resolveRefs: function (schema, parameterSourceOption, components, schemaResolutionCache, stack = 0) {
+    const ERR_TOO_MANY_LEVELS = '<Error: Too many levels of nesting to fake this schema>';
+
     var resolvedSchema, prop, splitRef;
     stack++;
     schemaResolutionCache = schemaResolutionCache || {};
     if (stack > 20) {
-      return { value: '<Error: Too many levels of nesting to fake this schema>' };
+      return { value: ERR_TOO_MANY_LEVELS };
     }
 
     if (!schema) {
@@ -151,7 +153,9 @@ module.exports = {
       if (resolvedSchema) {
         let refResolvedSchema = this.resolveRefs(resolvedSchema, parameterSourceOption,
           components, schemaResolutionCache, stack);
-        schemaResolutionCache[refKey] = refResolvedSchema;
+        if (refResolvedSchema.value !== ERR_TOO_MANY_LEVELS) {
+          schemaResolutionCache[refKey] = refResolvedSchema;
+        }
         return refResolvedSchema;
       }
       return { value: 'reference ' + schema.$ref + ' not found in the OpenAPI spec' };

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -188,7 +188,7 @@ module.exports = {
         let refResolvedSchema = this.resolveRefs(resolvedSchema, parameterSourceOption,
           components, schemaResolutionCache, resolveFor, stack, _.cloneDeep(seenRef));
 
-        if (refResolvedSchema.value !== ERR_TOO_MANY_LEVELS) {
+        if (refResolvedSchema && refResolvedSchema.value !== ERR_TOO_MANY_LEVELS) {
           schemaResolutionCache[refKey] = refResolvedSchema;
         }
 

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -113,10 +113,12 @@ module.exports = {
    */
 
   resolveRefs: function (schema, parameterSourceOption, components, schemaResolutionCache, stack = 0, seenRef = {}) {
+    var resolvedSchema, prop, splitRef,
+      ERR_TOO_MANY_LEVELS = '<Error: Too many levels of nesting to fake this schema>';
 
-    var resolvedSchema, prop, splitRef;
     stack++;
     schemaResolutionCache = schemaResolutionCache || {};
+
     if (stack > 20) {
       return { value: ERR_TOO_MANY_LEVELS };
     }

--- a/test/data/valid_openapi/too-many-refs.json
+++ b/test/data/valid_openapi/too-many-refs.json
@@ -1,0 +1,180 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "description": "Too Many Refs",
+    "version": "v1",
+    "title": "Too Many Refs",
+    "termsOfService": "http://www.example.com/termsOfService",
+    "contact": {
+      "name": "Sample",
+      "url": "http://sample.com/",
+      "email": "sample@sample.com"
+    }
+  },
+  "tags": [
+    {
+      "name": "Folder tree"
+    }
+  ],
+  "paths": {
+    "/path": {
+      "get": {
+        "tags": [
+          "Some path"
+        ],
+        "summary": "Too many refs path",
+        "description": "Returns a list of folders in a nested, tree structure.",
+        "operationId": "listFolderTree",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/b"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/path2": {
+      "get": {
+        "tags": [
+          "Some path"
+        ],
+        "summary": "Too many refs path",
+        "description": "Returns a list of folders in a nested, tree structure.",
+        "operationId": "listFolderTree",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/k"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://{host}/sample/api",
+      "variables": {
+        "host": {
+          "default": "unknown"
+        }
+      }
+    }
+  ],
+  "components": {
+    "schemas": {
+      "b": {
+        "type": "object",
+        "properties": {
+          "c": {
+            "$ref": "#/components/schemas/c"
+          }
+        }
+      },
+      "c": {
+        "type": "object",
+        "properties": {
+          "d": {
+            "$ref": "#/components/schemas/d"
+          }
+        }
+      },
+
+      "d": {
+        "type": "object",
+        "properties": {
+          "e": {
+            "$ref": "#/components/schemas/e"
+          }
+        }
+      },
+      "e": {
+        "type": "object",
+        "properties": {
+          "f": {
+            "$ref": "#/components/schemas/f"
+          }
+        }
+      },
+      "f": {
+        "type": "object",
+        "properties": {
+          "g": {
+            "$ref": "#/components/schemas/g"
+          }
+        }
+      },
+      "g": {
+        "type": "object",
+        "properties": {
+          "h": {
+            "$ref": "#/components/schemas/h"
+          }
+        }
+      },
+      "h": {
+        "type": "object",
+        "properties": {
+          "i": {
+            "$ref": "#/components/schemas/i"
+          }
+        }
+      },
+      "i": {
+        "type": "object",
+        "properties": {
+          "j": {
+            "$ref": "#/components/schemas/j"
+          }
+        }
+      },
+      "j": {
+        "type": "object",
+        "properties": {
+          "k": {
+            "$ref": "#/components/schemas/k"
+          }
+        }
+      },
+      "k": {
+        "type": "object",
+        "properties": {
+          "l": {
+            "$ref": "#/components/schemas/a"
+          }
+        }
+      },
+      "a": {
+				"required": [
+					"id",
+					"name"
+				],
+				"properties": {
+					"id": {
+						"type": "integer",
+						"format": "int64"
+					},
+					"name": {
+						"type": "string"
+					},
+					"tag": {
+						"type": "string"
+					}
+				}
+			}
+    }
+  }
+}

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -31,7 +31,26 @@ describe('CONVERT FUNCTION TESTS ', function() {
       multipleRefs = path.join(__dirname, VALID_OPENAPI_PATH, '/multiple_refs.json'),
       issue150 = path.join(__dirname, VALID_OPENAPI_PATH + '/issue#150.yml'),
       issue173 = path.join(__dirname, VALID_OPENAPI_PATH, '/issue#173.yml'),
-      issue152 = path.join(__dirname, VALID_OPENAPI_PATH, '/path-refs-error.yaml');
+      issue152 = path.join(__dirname, VALID_OPENAPI_PATH, '/path-refs-error.yaml'),
+      tooManyRefs = path.join(__dirname, VALID_OPENAPI_PATH, '/too-many-refs.json');
+
+    it('Should generate collection conforming to schema for and fail if not valid ' +
+    tooManyRefs, function(done) {
+      var openapi = fs.readFileSync(tooManyRefs, 'utf8'),
+        body;
+      Converter.convert({ type: 'string', data: openapi }, { schemaFaker: true }, (err, conversionResult) => {
+
+        expect(err).to.be.null;
+        expect(conversionResult.result).to.equal(true);
+        expect(conversionResult.output.length).to.equal(1);
+        expect(conversionResult.output[0].type).to.equal('collection');
+        expect(conversionResult.output[0].data).to.have.property('info');
+        expect(conversionResult.output[0].data).to.have.property('item');
+        body = conversionResult.output[0].data.item[1].response[0].body;
+        expect(body).to.not.contain('<Error: Too many levels of nesting to fake this schema>');
+        done();
+      });
+    });
 
     it('Should generate collection conforming to schema for and fail if not valid ' +
     issue152, function(done) {
@@ -39,7 +58,6 @@ describe('CONVERT FUNCTION TESTS ', function() {
         refNotFound = 'reference #/paths/~1pets/get/responses/200/content/application~1json/schema/properties/newprop' +
         ' not found in the OpenAPI spec';
       Converter.convert({ type: 'string', data: openapi }, { schemaFaker: true }, (err, conversionResult) => {
-        fs.writeFileSync('pathred2.json', JSON.stringify(conversionResult.output[0].data, null, 2));
         expect(err).to.be.null;
         expect(conversionResult.result).to.equal(true);
         expect(conversionResult.output.length).to.equal(1);


### PR DESCRIPTION
Schema resolution cache should not contain '<Error: Too many levels of nesting to fake this schema>' as the value for any reference. 