### PR TITLE
Added test generation for:

### DIFF
--- a/bin/openapi2postmanv2.js
+++ b/bin/openapi2postmanv2.js
@@ -6,7 +6,9 @@ var program = require('commander'),
   inputFile,
   outputFile,
   prettyPrintFlag,
+  configFile,
   testFlag,
+  testsuiteFile,
   swaggerInput,
   swaggerData;
 
@@ -15,7 +17,9 @@ program
   .option('-s, --spec <spec>', 'Convert given OPENAPI 3.0.0 spec to Postman Collection v2.0')
   .option('-o, --output <output>', 'Write the collection to an output file')
   .option('-t, --test', 'Test the OPENAPI converter')
-  .option('-p, --pretty', 'Pretty print the JSON file');
+  .option('-p, --pretty', 'Pretty print the JSON file')
+  .option('-c, --config <config>', 'JSON file containing Converter options')
+  .option('-g, --generate <generate>', 'Generate postman tests given the JSON file with test options');
 
 
 program.on('--help', function() {
@@ -41,6 +45,8 @@ inputFile = program.spec;
 outputFile = program.output || false;
 testFlag = program.test || false;
 prettyPrintFlag = program.pretty || false;
+configFile = program.config || false;
+testsuiteFile = program.generate || false;
 swaggerInput;
 swaggerData;
 
@@ -73,10 +79,25 @@ function writetoFile(prettyPrintFlag, file, collection) {
  * @returns {void}
  */
 function convert(swaggerData) {
+  let options = {};
+
+  if (configFile) {
+    configFile = path.resolve(configFile);
+    console.log('Config file: ', configFile);
+    options = JSON.parse(fs.readFileSync(configFile, 'utf8'));
+  }
+
+  if (testsuiteFile) {
+    testsuiteFile = path.resolve(testsuiteFile);
+    console.log('Testsuite file: ', testsuiteFile);
+    options.testSuite = true;
+    options.testSuiteSettings = JSON.parse(fs.readFileSync(testsuiteFile, 'utf8'));
+  }
+
   Converter.convert({
     type: 'string',
     data: swaggerData
-  }, {}, (err, status) => {
+  }, options, (err, status) => {
     if (err) {
       return console.error(err);
     }

--- a/examples/postman-testsuite.json
+++ b/examples/postman-testsuite.json
@@ -1,0 +1,31 @@
+{
+  "version": 1.0,
+  "generateTests": {
+    "responseChecks": {
+      "StatusSuccess": {
+        "enabled": true
+      },
+      "responseTime": {
+        "enabled": true,
+        "maxMs": 300
+      },
+      "contentType": {
+        "enabled": true
+      },
+      "jsonBody": {
+        "enabled": true
+      },
+      "schemaValidation": {
+        "enabled": true
+      }
+    }
+  },
+  "extendTests": [
+    {
+      "openApiOperationId": "get-lists",
+      "tests": [
+        "pm.test('200 ok', function(){pm.response.to.have.status(200);}); pm.test('check userId after create', function(){Number.isInteger(responseBody);}); postman.setEnvironmentVariable(\"userId\", responseBody);"
+      ]
+    }
+  ]
+}

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1804,6 +1804,7 @@ module.exports = {
       displayUrl,
       reqUrl = '/' + operationItem.path,
       pmBody,
+      pmTests,
       authMeta,
       swagResponse,
       localServers = _.get(operationItem, 'properties.servers'),
@@ -2061,7 +2062,176 @@ module.exports = {
       });
     }
 
+    // Generate tests for the response
+    pmTests = this.convertResponsesToPmTest(operation, operationItem, components, options, schemaCache);
+
+    if (!_.isEmpty(pmTests)) {
+      // Add test event
+      item.events.add(pmTests);
+    }
+
     return item;
+  },
+
+  /**
+   * function to convert an openapi reponse object to object of postman tests
+   * @param {*} operation openapi operation object
+   * @param {*} operationItem - The operation item to get relevant information for the test generation
+   * @param {object} components - components defined in the OAS spec. These are used to
+   * resolve references while generating params.
+   * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
+   * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
+   * @returns {*} array of all query params
+   */
+  convertResponsesToPmTest: function (operation, operationItem, components, options, schemaCache) {
+    console.log('options', options);
+    options = _.merge({}, defaultOptions, options);
+    let testEvent = {},
+      testSuite = {},
+      testSuiteSettings = {},
+      testSuiteExtensions = [],
+      requestsTests = [],
+      swagResponse = {};
+
+    // Check for test suite flag, abort early
+    if (!options.testSuite) {
+      return testEvent;
+    }
+
+    // Check test suite for later usage, potentially convert object
+    if (options.testSuite && options.testSuiteSettings) {
+      testSuite = options.testSuiteSettings;
+      if (testSuite.generateTests) {
+        testSuiteSettings = options.testSuiteSettings.generateTests;
+      }
+      if (testSuite.extendTests) {
+        testSuiteExtensions = options.testSuiteSettings.extendTests;
+      }
+      console.log('optionsTestSuite', testSuiteSettings);
+    }
+
+    _.forOwn(operation.responses, (response, code) => {
+
+      // Only support 2xx response checks
+      // TODO Investigate how to support other response codes like validation response 4xx or 5xx
+      if (!_.inRange(code, 200, 299)) {
+        return; // skip this response
+      }
+
+      // Format response
+      swagResponse = response;
+      if (response.$ref) {
+        swagResponse = this.getRefObject(response.$ref, components, options);
+      }
+
+      // Add status code check
+      // TODO Validate other request codes
+      // if (operationItem.method.toUpperCase() === 'GET') {
+      //   requestsTests.push(
+      //     '// Validate status code \n'+
+      //     'pm.test("Status code should be '+code+'", function () {\n' +
+      //     '    pm.response.to.have.status('+code+');\n' +
+      //     '});\n'
+      //   )
+      // }
+
+      // Add status success check
+      if (_.get(testSuiteSettings, 'responseChecks.StatusSuccess.enabled')) {
+        requestsTests.push(
+          '// Validate status 2xx \n' +
+          'pm.test("Status code is 2xx", function () {\n' +
+          '   pm.response.to.be.success;\n' +
+          '});\n'
+        );
+      }
+
+      // Add response timer check
+      if (_.get(testSuiteSettings, 'responseChecks.responseTime.enabled')) {
+        let maxMs = _.get(testSuiteSettings, 'responseChecks.responseTime.maxMs');
+        requestsTests.push(
+          '// Validate response time \n' +
+          'pm.test("Response time is less than ' + maxMs + 'ms", function () {\n' +
+          '    pm.expect(pm.response.responseTime).to.be.below(' + maxMs + ');\n' +
+          '});\n'
+        );
+      }
+
+      // Process the response content
+      _.forOwn(swagResponse.content, (content, contentType) => {
+        if (contentType) {
+          // Add content-type check
+          if (_.get(testSuiteSettings, 'responseChecks.contentType.enabled')) {
+            requestsTests.push(
+              '// Validate content-type \n' +
+              'pm.test("Content-Type is ' + contentType + '", function () {\n' +
+              // '   pm.response.to.have.header("Content-Type");\n' +
+              // '   pm.response.to.have.header("Content-Type", "' + contentType + '");\n' +
+              '   pm.expect(pm.response.headers.get("Content-Type")).to.include("' + contentType + '");\n' +
+              '});\n'
+            );
+          }
+
+          if (contentType === APP_JSON) {
+            // Add JSON body check
+            if (_.get(testSuiteSettings, 'responseChecks.jsonBody.enabled')) {
+              requestsTests.push(
+                '// Response should have JSON Body\n' +
+                'pm.test("Response has JSON Body", function () {\n' +
+                '    pm.response.to.have.jsonBody();\n' +
+                '});\n');
+            }
+
+            // Add JSON schema check
+            if (_.get(testSuiteSettings, 'responseChecks.schemaValidation.enabled')) {
+              let schemaContent = this.getRefObject(content.schema.$ref, components, options),
+                // When processing a reference, schema.type could also be undefined
+                resolvedSchema = deref.resolveRefs(schemaContent, 'response', components,
+                  schemaCache, PROCESSING_TYPE.VALIDATION);
+
+              requestsTests.push(
+                '// Response Validation\n' +
+                'const schema = ' + JSON.stringify(resolvedSchema) + '\n' +
+                '\n' +
+                '// Test whether the response matches the schema\n' +
+                'pm.test(\'Schema is valid\', function() {\n' +
+                '   pm.response.to.have.jsonSchema(schema,{unknownFormats: ["int32", "int64"]});\n' +
+                '});\n'
+              );
+            }
+          }
+
+        }
+
+      });
+    });
+
+    // Add test extensions that are defined in the test suite file
+    if (testSuiteExtensions.length > 0) {
+      testSuiteExtensions.forEach((testExtension) => {
+        if (operation.operationId && testExtension.openApiOperationId &&
+          operation.operationId === testExtension.openApiOperationId) {
+          console.log('testExtension', testExtension);
+          if (testExtension.tests.length > 0) {
+            testExtension.tests.forEach((postmanTest) => {
+              try {
+                requestsTests.push(postmanTest);
+              } catch (e) {
+                console.log('invalid extendTests for ' + testExtension.openApiOperationI);
+              }
+            });
+          }
+        }
+      });
+    }
+
+    // Add tests to postman item
+    if (requestsTests.length > 0) {
+      testEvent = {
+        listen: 'test',
+        script: requestsTests
+      };
+    }
+    return testEvent;
   },
 
   /**

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -44,6 +44,10 @@ class SchemaPack {
     let indentCharacter = this.computedOptions.indentCharacter;
     this.computedOptions.indentCharacter = indentCharacter === 'tab' ? '\t' : ' ';
 
+    // hardcoding the test suite options CLI mapping - not exposed to postman users yet
+    this.computedOptions.testSuite = options.testSuite;
+    this.computedOptions.testSuiteSettings = options.testSuiteSettings;
+
     this.validate();
   }
 


### PR DESCRIPTION
- Success status check
- Response time check
- Content-type check
- JSON schema validation
- JSON body check

Merged #218 for easy config file usage in the CLI tool.

Added Postman test suite settings, which allow you to define which types of basic tests to be included or not, in the postman generation.
Added Post test suite file loading (inspired by #218) option for the CLI
Added postman-testsuite.json example

Added test suite extension option, which offers the option to include manually defined postman tests based. The test extensions are mapped based on the OpenApi operationID.