### PR TITLE
Fixed unable to validate schema with type: array

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -20,6 +20,11 @@ const _ = require('lodash'),
   PARAMETER_SOURCE = {
     REQUEST: 'REQUEST',
     RESPONSE: 'RESPONSE'
+  },
+  // Specifies type of Resolving of Refs that can be performed
+  RESOLVE_REFS_FOR = {
+    VALIDATION: 'VALIDATION',
+    CONVERSION: 'CONVERSION'
   };
 
 module.exports = {
@@ -54,23 +59,28 @@ module.exports = {
    * @param {string} parameterSourceOption tells that the schema object is of request or response
    * @param {*} components components in openapi spec.
    * @param {object} schemaResolutionCache stores already resolved references
+   * @param {*} resolveFor - resolve refs for validation/conversion (value to be one of VALIDATION/CONVERSION)
    * @param {*} stack counter which keeps a tab on nested schemas
    * @param {*} seenRef References that are repeated. Used to identify circular references.
    * @returns {*} schema - schema that adheres to all individual schemas in schemaArr
    */
-  resolveAllOf: function (schemaArr, parameterSourceOption, components, schemaResolutionCache, stack = 0, seenRef) {
+  resolveAllOf: function (schemaArr, parameterSourceOption, components, schemaResolutionCache,
+    resolveFor = RESOLVE_REFS_FOR.CONVERSION, stack = 0, seenRef) {
+
     if (!(schemaArr instanceof Array)) {
       return null;
     }
 
     if (schemaArr.length === 1) {
       // for just one entry in allOf, don't need to enforce type: object restriction
-      return this.resolveRefs(schemaArr[0], parameterSourceOption, components, schemaResolutionCache, stack, seenRef);
+      return this.resolveRefs(schemaArr[0], parameterSourceOption, components, schemaResolutionCache, resolveFor,
+        stack, seenRef);
     }
 
     // generate one object for each schema
     let indivObjects = schemaArr.map((schema) => {
-        return this.resolveRefs(schema, parameterSourceOption, components, schemaResolutionCache, stack, seenRef);
+        return this.resolveRefs(schema, parameterSourceOption, components, schemaResolutionCache, resolveFor,
+          stack, seenRef);
       }).filter((schema) => {
         return schema.type === 'object';
       }),
@@ -107,11 +117,14 @@ module.exports = {
    * @param {string} parameterSourceOption tells that the schema object is of request or response
    * @param {*} components components in openapi spec.
    * @param {object} schemaResolutionCache stores already resolved references
+   * @param {*} resolveFor - resolve refs for validation/conversion (value to be one of VALIDATION/CONVERSION)
    * @param {*} stack counter which keeps a tab on nested schemas
    * @param {*} seenRef - References that are repeated. Used to identify circular references.
    * @returns {*} schema satisfying JSON-schema-faker.
    */
-  resolveRefs: function (schema, parameterSourceOption, components, schemaResolutionCache, stack = 0, seenRef = {}) {
+  resolveRefs: function (schema, parameterSourceOption, components, schemaResolutionCache,
+    resolveFor = RESOLVE_REFS_FOR.CONVERSION, stack = 0, seenRef = {}) {
+
     var resolvedSchema, prop, splitRef;
     stack++;
     schemaResolutionCache = schemaResolutionCache || {};
@@ -124,16 +137,16 @@ module.exports = {
     }
 
     if (schema.anyOf) {
-      return this.resolveRefs(schema.anyOf[0], parameterSourceOption, components, schemaResolutionCache, stack,
-        _.cloneDeep(seenRef));
+      return this.resolveRefs(schema.anyOf[0], parameterSourceOption, components, schemaResolutionCache, resolveFor,
+        stack, _.cloneDeep(seenRef));
     }
     if (schema.oneOf) {
-      return this.resolveRefs(schema.oneOf[0], parameterSourceOption, components, schemaResolutionCache, stack,
-        _.cloneDeep(seenRef));
+      return this.resolveRefs(schema.oneOf[0], parameterSourceOption, components, schemaResolutionCache, resolveFor,
+        stack, _.cloneDeep(seenRef));
     }
     if (schema.allOf) {
-      return this.resolveAllOf(schema.allOf, parameterSourceOption, components, schemaResolutionCache, stack,
-        _.cloneDeep(seenRef));
+      return this.resolveAllOf(schema.allOf, parameterSourceOption, components, schemaResolutionCache, resolveFor,
+        stack, _.cloneDeep(seenRef));
     }
     if (schema.$ref && _.isFunction(schema.$ref.split)) {
       let refKey = schema.$ref;
@@ -164,7 +177,7 @@ module.exports = {
 
       if (resolvedSchema) {
         let refResolvedSchema = this.resolveRefs(resolvedSchema, parameterSourceOption,
-          components, schemaResolutionCache, stack, _.cloneDeep(seenRef));
+          components, schemaResolutionCache, resolveFor, stack, _.cloneDeep(seenRef));
         schemaResolutionCache[refKey] = refResolvedSchema;
         return refResolvedSchema;
       }
@@ -196,7 +209,7 @@ module.exports = {
             }
             /* eslint-enable */
             tempSchema.properties[prop] = this.resolveRefs(property,
-              parameterSourceOption, components, schemaResolutionCache, stack, _.cloneDeep(seenRef));
+              parameterSourceOption, components, schemaResolutionCache, resolveFor, stack, _.cloneDeep(seenRef));
           }
         }
         return tempSchema;
@@ -207,15 +220,18 @@ module.exports = {
     }
     else if (schema.type === 'array' && schema.items) {
 
-      // This nonsense is needed because the schemaFaker doesn't respect options.maxItems/minItems
-      schema.maxItems = 2;
-      schema.minItems = 2;
+      // Set minItems and maxItems property as 2 for CONVERSION
+      if (resolveFor === RESOLVE_REFS_FOR.CONVERSION) {
+        // This is needed because the schemaFaker doesn't respect options.maxItems/minItems
+        schema.maxItems = 2;
+        schema.minItems = 2;
+      }
       // have to create a shallow clone of schema object,
       // so that the original schema.items object will not change
       // without this, schemas with circular references aren't faked correctly
       let tempSchema = _.omit(schema, 'items');
       tempSchema.items = this.resolveRefs(schema.items, parameterSourceOption,
-        components, schemaResolutionCache, stack, _.cloneDeep(seenRef));
+        components, schemaResolutionCache, resolveFor, stack, _.cloneDeep(seenRef));
       return tempSchema;
     }
     else if (!schema.hasOwnProperty('default')) {

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -20,11 +20,6 @@ const _ = require('lodash'),
   PARAMETER_SOURCE = {
     REQUEST: 'REQUEST',
     RESPONSE: 'RESPONSE'
-  },
-  // Specifies type of Resolving of Refs that can be performed
-  RESOLVE_REFS_FOR = {
-    VALIDATION: 'VALIDATION',
-    CONVERSION: 'CONVERSION'
   };
 
 module.exports = {
@@ -65,7 +60,7 @@ module.exports = {
    * @returns {*} schema - schema that adheres to all individual schemas in schemaArr
    */
   resolveAllOf: function (schemaArr, parameterSourceOption, components, schemaResolutionCache,
-    resolveFor = RESOLVE_REFS_FOR.CONVERSION, stack = 0, seenRef) {
+    resolveFor = 'CONVERSION', stack = 0, seenRef) {
 
     if (!(schemaArr instanceof Array)) {
       return null;
@@ -123,7 +118,7 @@ module.exports = {
    * @returns {*} schema satisfying JSON-schema-faker.
    */
   resolveRefs: function (schema, parameterSourceOption, components, schemaResolutionCache,
-    resolveFor = RESOLVE_REFS_FOR.CONVERSION, stack = 0, seenRef = {}) {
+    resolveFor = 'CONVERSION', stack = 0, seenRef = {}) {
 
     var resolvedSchema, prop, splitRef;
     stack++;
@@ -220,8 +215,9 @@ module.exports = {
     }
     else if (schema.type === 'array' && schema.items) {
 
-      // Set minItems and maxItems property as 2 for CONVERSION
-      if (resolveFor === RESOLVE_REFS_FOR.CONVERSION) {
+      // For VALIDATION - keep minItems and maxItems properties defined by user in schema as is
+      // FOR CONVERSION - need to set both properties to 2 for schema faking
+      if (resolveFor === 'CONVERSION') {
         // This is needed because the schemaFaker doesn't respect options.maxItems/minItems
         schema.maxItems = 2;
         schema.minItems = 2;

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -64,8 +64,8 @@ const async = require('async'),
     RESPONSE_HEADER: 'response header',
     RESPONSE_BODY: 'response body'
   },
-  // Specifies types of Resolving of Refs that can be performed
-  RESOLVE_REFS_FOR = {
+  // Specifies types of processing Refs
+  PROCESSING_TYPE = {
     VALIDATION: 'VALIDATION',
     CONVERSION: 'CONVERSION'
   },
@@ -127,7 +127,7 @@ function safeSchemaFaker(oldSchema, resolveTo, parameterSourceOption, components
     schemaFakerCache = _.get(schemaCache, 'schemaFakerCache', {});
 
   resolvedSchema = deref.resolveRefs(oldSchema, parameterSourceOption, components, schemaResolutionCache,
-    RESOLVE_REFS_FOR.CONVERSION);
+    PROCESSING_TYPE.CONVERSION);
   key = JSON.stringify(resolvedSchema);
 
   if (resolveTo === 'schema') {
@@ -2145,7 +2145,7 @@ module.exports = {
           pathVar.value,
           schemaPathVar.pathPrefix + '[?(@.name==\'' + schemaPathVar.name + '\')]',
           deref.resolveRefs(schemaPathVar.schema, 'request', components, schemaResolutionCache,
-            RESOLVE_REFS_FOR.VALIDATION),
+            PROCESSING_TYPE.VALIDATION),
           components, options, cb);
       }, 0);
     }, (err, res) => {
@@ -2247,7 +2247,7 @@ module.exports = {
           pQuery.value,
           schemaParam.pathPrefix + '[?(@.name==\'' + schemaParam.name + '\')]',
           deref.resolveRefs(schemaParam.schema, 'request', components, schemaResolutionCache,
-            RESOLVE_REFS_FOR.VALIDATION),
+            PROCESSING_TYPE.VALIDATION),
           components, options,
           cb
         );
@@ -2309,7 +2309,7 @@ module.exports = {
           pHeader.value,
           schemaHeader.pathPrefix + '[?(@.name==\'' + schemaHeader.name + '\')]',
           deref.resolveRefs(schemaHeader.schema, 'request', components, schemaResolutionCache,
-            RESOLVE_REFS_FOR.VALIDATION),
+            PROCESSING_TYPE.VALIDATION),
           components, options,
           cb
         );
@@ -2379,7 +2379,7 @@ module.exports = {
           pHeader.value,
           schemaPathPrefix + '.headers[' + pHeader.key + ']',
           deref.resolveRefs(schemaHeader.schema, 'response', components, schemaResolutionCache,
-            RESOLVE_REFS_FOR.VALIDATION),
+            PROCESSING_TYPE.VALIDATION),
           components,
           options,
           cb
@@ -2428,7 +2428,7 @@ module.exports = {
       try {
         ajv = new Ajv({ unknownFormats: ['int32', 'int64'], allErrors: true });
         validate = ajv.compile(deref.resolveRefs(jsonSchemaBody, 'request', components, schemaResolutionCache,
-          RESOLVE_REFS_FOR.VALIDATION));
+          PROCESSING_TYPE.VALIDATION));
         res = validate(JSON.parse(requestBody.raw));
       }
       catch (e) {
@@ -2492,7 +2492,7 @@ module.exports = {
         body,
         schemaPathPrefix + '.content[application/json].schema',
         deref.resolveRefs(schemaContent, 'response', components, schemaResolutionCache,
-          RESOLVE_REFS_FOR.VALIDATION),
+          PROCESSING_TYPE.VALIDATION),
         components,
         _.extend({}, options, { shortValidationErrors: true }),
         callback

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -64,6 +64,11 @@ const async = require('async'),
     RESPONSE_HEADER: 'response header',
     RESPONSE_BODY: 'response body'
   },
+  // Specifies types of Resolving of Refs that can be performed
+  RESOLVE_REFS_FOR = {
+    VALIDATION: 'VALIDATION',
+    CONVERSION: 'CONVERSION'
+  },
 
   // These are the methods supported in the PathItem schema
   // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#pathItemObject
@@ -121,7 +126,8 @@ function safeSchemaFaker(oldSchema, resolveTo, parameterSourceOption, components
     schemaResolutionCache = _.get(schemaCache, 'schemaResolutionCache', {}),
     schemaFakerCache = _.get(schemaCache, 'schemaFakerCache', {});
 
-  resolvedSchema = deref.resolveRefs(oldSchema, parameterSourceOption, components, schemaResolutionCache);
+  resolvedSchema = deref.resolveRefs(oldSchema, parameterSourceOption, components, schemaResolutionCache,
+    RESOLVE_REFS_FOR.CONVERSION);
   key = JSON.stringify(resolvedSchema);
 
   if (resolveTo === 'schema') {
@@ -2138,7 +2144,8 @@ module.exports = {
           pathVar.key,
           pathVar.value,
           schemaPathVar.pathPrefix + '[?(@.name==\'' + schemaPathVar.name + '\')]',
-          deref.resolveRefs(schemaPathVar.schema, 'request', components, schemaResolutionCache),
+          deref.resolveRefs(schemaPathVar.schema, 'request', components, schemaResolutionCache,
+            RESOLVE_REFS_FOR.VALIDATION),
           components, options, cb);
       }, 0);
     }, (err, res) => {
@@ -2239,7 +2246,8 @@ module.exports = {
           pQuery.key,
           pQuery.value,
           schemaParam.pathPrefix + '[?(@.name==\'' + schemaParam.name + '\')]',
-          deref.resolveRefs(schemaParam.schema, 'request', components, schemaResolutionCache),
+          deref.resolveRefs(schemaParam.schema, 'request', components, schemaResolutionCache,
+            RESOLVE_REFS_FOR.VALIDATION),
           components, options,
           cb
         );
@@ -2300,7 +2308,8 @@ module.exports = {
           pHeader.key,
           pHeader.value,
           schemaHeader.pathPrefix + '[?(@.name==\'' + schemaHeader.name + '\')]',
-          deref.resolveRefs(schemaHeader.schema, 'request', components, schemaResolutionCache),
+          deref.resolveRefs(schemaHeader.schema, 'request', components, schemaResolutionCache,
+            RESOLVE_REFS_FOR.VALIDATION),
           components, options,
           cb
         );
@@ -2369,7 +2378,8 @@ module.exports = {
           pHeader.key,
           pHeader.value,
           schemaPathPrefix + '.headers[' + pHeader.key + ']',
-          deref.resolveRefs(schemaHeader.schema, 'response', components, schemaResolutionCache),
+          deref.resolveRefs(schemaHeader.schema, 'response', components, schemaResolutionCache,
+            RESOLVE_REFS_FOR.VALIDATION),
           components,
           options,
           cb
@@ -2417,7 +2427,8 @@ module.exports = {
 
       try {
         ajv = new Ajv({ unknownFormats: ['int32', 'int64'], allErrors: true });
-        validate = ajv.compile(deref.resolveRefs(jsonSchemaBody, 'request', components, schemaResolutionCache));
+        validate = ajv.compile(deref.resolveRefs(jsonSchemaBody, 'request', components, schemaResolutionCache,
+          RESOLVE_REFS_FOR.VALIDATION));
         res = validate(JSON.parse(requestBody.raw));
       }
       catch (e) {
@@ -2480,7 +2491,8 @@ module.exports = {
         null, // no param name for the request body
         body,
         schemaPathPrefix + '.content[application/json].schema',
-        deref.resolveRefs(schemaContent, 'response', components, schemaResolutionCache),
+        deref.resolveRefs(schemaContent, 'response', components, schemaResolutionCache,
+          RESOLVE_REFS_FOR.VALIDATION),
         components,
         _.extend({}, options, { shortValidationErrors: true }),
         callback

--- a/test/unit/deref.test.js
+++ b/test/unit/deref.test.js
@@ -24,6 +24,9 @@ describe('DEREF FUNCTION TESTS ', function() {
           }
         }]
       },
+      schemaWithTypeArray = {
+        $ref: '#/components/schemas/schemaTypeArray'
+      },
       componentsAndPaths = {
         components: {
           schemas: {
@@ -69,6 +72,14 @@ describe('DEREF FUNCTION TESTS ', function() {
                   format: 'email'
                 }
               }
+            },
+            schemaTypeArray: {
+              type: 'array',
+              items: {
+                type: 'string'
+              },
+              minItems: 5,
+              maxItems: 55
             }
           }
         }
@@ -77,7 +88,9 @@ describe('DEREF FUNCTION TESTS ', function() {
       output = deref.resolveRefs(schema, parameterSource, componentsAndPaths),
       output_withdot = deref.resolveRefs(schemaWithDotInKey, parameterSource, componentsAndPaths),
       output_customFormat = deref.resolveRefs(schemaWithCustomFormat, parameterSource, componentsAndPaths),
-      output_withAllOf = deref.resolveRefs(schemaWithAllOf, parameterSource, componentsAndPaths);
+      output_withAllOf = deref.resolveRefs(schemaWithAllOf, parameterSource, componentsAndPaths),
+      output_validationTypeArray = deref.resolveRefs(schemaWithTypeArray, parameterSource, componentsAndPaths,
+        {}, 'VALIDATION');
 
 
     expect(output).to.deep.include({ type: 'object',
@@ -98,6 +111,17 @@ describe('DEREF FUNCTION TESTS ', function() {
         id: { default: '<long>', type: 'integer' },
         test_prop: { default: '<string>', type: 'string' }
       }
+    });
+
+    // deref.resolveRef() should not change minItems and maxItems for VALIDATION
+    expect(output_validationTypeArray).to.deep.include({
+      type: 'array',
+      items: {
+        type: 'string',
+        default: '<string>'
+      },
+      minItems: 5,
+      maxItems: 55
     });
 
     done();


### PR DESCRIPTION
Issue : https://github.com/postmanlabs/postman-app-support/issues/8098

Bug was happening due to always overriding `minItems` and `maxItems` properties to 2 for type: array in `deref.resolveRefs()`.

Added support for Resolving refs for CONVERSION/VALIDATION in `deref.resolveRefs()` function.