### PR TITLE
Fixed URIError for invalid Uri in transaction.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1842,11 +1842,23 @@ module.exports = {
     // first step - get array of requests from schema
     let parsedUrl = require('url').parse(url),
       retVal = [],
-      pathToMatch = decodeURI(parsedUrl.pathname),
+      pathToMatch,
       matchedPath,
       matchedPathJsonPath,
       schemaPathItems = schema.paths,
       filteredPathItemsArray = [];
+
+    // Return no matches for invalid url (if unable to decode parsed url)
+    try {
+      pathToMatch = decodeURI(parsedUrl.pathname);
+    }
+    catch (e) {
+      console.warn(
+        'Error decoding request URI endpoint. URI: ', url,
+        'Error', e
+      );
+      return retVal;
+    }
 
     // if pathToMatch starts with '/', we assume it's the correct path
     // if not, we assume the segment till the first '/' is the host


### PR DESCRIPTION
Due to invalid escape character present in transaction (collection to validated against schema), `decodeURI()` was leading to URIError and breaking.

See more at: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Malformed_URI