### PR TITLE
Add global level security schemes to collection level auth

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -501,8 +501,6 @@ module.exports = {
           // params - these contain path/header/body params
           operationItem.parameters = this.getRequestParams(operationItem.parameters, commonParams,
             componentsAndPaths, options);
-          // auth info - local security object takes precedence over the parent object
-          operationItem.security = operationItem.security || spec.security;
           summary = operationItem.summary || operationItem.description;
           currentNode.addMethod({
             name: summary,
@@ -667,8 +665,6 @@ module.exports = {
         operationItem.parameters = this.getRequestParams(operationItem.parameters, commonParams,
           components, options);
 
-        // auth info - local security object takes precedence over the parent object
-        operationItem.security = operationItem.security || spec.security;
         summary = operationItem.summary || operationItem.description;
 
         // add the request which has not any tags
@@ -896,12 +892,11 @@ module.exports = {
     var securityDef,
       helper;
 
-    // return noAuth if security set is not defined
+    // return false if security set is not defined
     // or is an empty array
+    // this will set the request's auth to default which is 'inherit from parent'
     if (!securitySet || (Array.isArray(securitySet) && securitySet.length === 0)) {
-      return {
-        type: 'noauth'
-      };
+      return {};
     }
 
     securitySet.forEach((security) => {

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -255,12 +255,16 @@ class SchemaPack {
     if (openapi.security) {
       authHelper = schemaUtils.getAuthHelper(openapi, openapi.security);
       if (authHelper) {
-        if (authHelper.type === 'apiKey') {
+        if (authHelper.type === 'api-key') {
           if (authHelper.properties.in === 'header' || authHelper.properties.in === 'query') {
-            generatedStore.collection.auth = {};
+            generatedStore.collection.auth = {
+              type: 'noauth'
+            };
           }
         }
-        generatedStore.collection.auth = authHelper;
+        else {
+          generatedStore.collection.auth = authHelper;
+        }
       }
     }
     // ---- Collection Variables ----

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -256,15 +256,15 @@ class SchemaPack {
       authHelper = schemaUtils.getAuthHelper(openapi, openapi.security);
       if (authHelper) {
         if (authHelper.type === 'api-key') {
+          // if authHelper has type apikey and has properties in header or query
+          // we override authHelper to 'noauth'
           if (authHelper.properties.in === 'header' || authHelper.properties.in === 'query') {
-            generatedStore.collection.auth = {
+            authHelper = {
               type: 'noauth'
             };
           }
         }
-        else {
-          generatedStore.collection.auth = authHelper;
-        }
+        generatedStore.collection.auth = authHelper;
       }
     }
     // ---- Collection Variables ----

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -216,6 +216,7 @@ class SchemaPack {
       generatedStore = {},
       collectionJSON,
       componentsAndPaths,
+      authHelper,
       schemaCache = {
         schemaResolutionCache: this.schemaResolutionCache,
         schemaFakerCache: this.schemaFakerCache
@@ -251,7 +252,17 @@ class SchemaPack {
       }
     });
 
-
+    if (openapi.security) {
+      authHelper = schemaUtils.getAuthHelper(openapi, openapi.security);
+      if (authHelper) {
+        if (authHelper.type === 'apiKey') {
+          if (authHelper.properties.in === 'header' || authHelper.properties.in === 'query') {
+            generatedStore.collection.auth = {};
+          }
+        }
+        generatedStore.collection.auth = authHelper;
+      }
+    }
     // ---- Collection Variables ----
     // adding the collection variables for all the necessary root level variables
     // and adding them to the collection variables

--- a/test/data/valid_openapi/empty-security-test-case.yaml
+++ b/test/data/valid_openapi/empty-security-test-case.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.0
+info:
+  title: "Reproduce Authorization issue"
+  version: 0.0.1
+security:
+  - MyAuth: []
+paths:
+  /health:
+    get:
+      summary: "health"
+      description: "Health check - always returns OK"
+      operationId: "get_healthz"
+      responses:
+        '200':
+          description: "OK"
+          content:
+            text/plain:
+              schema:
+                type: "string"
+                default: "OK"
+  /status:
+    get:
+      summary: "status"
+      description: "Returns the service version"
+      operationId: "get_status"
+      responses:
+        '200':
+          description: "Service info multi-line string"
+          content:
+            text/plain:
+              schema:
+                type: "string"
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: token
+    MyAuth:
+      type: apiKey
+      description: "This is my auth"
+      name: Mera-Auth
+      in: header

--- a/test/data/valid_openapi/security-test-cases.yaml
+++ b/test/data/valid_openapi/security-test-cases.yaml
@@ -1,0 +1,44 @@
+openapi: 3.0.0
+info:
+  title: "Reproduce Authorization issue"
+  version: 0.0.1
+security:
+  - MyAuth: []
+  - BearerAuth: []
+paths:
+  /health:
+    get:
+      summary: "health"
+      description: "Health check - always returns OK"
+      operationId: "get_healthz"
+      responses:
+        '200':
+          description: "OK"
+          content:
+            text/plain:
+              schema:
+                type: "string"
+                default: "OK"
+  /status:
+    get:
+      summary: "status"
+      description: "Returns the service version"
+      operationId: "get_status"
+      responses:
+        '200':
+          description: "Service info multi-line string"
+          content:
+            text/plain:
+              schema:
+                type: "string"
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: token
+    MyAuth:
+      type: apiKey
+      description: "This is my auth"
+      name: Mera-Auth
+      in: header

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -38,12 +38,14 @@ describe('CONVERT FUNCTION TESTS ', function() {
       issue193 = path.join(__dirname, VALID_OPENAPI_PATH, '/issue#193.yml'),
       tooManyRefs = path.join(__dirname, VALID_OPENAPI_PATH, '/too-many-refs.json'),
       tagsFolderSpec = path.join(__dirname, VALID_OPENAPI_PATH + '/petstore-detailed.yaml'),
-      securityTestCases = path.join(__dirname, VALID_OPENAPI_PATH + '/security-test-cases.yaml');
+      securityTestCases = path.join(__dirname, VALID_OPENAPI_PATH + '/security-test-cases.yaml'),
+      emptySecurityTestCase = path.join(__dirname, VALID_OPENAPI_PATH + '/empty-security-test-case.yaml');
 
 
     it('Should add collection level auth with type as `bearer`' +
     securityTestCases, function(done) {
-      var openapi = fs.readFileSync(securityTestCases, 'utf8');
+      var openapi = fs.readFileSync(securityTestCases, 'utf8'),
+        auth;
       Converter.convert({ type: 'string', data: openapi }, {}, (err, conversionResult) => {
 
         expect(err).to.be.null;
@@ -54,6 +56,26 @@ describe('CONVERT FUNCTION TESTS ', function() {
         expect(conversionResult.output[0].data).to.have.property('item');
         expect(conversionResult.output[0].data.auth).to.have.property('type');
         expect(conversionResult.output[0].data.auth.type).to.equal('bearer');
+        auth = conversionResult.output[0].data.item[0].request.auth;
+        expect(auth).to.have.property('type');
+        expect(auth.type).to.be.equal('inherit');
+        done();
+      });
+    });
+
+    it('Should have noauth at the collection level ' +
+    emptySecurityTestCase, function(done) {
+      var openapi = fs.readFileSync(emptySecurityTestCase, 'utf8');
+      Converter.convert({ type: 'string', data: openapi }, {}, (err, conversionResult) => {
+
+        expect(err).to.be.null;
+        expect(conversionResult.result).to.equal(true);
+        expect(conversionResult.output.length).to.equal(1);
+        expect(conversionResult.output[0].type).to.equal('collection');
+        expect(conversionResult.output[0].data).to.have.property('info');
+        expect(conversionResult.output[0].data).to.have.property('item');
+        expect(conversionResult.output[0].data.auth).to.have.property('type');
+        expect(conversionResult.output[0].data.auth.type).to.equal('noauth');
         done();
       });
     });

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -37,7 +37,26 @@ describe('CONVERT FUNCTION TESTS ', function() {
       issue152 = path.join(__dirname, VALID_OPENAPI_PATH, '/path-refs-error.yaml'),
       issue193 = path.join(__dirname, VALID_OPENAPI_PATH, '/issue#193.yml'),
       tooManyRefs = path.join(__dirname, VALID_OPENAPI_PATH, '/too-many-refs.json'),
-      tagsFolderSpec = path.join(__dirname, VALID_OPENAPI_PATH + '/petstore-detailed.yaml');
+      tagsFolderSpec = path.join(__dirname, VALID_OPENAPI_PATH + '/petstore-detailed.yaml'),
+      securityTestCases = path.join(__dirname, VALID_OPENAPI_PATH + '/security-test-cases.yaml');
+
+
+    it('Should add collection level auth with type as `bearer`' +
+    securityTestCases, function(done) {
+      var openapi = fs.readFileSync(securityTestCases, 'utf8');
+      Converter.convert({ type: 'string', data: openapi }, {}, (err, conversionResult) => {
+
+        expect(err).to.be.null;
+        expect(conversionResult.result).to.equal(true);
+        expect(conversionResult.output.length).to.equal(1);
+        expect(conversionResult.output[0].type).to.equal('collection');
+        expect(conversionResult.output[0].data).to.have.property('info');
+        expect(conversionResult.output[0].data).to.have.property('item');
+        expect(conversionResult.output[0].data.auth).to.have.property('type');
+        expect(conversionResult.output[0].data.auth.type).to.equal('bearer');
+        done();
+      });
+    });
 
     it('Should generate collection conforming to schema for and fail if not valid ' +
     tooManyRefs, function(done) {

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -59,7 +59,7 @@ describe('CONVERT FUNCTION TESTS ', function() {
       });
     });
 
-    it('Should have noauth at the collection level ' +
+    it('Should have noauth at the collection level if auth type is api-key and properties in header' +
     emptySecurityTestCase, function(done) {
       var openapi = fs.readFileSync(emptySecurityTestCase, 'utf8');
       Converter.convert({ type: 'string', data: openapi }, {}, (err, conversionResult) => {

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -44,8 +44,7 @@ describe('CONVERT FUNCTION TESTS ', function() {
 
     it('Should add collection level auth with type as `bearer`' +
     securityTestCases, function(done) {
-      var openapi = fs.readFileSync(securityTestCases, 'utf8'),
-        auth;
+      var openapi = fs.readFileSync(securityTestCases, 'utf8');
       Converter.convert({ type: 'string', data: openapi }, {}, (err, conversionResult) => {
 
         expect(err).to.be.null;
@@ -56,9 +55,6 @@ describe('CONVERT FUNCTION TESTS ', function() {
         expect(conversionResult.output[0].data).to.have.property('item');
         expect(conversionResult.output[0].data.auth).to.have.property('type');
         expect(conversionResult.output[0].data.auth.type).to.equal('bearer');
-        auth = conversionResult.output[0].data.item[0].request.auth;
-        expect(auth).to.have.property('type');
-        expect(auth.type).to.be.equal('inherit');
         done();
       });
     });


### PR DESCRIPTION
Fixes: #86 
Following openapi schema reproduces this issue.
```
openapi: 3.0.0
info:
  title: "Reproduce Authorization issue"
  version: 0.0.1
security:
  - BearerAuth: []
paths:
  /status:
    get:
      summary: "status"
      description: "Returns the service version"
      operationId: "get_status"
      responses:
        '200':
          description: "Service info multi-line string"
          content:
            text/plain:
              schema:
                type: "string"
components:
  securitySchemes:
    BearerAuth:
      type: http
      scheme: bearer
      bearerFormat: token
```

Current behavior:
- All the requests created from paths in this schema have an Auth object with security scheme present at the global level of the schema. 
- No auth is added for the ones having in: header. And appropriate headers are added for them.
- No Auth is added at the collection level.

Expected behavior: 
- Global security scheme should be added at the collection auth level.
- All the requests which don’t have any auth defined should have ‘Inherit From Parent’ selected in Postman. 