### PR TITLE
Path level server object with variables is not handled correctly

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1638,6 +1638,7 @@ module.exports = {
           serverObj = operationItem.servers[0];
           baseUrl = serverObj.url.replace(/{/g, ':').replace(/}/g, '');
           pathVariables = serverObj.variables;
+          baseUrl += (reqUrl ? reqUrl : '');
         }
         else {
           displayUrl = '{{' + operationItem.path + 'Url}}' + reqUrl;

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1522,7 +1522,7 @@ module.exports = {
     return path.match(/(\{\{[^\/\{\}]+\}\})/g);
   },
 
-  /** Separates outs collection and path variables from the reqUrl
+  /** Separates out collection and path variables from the reqUrl
    *
    * @param {string} reqUrl Request Url
    * @param {Array} pathVars Path variables
@@ -1634,16 +1634,11 @@ module.exports = {
     else {
       // accounting for the overriding of the root level servers object if present at the path level
       if (Array.isArray(globalServers) && globalServers.length) {
-        if (operationItem.servers[0].hasOwnProperty('variables')) {
-          serverObj = operationItem.servers[0];
-          baseUrl = serverObj.url.replace(/{/g, ':').replace(/}/g, '');
-          pathVariables = serverObj.variables;
-          baseUrl += (reqUrl ? reqUrl : '');
-        }
-        else {
-          displayUrl = '{{' + operationItem.path + 'Url}}' + reqUrl;
-        }
+        // All the global servers present at the path level are taken care of in generateTrieFromPaths
+        // Just adding the same structure of the url as the display URL.
+        displayUrl = '{{' + operationItem.path + 'Url}}' + reqUrl;
       }
+      // In case there are no server available use the baseUrl
       else {
         baseUrl += reqUrl;
         if (pathVariables) {

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1558,7 +1558,7 @@ module.exports = {
       });
     }
 
-    return { reqUrl, pathVars, collectionVars };
+    return { url: reqUrl, pathVars, collectionVars };
   },
 
   /**
@@ -1605,7 +1605,7 @@ module.exports = {
     sanitizeResult = this.sanitizeUrlPathParams(reqUrl, reqParams.path);
 
     // Updated reqUrl
-    reqUrl = sanitizeResult.reqUrl;
+    reqUrl = sanitizeResult.url;
 
     // Updated reqParams.path
     reqParams.path = sanitizeResult.pathVars;
@@ -1625,11 +1625,50 @@ module.exports = {
 
     if (Array.isArray(localServers) && localServers.length) {
       serverObj = operationItem.properties.servers[0];
-      baseUrl = serverObj.url.replace(/{/g, ':').replace(/}/g, '');
-      baseUrl += reqUrl;
+
+      // convert all {anything} to {{anything}}
+      baseUrl = this.fixPathVariablesInUrl(serverObj.url);
+
+      // add serverObj variables to pathVarArray
       if (serverObj.variables) {
-        pathVarArray = this.convertPathVariables('method', [], serverObj.variables, components, options, schemaCache);
+        _.forOwn(serverObj.variables, (value, key) => {
+          pathVarArray.push({
+            name: key,
+            value: value.default || '',
+            description: this.getParameterDescription(value)
+          });
+        });
+
+        // use pathVarAray to sanitize url for path params and collection variables.
+        sanitizeResult = this.sanitizeUrlPathParams(baseUrl, pathVarArray);
+
+        // update the base url with update url
+        baseUrl = sanitizeResult.url;
+
+        // Add new collection variables to the variableStore
+        sanitizeResult.collectionVars.forEach((element) => {
+          if (!variableStore[element.name]) {
+            variableStore[element.name] = {
+              id: element.name,
+              value: element.value || '',
+              description: element.description,
+              type: 'collection'
+            };
+          }
+        });
+
+        // remove all the collection variables from serverObj.variables
+        serverObj.pathVariables = {};
+        sanitizeResult.pathVars.forEach((element) => {
+          serverObj.pathVariables[element.name] = serverObj.variables[element.name];
+        });
+
+        // use this new filterd serverObj.pathVariables
+        // to generate pm path variables.
+        pathVarArray = this.convertPathVariables('method', [],
+          serverObj.pathVariables, components, options, schemaCache);
       }
+      baseUrl += reqUrl;
     }
     else {
       // accounting for the overriding of the root level servers object if present at the path level
@@ -2654,4 +2693,3 @@ module.exports = {
     };
   }
 };
-

--- a/test/data/valid_openapi/issue#160.json
+++ b/test/data/valid_openapi/issue#160.json
@@ -1,0 +1,194 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "#160",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "paths": {
+    "/pets": {
+     "servers": [
+        {
+          "url": "http://petstore.swagger.io:{port}/{basePath}",
+         "variables": {
+            "port": {
+              "enum": [
+                "8443",
+                "443"
+              ],
+              "default": "8443"
+            },
+            "basePath": {
+              "default": "v2"
+            }
+         }
+        }
+     ],
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paged array of pets",
+            "headers": {
+              "x-next": {
+                "description": "A link to the next page of responses",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pets"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      },
+      "Pets": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Pet"
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/data/valid_openapi/issue#160.json
+++ b/test/data/valid_openapi/issue#160.json
@@ -102,48 +102,6 @@
           }
         }
       }
-    },
-    "/pets/{petId}": {
-      "get": {
-        "summary": "Info for a specific pet",
-        "operationId": "showPetById",
-        "tags": [
-          "pets"
-        ],
-        "parameters": [
-          {
-            "name": "petId",
-            "in": "path",
-            "required": true,
-            "description": "The id of the pet to retrieve",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Expected response to a valid request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Pet"
-                }
-              }
-            }
-          },
-          "default": {
-            "description": "unexpected error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        }
-      }
     }
   },
   "components": {

--- a/test/data/valid_openapi/server_overriding.json
+++ b/test/data/valid_openapi/server_overriding.json
@@ -22,7 +22,19 @@
           "summary": "Should use the other domain",
           "servers": [
             {
-              "url": "https://other-api.example.com"
+              "url": "http://petstore.swagger.io:{port}/{basePath}",
+             "variables": {
+                "port": {
+                  "enum": [
+                    "8443",
+                    "443"
+                  ],
+                  "default": "8443"
+                },
+                "basePath": {
+                  "default": "v2"
+                }
+             }
             }
           ]
         }

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -12,6 +12,7 @@ describe('CONVERT FUNCTION TESTS ', function() {
     var testSpec = path.join(__dirname, VALID_OPENAPI_PATH + '/test.json'),
       testSpec1 = path.join(__dirname, VALID_OPENAPI_PATH + '/test1.json'),
       issue133 = path.join(__dirname, VALID_OPENAPI_PATH + '/issue#133.json'),
+      issue160 = path.join(__dirname, VALID_OPENAPI_PATH, '/issue#160.json'),
       unique_items_schema = path.join(__dirname, VALID_OPENAPI_PATH + '/unique_items_schema.json'),
       serverOverRidingSpec = path.join(__dirname, VALID_OPENAPI_PATH + '/server_overriding.json'),
       infoHavingContactOnlySpec = path.join(__dirname, VALID_OPENAPI_PATH + '/info_having_contact_only.json'),
@@ -75,6 +76,21 @@ describe('CONVERT FUNCTION TESTS ', function() {
         expect(conversionResult.output[0].data).to.have.property('info');
         expect(conversionResult.output[0].data).to.have.property('item');
 
+        done();
+      });
+    });
+
+    it('#GITHUB-160 should generate correct display url for path containing servers' +
+    issue160, function(done) {
+      var openapi = fs.readFileSync(issue160, 'utf8');
+      Converter.convert({ type: 'string', data: openapi }, {}, (err, conversionResult) => {
+        expect(err).to.be.null;
+        expect(conversionResult.result).to.equal(true);
+        expect(conversionResult.output.length).to.equal(1);
+        expect(conversionResult.output[0].type).to.equal('collection');
+        expect(conversionResult.output[0].data).to.have.property('info');
+        expect(conversionResult.output[0].data).to.have.property('item');
+        expect(conversionResult.output[0].data.item[0].item[0].request.url.host[0]).to.equal('{{petsUrl}}');
         done();
       });
     });

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -179,12 +179,13 @@ describe('CONVERT FUNCTION TESTS ', function() {
           let request = conversionResult.output[0].data.item[1].request,
             protocol = request.url.protocol,
             host = request.url.host.join('.'),
+            port = request.url.port,
             path = request.url.path.join('/'),
-            endPoint = protocol + '://' + host + '/' + path,
+            endPoint = protocol + '://' + host + ':' + port + '/' + path,
             host1 = conversionResult.output[0].data.variable[0].value,
             path1 = conversionResult.output[0].data.item[0].request.url.path.join('/'),
             endPoint1 = host1 + '/' + path1;
-          expect(endPoint).to.equal('https://other-api.example.com/secondary-domain/fails');
+          expect(endPoint).to.equal('http://petstore.swagger.io:{{port}}/:basePath/secondary-domain/fails');
           expect(endPoint1).to.equal('https://api.example.com/primary-domain/works');
           done();
         });

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -2070,8 +2070,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         resultObj = SchemaUtils.sanitizeUrlPathParams('/anotherpath/{{path}}/{{new-path-variable}}.{{onemore}}',
           pathParams);
 
-      expect(resultObj).to.have.property('reqUrl');
-      expect(resultObj.reqUrl).to.equal('/anotherpath/:path/{{new-path-variable}}.{{onemore}}');
+      expect(resultObj).to.have.property('url');
+      expect(resultObj.url).to.equal('/anotherpath/:path/{{new-path-variable}}.{{onemore}}');
       expect(resultObj).to.have.property('pathVars');
       expect(resultObj).to.have.property('collectionVars');
 


### PR DESCRIPTION
Multiple problems encountered in this issue. 

    serverObj.url.replace(/{/g, ':').replace(/}/g, ''); → this is an issue since the url could contain port as variable: http://petstore.swagger.io:{port}/{basePath} like so. which will result on http://petstore.swagger.io::port/:basePath which is an invalid path param in postman.

    Other issue observed is with the path. Currently if the serverObj.url is present, we do not respect the requestUrl along with the baseUrl. The final should be a concatenated string of reqUrl and baseUrl.

A new collection variable is created called `{nameOfPathUrl}` but that isn't used to add to the url for the request.
    Path variables isn’t the right choice while creating variables for serverObj, instead collection variables should be used. 