### PR TITLE
Fix #57: Add support for the top level tags object.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -402,6 +402,7 @@ module.exports = {
       i,
       summary,
       path,
+      tags = spec.tags,
       componentsAndPaths = {
         components: spec.components,
         paths: spec.paths
@@ -411,6 +412,30 @@ module.exports = {
       trie = new Trie(new Node({
         name: '/'
       })),
+
+      pruneEmptyFolders = function(currentNode) {
+        var requestCount = 0,
+          key,
+          child,
+          childRequestCount;
+
+        if (currentNode.hasOwnProperty('children')) {
+          for ([key, child] of Object.entries(currentNode.children)) {
+            childRequestCount = pruneEmptyFolders(child);
+            if (childRequestCount === 0) {
+              delete currentNode[key];
+              currentNode.childCount -= 1;
+            }
+            requestCount += childRequestCount;
+          }
+
+          if (currentNode.requestCount) {
+            requestCount += currentNode.requests.length;
+            currentNode.requestCount = requestCount;
+          }
+        }
+        return requestCount;
+      },
 
       // returns a list of methods supported at each pathItem
       // some pathItem props are not methods
@@ -425,6 +450,33 @@ module.exports = {
         });
         return methods;
       };
+
+    // adding children for the tags in the OAS
+    for (const tag in tags) {
+      if (tags.hasOwnProperty(tag)) {
+        let currentTagObject = tags[tag];
+        if (currentTagObject && currentTagObject.hasOwnProperty('name')) {
+          const tagName = currentTagObject.name;
+          currentNode = trie.root;
+          if (!currentNode.children[tagName]) {
+            // if the currentPath doesn't already exist at this node,
+            // add it as a folder
+            currentNode.addChildren(tagName, new Node({
+              name: tagName,
+              requestCount: 0,
+              requests: [],
+              children: {},
+              type: 'item-group',
+              childCount: 0
+            }));
+
+            // We are keeping the count children in a folder which can be a request or folder
+            // For ex- In case of /pets/a/b, pets has 1 childCount (i.e a)
+            currentNode.childCount += 1;
+          }
+        }
+      }
+    }
 
     for (path in paths) {
       if (paths.hasOwnProperty(path)) {
@@ -493,26 +545,50 @@ module.exports = {
         _.each(pathMethods, (method) => {
           // base operationItem
           operationItem = currentPathObject[method];
+          // get tags associated with path method.
+          let pathTags = operationItem.tags;
+
           // params - these contain path/header/body params
           operationItem.parameters = this.getRequestParams(operationItem.parameters, commonParams,
             componentsAndPaths, options);
           // auth info - local security object takes precedence over the parent object
           operationItem.security = operationItem.security || spec.security;
           summary = operationItem.summary || operationItem.description;
-          currentNode.addMethod({
-            name: summary,
-            method: method,
-            path: path,
-            properties: operationItem,
-            type: 'item',
-            servers: pathLevelServers || undefined
-          });
+
+          if (pathTags && pathTags[0] && pathTags[0] in trie.root.children) {
+            const matchingTagChildNode = trie.root.children[pathTags[0]];
+            matchingTagChildNode.addMethod({
+              name: summary,
+              method: method,
+              path: path,
+              properties: operationItem,
+              type: 'item',
+              servers: pathLevelServers || undefined
+            });
+            matchingTagChildNode.requestCount += 1;
+            matchingTagChildNode.childCount += 1;
+            currentNode.requestCount -= 1;
+            currentNode.childCount -= 1;
+          }
+          else {
+            currentNode.addMethod({
+              name: summary,
+              method: method,
+              path: path,
+              properties: operationItem,
+              type: 'item',
+              servers: pathLevelServers || undefined
+            });
+          }
           currentNode.childCount += 1;
         });
         pathLevelServers = undefined;
         commonParams = [];
       }
     }
+
+    // prune empty folders from trie
+    pruneEmptyFolders(trie.root);
 
     return {
       tree: trie,

--- a/package.json
+++ b/package.json
@@ -37,6 +37,12 @@
             "url": "http://petstore.swagger.io/v1"
           }
         ],
+        "tags": [
+          {
+            "name": "pets",
+            "description": "my description of pets"
+          }
+        ],
         "paths": {
           "/pets": {
             "get": {

--- a/test/data/valid_openapi/tags-spec.json
+++ b/test/data/valid_openapi/tags-spec.json
@@ -1,0 +1,54 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+      "version": "v1.20.0",
+      "title": "Group By Tags Test",
+      "description": "These paths should be grouped by tag"
+    },
+    "tags": [
+        {
+          "name": "a",
+          "description": "A Tag"
+        },
+        {
+          "name": "b",
+          "description": "B Tag"
+        }
+      ],
+    "paths": {
+        "/preamble/123/a": {
+            "get": {
+                "tags": [
+                    "a"
+                  ],
+                  "responses": {
+                    "200": {
+                      "description": "get successful response"
+                    }
+                }
+            },
+            "post": {
+              "tags": [
+                  "a"
+                ],
+                "responses": {
+                  "200": {
+                    "description": "modification successful response"
+                  }
+              }
+          }
+        },
+        "/preamble/123/b": {
+            "get": {
+                "tags": [
+                    "b"
+                  ],
+                  "responses": {
+                    "200": {
+                      "description": "successful response"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -630,6 +630,22 @@ describe('INTERFACE FUNCTION TESTS ', function () {
     });
   });
 
+  describe('The converter must respect tags from input', function() {
+    var tagsSpec = path.join(__dirname, VALID_OPENAPI_PATH + '/tags-spec.json'),
+      openapi = fs.readFileSync(tagsSpec, 'utf8');
+    Converter.convert({ type: 'string', data: openapi }, { schemaFaker: true }, (err, conversionResult) => {
+      expect(err).to.be.null;
+      expect(conversionResult.result).to.equal(true);
+      expect(conversionResult.output.length).to.equal(1);
+      expect(conversionResult.output[0].type).to.equal('collection');
+      expect(conversionResult.output[0].data).to.have.property('info');
+      expect(conversionResult.output[0].data).to.have.property('item');
+      expect(conversionResult.output[0].data.item[0].name).to.equal('a');
+      // need at least two items to form a folder.
+      expect(conversionResult.output[0].data.item[1].name).to.equal('/preamble/123/b');
+    });
+  });
+
   describe('The converter must throw an error for invalid input type', function() {
     it('(type: some invalid value)', function(done) {
       var result = Converter.validate({ type: 'fil', data: 'invalid_path' });


### PR DESCRIPTION
Create folder objects for tags and prefer those tag folders for
methods. Fall back to the path folders when no tags are present
in the OAS3 structure.

Add a final step to prune empty folders from the collection. Supporting
top level tags resulted in a number of empty folders in practice. This
last pass prunes those empty folders. This results in a nice collection
when tags are present in the OAS3 input.

IMHO, this fixes #57 