### PR TITLE
Improved example value for `requestParameterResolution` and `exampleParameterResolution` options.

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -55,12 +55,14 @@ module.exports = {
    * @param {*} components components in openapi spec.
    * @param {object} schemaResolutionCache stores already resolved references
    * @param {*} resolveFor - resolve refs for validation/conversion (value to be one of VALIDATION/CONVERSION)
+   * @param {string} resolveTo The desired JSON-generation mechanism (schema: prefer using the JSONschema to
+     generate a fake object, example: use specified examples as-is). Default: schema
    * @param {*} stack counter which keeps a tab on nested schemas
    * @param {*} seenRef References that are repeated. Used to identify circular references.
    * @returns {*} schema - schema that adheres to all individual schemas in schemaArr
    */
   resolveAllOf: function (schemaArr, parameterSourceOption, components, schemaResolutionCache,
-    resolveFor = 'CONVERSION', stack = 0, seenRef) {
+    resolveFor = 'CONVERSION', resolveTo = 'schema', stack = 0, seenRef) {
 
     if (!(schemaArr instanceof Array)) {
       return null;
@@ -69,13 +71,13 @@ module.exports = {
     if (schemaArr.length === 1) {
       // for just one entry in allOf, don't need to enforce type: object restriction
       return this.resolveRefs(schemaArr[0], parameterSourceOption, components, schemaResolutionCache, resolveFor,
-        stack, seenRef);
+        resolveTo, stack, seenRef);
     }
 
     // generate one object for each schema
     let indivObjects = schemaArr.map((schema) => {
         return this.resolveRefs(schema, parameterSourceOption, components, schemaResolutionCache, resolveFor,
-          stack, seenRef);
+          resolveTo, stack, seenRef);
       }).filter((schema) => {
         return schema.type === 'object';
       }),
@@ -113,13 +115,15 @@ module.exports = {
    * @param {*} components components in openapi spec.
    * @param {object} schemaResolutionCache stores already resolved references
    * @param {*} resolveFor - resolve refs for validation/conversion (value to be one of VALIDATION/CONVERSION)
+   * @param {string} resolveTo The desired JSON-generation mechanism (schema: prefer using the JSONschema to
+    generate a fake object, example: use specified examples as-is). Default: schema
    * @param {*} stack counter which keeps a tab on nested schemas
    * @param {*} seenRef - References that are repeated. Used to identify circular references.
    * @returns {*} schema satisfying JSON-schema-faker.
    */
 
   resolveRefs: function (schema, parameterSourceOption, components, schemaResolutionCache,
-    resolveFor = 'CONVERSION', stack = 0, seenRef = {}) {
+    resolveFor = 'CONVERSION', resolveTo = 'schema', stack = 0, seenRef = {}) {
     var resolvedSchema, prop, splitRef,
       ERR_TOO_MANY_LEVELS = '<Error: Too many levels of nesting to fake this schema>';
 
@@ -136,15 +140,15 @@ module.exports = {
 
     if (schema.anyOf) {
       return this.resolveRefs(schema.anyOf[0], parameterSourceOption, components, schemaResolutionCache, resolveFor,
-        stack, _.cloneDeep(seenRef));
+        resolveTo, stack, _.cloneDeep(seenRef));
     }
     if (schema.oneOf) {
       return this.resolveRefs(schema.oneOf[0], parameterSourceOption, components, schemaResolutionCache, resolveFor,
-        stack, _.cloneDeep(seenRef));
+        resolveTo, stack, _.cloneDeep(seenRef));
     }
     if (schema.allOf) {
       return this.resolveAllOf(schema.allOf, parameterSourceOption, components, schemaResolutionCache, resolveFor,
-        stack, _.cloneDeep(seenRef));
+        resolveTo, stack, _.cloneDeep(seenRef));
     }
     if (schema.$ref && _.isFunction(schema.$ref.split)) {
       let refKey = schema.$ref;
@@ -186,7 +190,7 @@ module.exports = {
 
       if (resolvedSchema) {
         let refResolvedSchema = this.resolveRefs(resolvedSchema, parameterSourceOption,
-          components, schemaResolutionCache, resolveFor, stack, _.cloneDeep(seenRef));
+          components, schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef));
 
         if (refResolvedSchema && refResolvedSchema.value !== ERR_TOO_MANY_LEVELS) {
           schemaResolutionCache[refKey] = refResolvedSchema;
@@ -221,8 +225,8 @@ module.exports = {
               continue;
             }
             /* eslint-enable */
-            tempSchema.properties[prop] = this.resolveRefs(property,
-              parameterSourceOption, components, schemaResolutionCache, resolveFor, stack, _.cloneDeep(seenRef));
+            tempSchema.properties[prop] = this.resolveRefs(property, parameterSourceOption, components,
+              schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef));
           }
         }
         return tempSchema;
@@ -230,8 +234,10 @@ module.exports = {
 
       schema.type = 'string';
 
-      // Don't override default value to schema for validation
-      resolveFor !== 'VALIDATION' && (schema.default = '<object>');
+      // Override deefault value to appropriate type representation for parameter resolution to schema
+      if (resolveFor === 'CONVERSION' && resolveTo === 'schema') {
+        schema.default = '<object>';
+      }
     }
     else if (schema.type === 'array' && schema.items) {
       /*
@@ -260,13 +266,13 @@ module.exports = {
       // without this, schemas with circular references aren't faked correctly
       let tempSchema = _.omit(schema, 'items');
       tempSchema.items = this.resolveRefs(schema.items, parameterSourceOption,
-        components, schemaResolutionCache, resolveFor, stack, _.cloneDeep(seenRef));
+        components, schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef));
       return tempSchema;
     }
     else if (!schema.hasOwnProperty('default')) {
       if (schema.hasOwnProperty('type')) {
         // Don't override default value to schema for validation
-        if (resolveFor === 'CONVERSION') {
+        if (resolveFor === 'CONVERSION' && resolveTo === 'schema') {
           if (!schema.hasOwnProperty('format')) {
             schema.default = '<' + schema.type + '>';
           }

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -129,7 +129,7 @@ function safeSchemaFaker(oldSchema, resolveTo, resolveFor, parameterSourceOption
     schemaFakerCache = _.get(schemaCache, 'schemaFakerCache', {});
 
   resolvedSchema = deref.resolveRefs(oldSchema, parameterSourceOption, components, schemaResolutionCache,
-    resolveFor);
+    resolveFor, resolveTo);
   key = JSON.stringify(resolvedSchema);
 
   if (resolveTo === 'schema') {
@@ -773,12 +773,13 @@ module.exports = {
     else {
       _.forEach(commonPathVars, (variable) => {
         let description = this.getParameterDescription(variable);
+
         variables.push({
           key: variable.name,
           // we only fake the schema for param-level pathVars
           value: options.schemaFaker ?
-            safeSchemaFaker(variable.schema || {}, 'schema', PROCESSING_TYPE.CONVERSION, PARAMETER_SOURCE.REQUEST,
-              components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache) : '',
+            safeSchemaFaker(variable.schema || {}, options.requestParametersResolution, PROCESSING_TYPE.CONVERSION,
+              PARAMETER_SOURCE.REQUEST, components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache) : '',
           description: description
         });
       });
@@ -2239,7 +2240,7 @@ module.exports = {
 
       // This is dereferenced schema (converted to JSON schema for validation)
       schema = deref.resolveRefs(openApiSchemaObj, parameterSourceOption, components,
-        schemaCache.schemaResolutionCache, PROCESSING_TYPE.VALIDATION);
+        schemaCache.schemaResolutionCache, PROCESSING_TYPE.VALIDATION, resolveTo);
 
     if (needJsonMatching) {
       try {

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2240,7 +2240,7 @@ module.exports = {
 
       // This is dereferenced schema (converted to JSON schema for validation)
       schema = deref.resolveRefs(openApiSchemaObj, parameterSourceOption, components,
-        schemaCache.schemaResolutionCache, PROCESSING_TYPE.VALIDATION, resolveTo);
+        schemaCache.schemaResolutionCache, PROCESSING_TYPE.VALIDATION, 'example');
 
     if (needJsonMatching) {
       try {

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -163,7 +163,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         parameterSource = 'REQUEST',
         resolveTo = 'schema',
         resolveFor = 'CONVERSION',
-        resolvedSchema = deref.resolveRefs(schema, parameterSource, { components }, {}, resolveFor),
+        resolvedSchema = deref.resolveRefs(schema, parameterSource, { components }, {}, resolveFor, resolveTo),
         schemaCache = {
           schemaFakerCache: {},
           schemaResolutionCache: {}
@@ -205,7 +205,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           schemaResolutionCache: {}
         },
         resolvedSchema = deref.resolveRefs(schema, parameterSource, { components }, schemaCache.schemaResolutionCache,
-          resolveFor),
+          resolveFor, resolveTo),
         key = hash('resolveToExample ' + JSON.stringify(resolvedSchema)),
         fakedSchema = SchemaUtils.safeSchemaFaker(schema, resolveTo, resolveFor, parameterSource,
           { components }, 'default', '  ', schemaCache);
@@ -640,7 +640,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
       expect(retVal).to.be.an('array');
       expect(retVal[0].key).to.equal('varName');
       expect(retVal[0].description).to.equal('varDesc');
-      expect(retVal[0].value).to.equal('<integer>');
+      expect(retVal[0].value).to.be.a('number');
     });
   });
 


### PR DESCRIPTION
Existing flow used to rely on value to fallback to schema when no example/s were available. With this change when example is not available value will fallback to faked value based on schema provided. 