### PR TITLE
Validate metadata with option `validateMetadata`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 #### v1.1.14 (April 28, 2020)
 * Added a new function to get meta data from a schema.
-* Fix for [#169]https://github.com/postmanlabs/openapi-to-postman/issues/169 - Removed unused folderStrategy option.
+* Fix for [#169](https://github.com/postmanlabs/openapi-to-postman/issues/169) - Removed unused folderStrategy option.
 
 #### v1.1.13 (April 21, 2020)
 * Added support for detailed validation body mismatches with option detailedBlobValidation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # OpenAPI-Postman Changelog
+#### v1.1.17 (May 15, 2020)
+* Fix for [#3](https://github.com/postmanlabs/openapi-to-postman/issues/3) [#57](https://github.com/postmanlabs/openapi-to-postman/issues/57) - Introduced a new option `folderStrategy`, can choose between `Tags` or `Path` while creating folders in Postman Collection.
+* Fixed an issue where undefined was returned as error message while trying to import invalid format.
+* Use `minItems` and `maxItems` values if available in schema with type array.
+
 #### v1.1.16 (May 4, 2020)
 * Change Url to URL in Naming Request option.
 

--- a/assets/json-schema-faker.js
+++ b/assets/json-schema-faker.js
@@ -24430,6 +24430,10 @@ function extend() {
       return dateTimeGenerator().slice(11);
   }
 
+  const FRAGMENT = '[a-zA-Z][a-zA-Z0-9+-.]*';
+  const URI_PATTERN = `https?://{hostname}(?:${FRAGMENT})+`;
+  const PARAM_PATTERN = '(?:\\?([a-z]{1,7}(=\\w{1,5})?&){0,3})?';
+
   /**
    * Predefined core formats
    * @type {[key: string]: string}
@@ -24438,9 +24442,24 @@ function extend() {
       email: '[a-zA-Z\\d][a-zA-Z\\d-]{1,13}[a-zA-Z\\d]@{hostname}',
       hostname: '[a-zA-Z]{1,33}\\.[a-z]{2,4}',
       ipv6: '[a-f\\d]{4}(:[a-f\\d]{4}){7}',
-      uri: 'https?://[a-zA-Z][a-zA-Z0-9+-.]*',
-      'uri-reference': '(https?://|#|/|)[a-zA-Z][a-zA-Z0-9+-.]*',
+      uri: URI_PATTERN,
+      slug: '[a-zA-Z\\d_-]+',
+    
+      // types from draft-0[67] (?)
+      'uri-reference': `${URI_PATTERN}${PARAM_PATTERN}`,
+      'uri-template': URI_PATTERN.replace('(?:', '(?:/\\{[a-z][:a-zA-Z0-9-]*\\}|'),
+      'json-pointer': `(/(?:${FRAGMENT.replace(']*', '/]*')}|~[01]))+`,
+    
+      // some types from https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#data-types (?)
+      uuid: '^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$',
   };
+
+  regexps.iri = regexps['uri-reference'];
+  regexps['iri-reference'] = regexps['uri-reference'];
+
+  regexps['idn-email'] = regexps.email;
+  regexps['idn-hostname'] = regexps.hostname;
+
   /**
    * Generates randomized string basing on a built-in regex format
    *
@@ -24476,6 +24495,14 @@ function extend() {
           case 'ipv6':
           case 'uri':
           case 'uri-reference':
+          case 'iri':
+          case 'iri-reference':
+          case 'idn-email':
+          case 'idn-hostname':
+          case 'json-pointer':
+          case 'slug':
+          case 'uri-template':
+          case 'uuid':
               return coreFormatGenerator(value.format);
           default:
               if (typeof callback === 'undefined') {

--- a/lib/ajvValidationError.js
+++ b/lib/ajvValidationError.js
@@ -22,11 +22,13 @@ function ajvValidationError(ajvValidationErrorObj, data) {
       mismatchObj.reasonCode = 'MISSING_IN_SCHEMA';
       break;
 
-    case 'dependencies':
-      mismatchObj.reason = `The ${data.humanPropName} property "${mismatchPropName}" ` +
-      `should have property "${_.get(ajvValidationErrorObj, 'params.missingProperty')}" when property ` +
-      `"${_.get(ajvValidationErrorObj, 'params.property')}" is present`;
-      break;
+      // currently not supported as OAS doesn't support this keyword
+      // case 'dependencies':
+      //   mismatchObj.reasonCode = 'MISSING_IN_REQUEST';
+      //   mismatchObj.reason = `The ${data.humanPropName} property "${mismatchPropName}" ` +
+      //   `should have property "${_.get(ajvValidationErrorObj, 'params.missingProperty')}" when property ` +
+      //   `"${_.get(ajvValidationErrorObj, 'params.property')}" is present`;
+      //   break;
 
     case 'required':
       mismatchObj.reasonCode = 'MISSING_IN_REQUEST';
@@ -34,10 +36,11 @@ function ajvValidationError(ajvValidationErrorObj, data) {
         `property "${_.get(ajvValidationErrorObj, 'params.missingProperty')}"`;
       break;
 
-    case 'propertyNames':
-      mismatchObj.reason = `The ${data.humanPropName} property "${mismatchPropName}" contains invalid ` +
-        `property named "${_.get(ajvValidationErrorObj, 'params.propertyName')}"`;
-      break;
+      // currently not supported as OAS doesn't support this keyword
+      // case 'propertyNames':
+      //   mismatchObj.reason = `The ${data.humanPropName} property "${mismatchPropName}" contains invalid ` +
+      //     `property named "${_.get(ajvValidationErrorObj, 'params.propertyName')}"`;
+      //   break;`
 
     default:
       break;

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -229,7 +229,9 @@ module.exports = {
       }
 
       schema.type = 'string';
-      schema.default = '<object>';
+
+      // Don't override default value to schema for validation
+      resolveFor !== 'VALIDATION' && (schema.default = '<object>');
     }
     else if (schema.type === 'array' && schema.items) {
       /*
@@ -263,20 +265,23 @@ module.exports = {
     }
     else if (!schema.hasOwnProperty('default')) {
       if (schema.hasOwnProperty('type')) {
-        if (!schema.hasOwnProperty('format')) {
-          schema.default = '<' + schema.type + '>';
-        }
-        else if (type.hasOwnProperty(schema.type)) {
-          schema.default = type[schema.type][schema.format];
-
-          // in case the format is a custom format (email, hostname etc.)
-          // https://swagger.io/docs/specification/data-models/data-types/#string
-          if (!schema.default && schema.format) {
-            schema.default = '<' + schema.format + '>';
+        // Don't override default value to schema for validation
+        if (resolveFor === 'CONVERSION') {
+          if (!schema.hasOwnProperty('format')) {
+            schema.default = '<' + schema.type + '>';
           }
-        }
-        else {
-          schema.default = '<' + schema.type + (schema.format ? ('-' + schema.format) : '') + '>';
+          else if (type.hasOwnProperty(schema.type)) {
+            schema.default = type[schema.type][schema.format];
+
+            // in case the format is a custom format (email, hostname etc.)
+            // https://swagger.io/docs/specification/data-models/data-types/#string
+            if (!schema.default && schema.format) {
+              schema.default = '<' + schema.format + '>';
+            }
+          }
+          else {
+            schema.default = '<' + schema.type + (schema.format ? ('-' + schema.format) : '') + '>';
+          }
         }
       }
       else if (schema.enum && schema.enum.length > 0) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -145,6 +145,15 @@ module.exports = {
           'in the request/response body.',
         external: true,
         usage: ['VALIDATION']
+      },
+      {
+        name: 'Suggest fixes if available',
+        id: 'suggestAvailableFixes',
+        type: 'boolean',
+        default: false,
+        description: 'Whether to provide fixes for patching corresponding mismatches.',
+        external: true,
+        usage: ['VALIDATION']
       }
     ];
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -39,7 +39,7 @@ module.exports = {
         ' If “Fallback” is selected, the request will be named after one of the following schema' +
         ' values: `description`, `operationid`, `url`.',
         external: true,
-        usage: ['CONVERSION']
+        usage: ['CONVERSION', 'VALIDATION']
       },
       {
         name: 'Set indent character',
@@ -152,6 +152,15 @@ module.exports = {
         type: 'boolean',
         default: false,
         description: 'Whether to provide fixes for patching corresponding mismatches.',
+        external: true,
+        usage: ['VALIDATION']
+      },
+      {
+        name: 'Show Metadata validation messages',
+        id: 'validateMetadata',
+        type: 'boolean',
+        default: false,
+        description: 'Whether to show mismatches for incorrect name and description of request',
         external: true,
         usage: ['VALIDATION']
       }

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2568,6 +2568,96 @@ module.exports = {
     });
   },
 
+  /**
+   *
+   * @param {*} transaction Transaction with which to compare
+   * @param {*} transactionPathPrefix the jsonpath for this validation (will be prepended to all identified mismatches)
+   * @param {*} schemaPath the applicable pathItem defined at the schema level
+   * @param {*} pathRoute Route to applicable pathItem (i.e. 'GET /users/{userID}')
+   * @param {*} options OAS options
+   * @param {*} callback Callback
+   * @returns {array} mismatches (in the callback)
+   */
+  checkMetadata(transaction, transactionPathPrefix, schemaPath, pathRoute, options, callback) {
+    let expectedReqName,
+      expectedReqDesc,
+      reqNameMismatch,
+      actualReqName = _.get(transaction, 'name'),
+      actualReqDesc = _.get(transaction, 'request.name'),
+      mismatches = [],
+      mismatchObj,
+      reqUrl;
+
+    if (!options.validateMetadata) {
+      return callback(null, []);
+    }
+
+    // handling path templating in request url if any
+    // convert all {anything} to {{anything}}
+    reqUrl = this.fixPathVariablesInUrl(pathRoute.slice(pathRoute.indexOf('/')));
+
+    // convert all /{{one}}/{{two}} to /:one/:two
+    // Doesn't touch /{{file}}.{{format}}
+    reqUrl = this.sanitizeUrlPathParams(reqUrl, []).url;
+    expectedReqDesc = schemaPath.description;
+
+    switch (options.requestNameSource) {
+      case 'fallback' : {
+        // operationId is usually camelcase or snake case
+        expectedReqName = schemaPath.summary || utils.insertSpacesInName(schemaPath.operationId) || reqUrl;
+        reqNameMismatch = (actualReqName !== expectedReqName);
+        break;
+      }
+      case 'url' : {
+        // actual value may differ in conversion as it uses local/global servers info to generate it
+        // for now suggest actual path as request name
+        expectedReqName = reqUrl;
+        reqNameMismatch = !_.endsWith(actualReqName, reqUrl);
+        break;
+      }
+      default : {
+        expectedReqName = schemaPath[options.requestNameSource];
+        reqNameMismatch = (actualReqName !== expectedReqName);
+        break;
+      }
+    }
+
+    if (reqNameMismatch) {
+      mismatchObj = {
+        property: 'REQUEST_NAME',
+        transactionJsonPath: transactionPathPrefix + '.name',
+        schemaJsonPath: null,
+        reasonCode: 'INVALID_VALUE',
+        reason: 'The request name didn\'t match with specified schema'
+      };
+
+      options.suggestAvailableFixes && (mismatchObj.suggestedFix = {
+        key: 'name',
+        actualValue: actualReqName,
+        suggestedValue: expectedReqName
+      });
+      mismatches.push(mismatchObj);
+    }
+
+    if (actualReqDesc !== expectedReqDesc) {
+      mismatchObj = {
+        property: 'REQUEST_DESCRIPTION',
+        transactionJsonPath: transactionPathPrefix + '.request.description',
+        schemaJsonPath: null,
+        reasonCode: 'INVALID_VALUE',
+        reason: 'The request description didn\'t match with specified schema'
+      };
+
+      options.suggestAvailableFixes && (mismatchObj.suggestedFix = {
+        key: 'description',
+        actualValue: actualReqDesc,
+        suggestedValue: expectedReqDesc
+      });
+      mismatches.push(mismatchObj);
+    }
+    return callback(null, mismatches);
+  },
+
   checkQueryParams(requestUrl, transactionPathPrefix, schemaPath, components, options,
     schemaCache, callback) {
     let parsedUrl = require('url').parse(requestUrl),

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2337,26 +2337,29 @@ module.exports = {
             // input was invalid. Don't throw mismatch
           }
 
-          // As json-schema-faker only supports Json Schema Draft 4, and Ajv is supporting Draft 7
-          // Remove keyword currently not supported in Json Schema Draft 4 to make both compatible with each other
+          // As OAS only supports some of Json Schema keywords, and Ajv is supporting all keywords from Draft 7
+          // Remove keyword currently not supported in OAS to make both compatible with each other
           filteredValidationError = _.filter(validate.errors, (validationError) => {
-            // for invalid `propertyNames` two error are thrown, which include error with `pattern` keyword
-            // so check whether error with `pattern` keyword is thrown for `propertyNames` keyword violation
+            // for invalid `propertyNames` two error are thrown by Ajv, which include error with `pattern` keyword
             if (validationError.keyword === 'pattern') {
               return !_.has(validationError, 'propertyName');
             }
-            return !_.includes(['propertyNames', 'const'], validationError.keyword);
+
+            // Following are non-supported keywords in OpenAPI spec but supported in Json schema (Ajv)
+            return !_.includes(['propertyNames', 'const', 'additionalItems', 'dependencies'], validationError.keyword);
           });
+
+          // sort errors based on dataPath, as this will ensure no overriding later
+          filteredValidationError = _.sortBy(filteredValidationError, ['dataPath']);
 
           if (!_.isEmpty(filteredValidationError)) {
             let mismatchObj,
-              fakedValue;
-
-            // Show detailed validation mismatches for only request/response body
-            if (options.detailedBlobValidation && needJsonMatching) {
+              suggestedValue,
               fakedValue = safeSchemaFaker(openApiSchemaObj || {}, 'example', PROCESSING_TYPE.VALIDATION,
                 parameterSourceOption, components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache);
 
+            // Show detailed validation mismatches for only request/response body
+            if (options.detailedBlobValidation && needJsonMatching) {
               _.forEach(filteredValidationError, (ajvError) => {
                 let localSchemaPath = ajvError.schemaPath.replace(/\//g, '.').slice(2);
 
@@ -2369,7 +2372,7 @@ module.exports = {
                 if (options.suggestAvailableFixes) {
                   mismatchObj.suggestedFix = {
                     key: _.split(ajvError.dataPath, '.').pop(),
-                    actualValue: _.get(valueToUse, ajvError.dataPath.slice(1), 'ERR'),
+                    actualValue: _.get(valueToUse, ajvError.dataPath.slice(1)),
                     suggestedValue: this.getSuggestedValue(fakedValue, valueToUse, ajvError)
                   };
                 }
@@ -2388,11 +2391,18 @@ module.exports = {
               }
 
               if (options.suggestAvailableFixes) {
+                suggestedValue = _.cloneDeep(valueToUse);
+
+                // Apply each fix individually to respect existing values in request
+                _.forEach(filteredValidationError, (ajvError) => {
+                  _.set(suggestedValue, ajvError.dataPath.slice(1),
+                    this.getSuggestedValue(fakedValue, valueToUse, ajvError));
+                });
+
                 mismatchObj.suggestedFix = {
                   key: property.toLowerCase(),
                   actualValue: valueToUse,
-                  suggestedValue: safeSchemaFaker(openApiSchemaObj || {}, 'example', PROCESSING_TYPE.VALIDATION,
-                    parameterSourceOption, components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache)
+                  suggestedValue
                 };
               }
 
@@ -3072,23 +3082,28 @@ module.exports = {
         suggestedValue = _.pick(targetActualValue, _.intersection(_.keys(targetActualValue), _.keys(targetFakedValue)));
         break;
 
-      // to do: check for multiple i j ones
-      case 'dependencies':
       case 'required':
         suggestedValue = _.assign({}, targetActualValue,
           _.pick(targetFakedValue, ajvValidationErrorObj.params.missingProperty));
         break;
 
-      // to do: check for multiple i j ones
+      case 'minItems':
+        suggestedValue = _.concat(targetActualValue, _.slice(targetFakedValue, targetActualValue.length));
+        break;
+
+      case 'maxItems':
+        suggestedValue = _.slice(targetActualValue, 0, ajvValidationErrorObj.params.limit);
+        break;
+
       case 'uniqueItems':
         tempSuggestedValue = _.cloneDeep(targetActualValue);
-        tempSuggestedValue[ajvValidationErrorObj.params.j] = targetFakedValue[ajvValidationErrorObj.params.j];
+        tempSuggestedValue[ajvValidationErrorObj.params.j] = _.last(targetFakedValue);
         suggestedValue = tempSuggestedValue;
         break;
 
       // minLength, maxLength, format, const, minimum, maximum, type, multipleOf, pattern,
       default:
-        suggestedValue = _.get(fakedValue, dataPath, 'ERR');
+        suggestedValue = _.get(fakedValue, dataPath);
         break;
     }
 

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2633,7 +2633,7 @@ module.exports = {
 
       options.suggestAvailableFixes && (mismatchObj.suggestedFix = {
         key: 'name',
-        actualValue: actualReqName,
+        actualValue: actualReqName || null,
         suggestedValue: expectedReqName
       });
       mismatches.push(mismatchObj);
@@ -2650,7 +2650,7 @@ module.exports = {
 
       options.suggestAvailableFixes && (mismatchObj.suggestedFix = {
         key: 'description',
-        actualValue: actualReqDesc,
+        actualValue: actualReqDesc || null,
         suggestedValue: expectedReqDesc
       });
       mismatches.push(mismatchObj);

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -114,6 +114,7 @@ function hash(input) {
 * @param {*} oldSchema the schema to fake
 * @param {string} resolveTo The desired JSON-generation mechanism (schema: prefer using the JSONschema to
    generate a fake object, example: use specified examples as-is). Default: schema
+* @param {*} resolveFor - resolve refs for flow validation/conversion (value to be one of VALIDATION/CONVERSION)
 * @param {string} parameterSourceOption Specifies whether the schema being faked is from a request or response.
 * @param {*} components list of predefined components (with schemas)
 * @param {string} schemaFormat default or xml
@@ -121,14 +122,14 @@ function hash(input) {
 * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
 * @returns {object} fakedObject
 */
-function safeSchemaFaker(oldSchema, resolveTo, parameterSourceOption, components,
+function safeSchemaFaker(oldSchema, resolveTo, resolveFor, parameterSourceOption, components,
   schemaFormat, indentCharacter, schemaCache) {
   var prop, key, resolvedSchema, fakedSchema,
     schemaResolutionCache = _.get(schemaCache, 'schemaResolutionCache', {}),
     schemaFakerCache = _.get(schemaCache, 'schemaFakerCache', {});
 
   resolvedSchema = deref.resolveRefs(oldSchema, parameterSourceOption, components, schemaResolutionCache,
-    PROCESSING_TYPE.CONVERSION);
+    resolveFor);
   key = JSON.stringify(resolvedSchema);
 
   if (resolveTo === 'schema') {
@@ -141,6 +142,12 @@ function safeSchemaFaker(oldSchema, resolveTo, parameterSourceOption, components
     key = 'resolveToExample ' + key;
     schemaFaker.option({
       useExamplesValue: true
+    });
+  }
+
+  if (resolveFor === PROCESSING_TYPE.VALIDATION) {
+    schemaFaker.option({
+      useDefaultValue: false
     });
   }
 
@@ -770,8 +777,8 @@ module.exports = {
           key: variable.name,
           // we only fake the schema for param-level pathVars
           value: options.schemaFaker ?
-            safeSchemaFaker(variable.schema || {}, 'schema', components, 'REQUEST',
-              SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache) : '',
+            safeSchemaFaker(variable.schema || {}, 'schema', PROCESSING_TYPE.CONVERSION, PARAMETER_SOURCE.REQUEST,
+              components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache) : '',
           description: description
         });
       });
@@ -1112,7 +1119,7 @@ module.exports = {
         if (this.getHeaderFamily(contentType) === HEADER_TYPE.XML) {
           schemaType = SCHEMA_FORMATS.XML;
         }
-        bodyData = safeSchemaFaker(bodyObj.schema || {}, resolveTo, parameterSourceOption,
+        bodyData = safeSchemaFaker(bodyObj.schema || {}, resolveTo, PROCESSING_TYPE.CONVERSION, parameterSourceOption,
           components, schemaType, indentCharacter, schemaCache);
       }
       else {
@@ -1176,7 +1183,7 @@ module.exports = {
     if (param.hasOwnProperty('schema')) {
       // fake data generated
       paramValue = options.schemaFaker ?
-        safeSchemaFaker(param.schema, resolveTo, PARAMETER_SOURCE.REQUEST,
+        safeSchemaFaker(param.schema, resolveTo, PROCESSING_TYPE.CONVERSION, PARAMETER_SOURCE.REQUEST,
           components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache) : '';
       // paramType = param.schema.type;
 
@@ -1383,7 +1390,7 @@ module.exports = {
         fakeData = '';
       }
       else {
-        fakeData = safeSchemaFaker(header.schema || {}, resolveTo, parameterSource,
+        fakeData = safeSchemaFaker(header.schema || {}, resolveTo, PROCESSING_TYPE.CONVERSION, parameterSource,
           components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache);
 
         // for schema.type=string or number,
@@ -2205,20 +2212,22 @@ module.exports = {
 
   /**
    *
-   * @param {*} property - one of QUERYPARAM, PATHVARIABLE, HEADER, BODY, RESPONSE_HEADER, RESPONSE_BODY
-   * @param {*} jsonPathPrefix - this will be prepended to all JSON schema paths on the request
-   * @param {*} txnParamName - Optional - The name of the param being validated (useful for query params,
+   * @param {String} property - one of QUERYPARAM, PATHVARIABLE, HEADER, BODY, RESPONSE_HEADER, RESPONSE_BODY
+   * @param {String} jsonPathPrefix - this will be prepended to all JSON schema paths on the request
+   * @param {String} txnParamName - Optional - The name of the param being validated (useful for query params,
    *  req headers, res headers)
    * @param {*} value - the value of the property in the request
-   * @param {*} schemaPathPrefix - this will be prepended to all JSON schema paths on the schema
-   * @param {*} schema - The schema against which to validate
-   * @param {*} components - Components in the spec that the schema might refer to
-   * @param {*} options - Global options
-   * @param {*} callback - For return
-   * @returns {*} array of mismatches
+   * @param {String} schemaPathPrefix - this will be prepended to all JSON schema paths on the schema
+   * @param {Object} openApiSchemaObj - The OpenAPI schema object against which to validate
+   * @param {String} parameterSourceOption tells that the schema object is of request or response
+   * @param {Object} components - Components in the spec that the schema might refer to
+   * @param {Object} options - Global options
+   * @param {Object} schemaCache object storing schemaFaker and schmeResolution caches
+   * @param {Function} callback - For return
+   * @returns {Array} array of mismatches
    */
-  checkValueAgainstSchema: function (property, jsonPathPrefix, txnParamName, value, schemaPathPrefix, schema,
-    components, options, callback) {
+  checkValueAgainstSchema: function (property, jsonPathPrefix, txnParamName, value, schemaPathPrefix, openApiSchemaObj,
+    parameterSourceOption, components, options, schemaCache, callback) {
 
     let mismatches = [],
       jsonValue,
@@ -2227,7 +2236,10 @@ module.exports = {
       invalidJson = false,
       ajv, validate,
       valueToUse = value,
-      res = true;
+
+      // This is dereferenced schema (converted to JSON schema for validation)
+      schema = deref.resolveRefs(openApiSchemaObj, parameterSourceOption, components,
+        schemaCache.schemaResolutionCache, PROCESSING_TYPE.VALIDATION);
 
     if (needJsonMatching) {
       try {
@@ -2247,7 +2259,9 @@ module.exports = {
       if (typeof schemaTypeToJsValidator[schema.type] === 'function') {
         if (!schemaTypeToJsValidator[schema.type](valueToUse)) {
           // if type didn't match, no point checking for AJV
-          let reason = '';
+          let reason = '',
+            mismatchObj;
+
           if (property === 'RESPONSE_BODY' || property === 'BODY') {
             // we don't have names for the body, but there's only one
             reason = 'The ' + humanPropName;
@@ -2277,18 +2291,31 @@ module.exports = {
             reason += `a ${typeof valueToUse} instead`;
           }
 
-          return callback(null, [{
+          mismatchObj = {
             property,
             transactionJsonPath: jsonPathPrefix,
             schemaJsonPath: schemaPathPrefix,
             reasonCode: 'INVALID_TYPE',
             reason
-          }]);
+          };
+
+          if (options.suggestAvailableFixes) {
+            mismatchObj.suggestedFix = {
+              key: txnParamName,
+              actualValue: valueToUse,
+              suggestedValue: safeSchemaFaker(openApiSchemaObj || {}, 'example', PROCESSING_TYPE.VALIDATION,
+                parameterSourceOption, components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache)
+            };
+          }
+
+          return callback(null, [mismatchObj]);
         }
 
         // only do AJV if type is array or object
         // simpler cases are handled by a type check
         if (schema.type === 'array' || schema.type === 'object') {
+          let filteredValidationError;
+
           try {
             // add Ajv options to support validation of OpenAPI schema.
             // For more details see https://ajv.js.org/#options
@@ -2303,25 +2330,54 @@ module.exports = {
               nullable: true
             });
             validate = ajv.compile(schema);
-            res = validate(valueToUse);
+            validate(valueToUse);
           }
           catch (e) {
             // something went wrong validating the schema
             // input was invalid. Don't throw mismatch
           }
-          if (!res) {
+
+          // As json-schema-faker only supports Json Schema Draft 4, and Ajv is supporting Draft 7
+          // Remove keyword currently not supported in Json Schema Draft 4 to make both compatible with each other
+          filteredValidationError = _.filter(validate.errors, (validationError) => {
+            // for invalid `propertyNames` two error are thrown, which include error with `pattern` keyword
+            // so check whether error with `pattern` keyword is thrown for `propertyNames` keyword violation
+            if (validationError.keyword === 'pattern') {
+              return !_.has(validationError, 'propertyName');
+            }
+            return !_.includes(['propertyNames', 'const'], validationError.keyword);
+          });
+
+          if (!_.isEmpty(filteredValidationError)) {
+            let mismatchObj,
+              fakedValue;
+
             // Show detailed validation mismatches for only request/response body
             if (options.detailedBlobValidation && needJsonMatching) {
-              _.forEach(validate.errors, (ajvError) => {
-                mismatches.push(_.assign({
+              fakedValue = safeSchemaFaker(openApiSchemaObj || {}, 'example', PROCESSING_TYPE.VALIDATION,
+                parameterSourceOption, components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache);
+
+              _.forEach(filteredValidationError, (ajvError) => {
+                let localSchemaPath = ajvError.schemaPath.replace(/\//g, '.').slice(2);
+
+                mismatchObj = _.assign({
                   property: property,
                   transactionJsonPath: jsonPathPrefix + ajvError.dataPath,
-                  schemaJsonPath: schemaPathPrefix + ajvError.schemaPath.replace(/\//g, '.').slice(1)
-                }, ajvValidationError(ajvError, { property, humanPropName })));
+                  schemaJsonPath: schemaPathPrefix + '.' + localSchemaPath
+                }, ajvValidationError(ajvError, { property, humanPropName }));
+
+                if (options.suggestAvailableFixes) {
+                  mismatchObj.suggestedFix = {
+                    key: _.split(ajvError.dataPath, '.').pop(),
+                    actualValue: _.get(valueToUse, ajvError.dataPath.slice(1), 'ERR'),
+                    suggestedValue: this.getSuggestedValue(fakedValue, valueToUse, ajvError)
+                  };
+                }
+                mismatches.push(mismatchObj);
               });
             }
             else {
-              let mismatchObj = {
+              mismatchObj = {
                 reason: 'The property didn\'t match the specified schema',
                 reasonCode: 'INVALID_TYPE'
               };
@@ -2329,6 +2385,15 @@ module.exports = {
               if (property === 'BODY') {
                 mismatchObj.reason = 'The request body didn\'t match the specified schema';
                 mismatchObj.reasonCode = 'INVALID_BODY';
+              }
+
+              if (options.suggestAvailableFixes) {
+                mismatchObj.suggestedFix = {
+                  key: property.toLowerCase(),
+                  actualValue: valueToUse,
+                  suggestedValue: safeSchemaFaker(openApiSchemaObj || {}, 'example', PROCESSING_TYPE.VALIDATION,
+                    parameterSourceOption, components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache)
+                };
               }
 
               mismatches.push(_.assign({
@@ -2343,7 +2408,23 @@ module.exports = {
           }
           // result passed. No AJV mismatch
         }
+
         // Schema was not AJV or object
+        // Req/Res Body was non-object but content type is application/json
+        else if (needJsonMatching) {
+          return callback(null, [{
+            property,
+            transactionJsonPath: jsonPathPrefix,
+            schemaJsonPath: schemaPathPrefix,
+            reasonCode: 'INVALID_TYPE',
+            reason: `The ${humanPropName} needs to be of type object/array, but we found "${valueToUse}"`,
+            suggestedFix: {
+              key: null,
+              actualValue: valueToUse,
+              suggestedValue: {} // suggest value to be object
+            }
+          }]);
+        }
       }
       else {
         // unknown schema.type found
@@ -2375,7 +2456,7 @@ module.exports = {
    * @param {*} schemaPath the applicable pathItem defined at the schema level
    * @param {*} components the components + paths from the OAS spec that need to be used to resolve $refs
    * @param {*} options OAS options
-   * @param {*} schemaResolutionCache cache used to store resolved schemas
+   * @param {*} schemaCache object storing schemaFaker and schmeResolution caches
    * @param {*} callback Callback
    * @returns {array} mismatches (in the callback)
    */
@@ -2385,7 +2466,7 @@ module.exports = {
     schemaPath,
     components,
     options,
-    schemaResolutionCache,
+    schemaCache,
     callback) {
 
     // schema path should have all parameters needed
@@ -2403,7 +2484,7 @@ module.exports = {
       return (param.in === 'path');
     });
 
-    async.map(determinedPathVariables, (pathVar, cb) => {
+    async.eachOf(determinedPathVariables, (pathVar, index, cb) => {
       let mismatches = [];
 
       schemaPathVar = _.find(schemaPathVariables, (param) => {
@@ -2416,10 +2497,10 @@ module.exports = {
           mismatches.push({
             property: mismatchProperty,
             // not adding the pathVar name to the jsonPath because URL is just a string
-            transactionJsonPath: transactionPathPrefix,
+            transactionJsonPath: transactionPathPrefix + `[${index}]`,
             schemaJsonPath: null,
             reasonCode: 'MISSING_IN_SCHEMA',
-            reason: `The path variable ${pathVar.key} was not found in the schema`
+            reason: `The path variable "${pathVar.key}" was not found in the schema`
           });
         }
         return cb(null, mismatches);
@@ -2432,16 +2513,17 @@ module.exports = {
         }
 
         this.checkValueAgainstSchema(mismatchProperty,
-          transactionPathPrefix,
+          transactionPathPrefix + `[${index}]`,
           pathVar.key,
           pathVar.value,
           schemaPathVar.pathPrefix + '[?(@.name==\'' + schemaPathVar.name + '\')]',
-          deref.resolveRefs(schemaPathVar.schema, 'request', components, schemaResolutionCache,
-            PROCESSING_TYPE.VALIDATION),
-          components, options, cb);
+          schemaPathVar.schema,
+          'REQUEST',
+          components, options, schemaCache, cb);
       }, 0);
     }, (err, res) => {
-      let mismatches = [];
+      let mismatches = [],
+        mismatchObj;
 
       if (err) {
         return callback(err);
@@ -2450,13 +2532,23 @@ module.exports = {
       // go through required schemaPathVariables, and params that aren't found in the given transaction are errors
       _.each(schemaPathVariables, (pathVar) => {
         if (!_.find(determinedPathVariables, (param) => { return param.key === pathVar.name; })) {
-          mismatches.push({
+          mismatchObj = {
             property: mismatchProperty,
             transactionJsonPath: null,
             schemaJsonPath: pathVar.pathPrefix,
             reasonCode: 'MISSING_IN_REQUEST',
             reason: `The required path variable "${pathVar.name}" was not found in the transaction`
-          });
+          };
+
+          if (options.suggestAvailableFixes) {
+            mismatchObj.suggestedFix = {
+              key: pathVar.name,
+              actualValue: null,
+              suggestedValue: safeSchemaFaker(pathVar.schema || {}, 'example', PROCESSING_TYPE.VALIDATION,
+                PARAMETER_SOURCE.REQUEST, components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache)
+            };
+          }
+          mismatches.push(mismatchObj);
         }
       });
 
@@ -2466,7 +2558,7 @@ module.exports = {
   },
 
   checkQueryParams(requestUrl, transactionPathPrefix, schemaPath, components, options,
-    schemaResolutionCache, callback) {
+    schemaCache, callback) {
     let parsedUrl = require('url').parse(requestUrl),
       schemaParams = _.filter(schemaPath.parameters, (param) => { return param.in === 'query'; }),
       requestQueryArray = [],
@@ -2509,7 +2601,7 @@ module.exports = {
       return callback(urlMalformedError);
     }
 
-    return async.map(requestQueryParams, (pQuery, cb) => {
+    return async.eachOf(requestQueryParams, (pQuery, index, cb) => {
       let mismatches = [];
       const schemaParam = _.find(schemaParams, (param) => { return param.name === pQuery.key; });
 
@@ -2518,7 +2610,7 @@ module.exports = {
         if (options.showMissingInSchemaErrors) {
           mismatches.push({
             property: mismatchProperty,
-            transactionJsonPath: transactionPathPrefix + '[?(@.key==\'' + pQuery.key + '\')]',
+            transactionJsonPath: transactionPathPrefix + `[${index}]`,
             schemaJsonPath: null,
             reasonCode: 'MISSING_IN_SCHEMA',
             reason: `The query parameter ${pQuery.key} was not found in the schema`
@@ -2534,27 +2626,38 @@ module.exports = {
           return cb(null, []);
         }
         this.checkValueAgainstSchema(mismatchProperty,
-          transactionPathPrefix + '[?(@.key==\'' + pQuery.key + '\')]',
+          transactionPathPrefix + `[${index}]`,
           pQuery.key,
           pQuery.value,
           schemaParam.pathPrefix + '[?(@.name==\'' + schemaParam.name + '\')]',
-          deref.resolveRefs(schemaParam.schema, 'request', components, schemaResolutionCache,
-            PROCESSING_TYPE.VALIDATION),
-          components, options,
-          cb
+          schemaParam.schema,
+          'REQUEST',
+          components, options, schemaCache, cb
         );
       }, 0);
     }, (err, res) => {
-      let mismatches = [];
+      let mismatches = [],
+        mismatchObj;
+
       _.each(_.filter(schemaParams, (q) => { return q.required; }), (qp) => {
         if (!_.find(requestQueryParams, (param) => { return param.key === qp.name; })) {
-          mismatches.push({
+          mismatchObj = {
             property: mismatchProperty,
             transactionJsonPath: null,
             schemaJsonPath: qp.pathPrefix + '[?(@.name==\'' + qp.name + '\')]',
             reasonCode: 'MISSING_IN_REQUEST',
             reason: `The required query parameter "${qp.name}" was not found in the transaction`
-          });
+          };
+
+          if (options.suggestAvailableFixes) {
+            mismatchObj.suggestedFix = {
+              key: qp.name,
+              actualValue: null,
+              suggestedValue: safeSchemaFaker(qp.schema || {}, 'example', PROCESSING_TYPE.VALIDATION,
+                PARAMETER_SOURCE.REQUEST, components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache)
+            };
+          }
+          mismatches.push(mismatchObj);
         }
       });
       return callback(null, _.concat(_.flatten(res), mismatches));
@@ -2562,7 +2665,7 @@ module.exports = {
   },
 
   checkRequestHeaders: function (headers, transactionPathPrefix, schemaPath, components, options,
-    schemaResolutionCache, callback) {
+    schemaCache, callback) {
     let schemaHeaders = _.filter(schemaPath.parameters, (param) => { return param.in === 'header'; }),
       mismatchProperty = 'HEADER';
 
@@ -2571,7 +2674,7 @@ module.exports = {
     }
     // 1. for each header, find relevant schemaPath property
 
-    return async.map(headers, (pHeader, cb) => {
+    return async.eachOf(headers, (pHeader, index, cb) => {
       let mismatches = [];
       const schemaHeader = _.find(schemaHeaders, (header) => { return header.name === pHeader.key; });
 
@@ -2580,7 +2683,7 @@ module.exports = {
         if (options.showMissingInSchemaErrors) {
           mismatches.push({
             property: mismatchProperty,
-            transactionJsonPath: transactionPathPrefix + '[?(@.key==\'' + pHeader.key + '\')]',
+            transactionJsonPath: transactionPathPrefix + `[${index}]`,
             schemaJsonPath: null,
             reasonCode: 'MISSING_IN_SCHEMA',
             reason: `The header ${pHeader.key} was not found in the schema`
@@ -2596,27 +2699,38 @@ module.exports = {
           return cb(null, []);
         }
         this.checkValueAgainstSchema(mismatchProperty,
-          transactionPathPrefix + '[?(@.key==\'' + pHeader.key + '\')]',
+          transactionPathPrefix + `[${index}]`,
           pHeader.key,
           pHeader.value,
           schemaHeader.pathPrefix + '[?(@.name==\'' + schemaHeader.name + '\')]',
-          deref.resolveRefs(schemaHeader.schema, 'request', components, schemaResolutionCache,
-            PROCESSING_TYPE.VALIDATION),
-          components, options,
-          cb
+          schemaHeader.schema,
+          'REQUEST',
+          components, options, schemaCache, cb
         );
       }, 0);
     }, (err, res) => {
-      let mismatches = [];
+      let mismatches = [],
+        mismatchObj;
+
       _.each(_.filter(schemaHeaders, (h) => { return h.required; }), (header) => {
         if (!_.find(headers, (param) => { return param.key === header.name; })) {
-          mismatches.push({
+          mismatchObj = {
             property: mismatchProperty,
             transactionJsonPath: null,
             schemaJsonPath: header.pathPrefix + '[?(@.name==\'' + header.name + '\')]',
             reasonCode: 'MISSING_IN_REQUEST',
             reason: `The required header "${header.name}" was not found in the transaction`
-          });
+          };
+
+          if (options.suggestAvailableFixes) {
+            mismatchObj.suggestedFix = {
+              key: header.name,
+              actualValue: null,
+              suggestedValue: safeSchemaFaker(header.schema || {}, 'example', PROCESSING_TYPE.VALIDATION,
+                PARAMETER_SOURCE.REQUEST, components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache)
+            };
+          }
+          mismatches.push(mismatchObj);
         }
       });
       return callback(null, _.concat(_.flatten(res), mismatches));
@@ -2624,7 +2738,7 @@ module.exports = {
   },
 
   checkResponseHeaders: function (schemaResponse, headers, transactionPathPrefix, schemaPathPrefix,
-    components, options, schemaResolutionCache, callback) {
+    components, options, schemaCache, callback) {
     // 0. Need to find relevant response from schemaPath.responses
     let schemaHeaders,
       mismatchProperty = 'RESPONSE_HEADER';
@@ -2641,7 +2755,7 @@ module.exports = {
 
     schemaHeaders = schemaResponse.headers;
 
-    return async.map(headers, (pHeader, cb) => {
+    return async.eachOf(headers, (pHeader, index, cb) => {
       let mismatches = [];
       const schemaHeader = schemaHeaders[pHeader.key];
 
@@ -2650,7 +2764,7 @@ module.exports = {
         if (options.showMissingInSchemaErrors) {
           mismatches.push({
             property: mismatchProperty,
-            transactionJsonPath: transactionPathPrefix + '/' + pHeader.key,
+            transactionJsonPath: transactionPathPrefix + `[${index}]`,
             schemaJsonPath: schemaPathPrefix + '.headers',
             reasonCode: 'MISSING_IN_SCHEMA',
             reason: `The header ${pHeader.key} was not found in the schema`
@@ -2666,19 +2780,19 @@ module.exports = {
           return cb(null, []);
         }
         return this.checkValueAgainstSchema(mismatchProperty,
-          transactionPathPrefix + '/' + pHeader.key,
+          transactionPathPrefix + `[${index}]`,
           pHeader.key,
           pHeader.value,
           schemaPathPrefix + '.headers[' + pHeader.key + ']',
-          deref.resolveRefs(schemaHeader.schema, 'response', components, schemaResolutionCache,
-            PROCESSING_TYPE.VALIDATION),
-          components,
-          options,
-          cb
+          schemaHeader.schema,
+          'RESPONSE',
+          components, options, schemaCache, cb
         );
       }, 0);
     }, (err, res) => {
-      let mismatches = [];
+      let mismatches = [],
+        mismatchObj;
+
       _.each(_.filter(schemaHeaders, (h, hName) => {
         h.name = hName;
         return h.required;
@@ -2691,6 +2805,16 @@ module.exports = {
             reasonCode: 'MISSING_IN_REQUEST',
             reason: `The required response header "${header.name}" was not found in the transaction`
           });
+
+          if (options.suggestAvailableFixes) {
+            mismatchObj.suggestedFix = {
+              key: header.key,
+              actualValue: null,
+              suggestedValue: safeSchemaFaker(header.schema || {}, 'example', PROCESSING_TYPE.VALIDATION,
+                PARAMETER_SOURCE.REQUEST, components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache)
+            };
+          }
+          mismatches.push(mismatchObj);
         }
       });
       callback(null, _.concat(_.flatten(res), mismatches));
@@ -2699,7 +2823,7 @@ module.exports = {
 
   // Only application/json is validated for now
   checkRequestBody: function (requestBody, transactionPathPrefix, schemaPathPrefix, schemaPath,
-    components, options, schemaResolutionCache, callback) {
+    components, options, schemaCache, callback) {
     // check for body modes
     // TODO: The application/json can be anything that's application/*+json
     let jsonSchemaBody = _.get(schemaPath, ['requestBody', 'content', 'application/json', 'schema']),
@@ -2717,10 +2841,11 @@ module.exports = {
           null, // no param name for the request body
           requestBody.raw,
           schemaPathPrefix + '.requestBody.content[application/json].schema',
-          deref.resolveRefs(jsonSchemaBody, 'request', components, schemaResolutionCache,
-            PROCESSING_TYPE.VALIDATION),
+          jsonSchemaBody,
+          'REQUEST',
           components,
           _.extend({}, options, { shortValidationErrors: true }),
+          schemaCache,
           callback
         );
       }, 0);
@@ -2731,7 +2856,7 @@ module.exports = {
   },
 
   checkResponseBody: function (schemaResponse, body, transactionPathPrefix, schemaPathPrefix,
-    components, options, schemaResolutionCache, callback) {
+    components, options, schemaCache, callback) {
     let schemaContent = _.get(schemaResponse, ['content', 'application/json', 'schema']),
       mismatchProperty = 'RESPONSE_BODY';
 
@@ -2759,17 +2884,18 @@ module.exports = {
         null, // no param name for the response body
         body,
         schemaPathPrefix + '.content[application/json].schema',
-        deref.resolveRefs(schemaContent, 'response', components, schemaResolutionCache,
-          PROCESSING_TYPE.VALIDATION),
+        schemaContent,
+        'RESPONSE',
         components,
         _.extend({}, options, { shortValidationErrors: true }),
+        schemaCache,
         callback
       );
     }, 0);
   },
 
   checkResponses: function (responses, transactionPathPrefix, schemaPathPrefix, schemaPath,
-    components, options, schemaResolutionCache, cb) {
+    components, options, schemaCache, cb) {
     // responses is an array of repsonses recd. for one Postman request
     // we've already determined the schemaPath against which all responses need to be validated
     // loop through all responses
@@ -2795,13 +2921,13 @@ module.exports = {
           headers: (cb) => {
             this.checkResponseHeaders(thisSchemaResponse, response.header,
               transactionPathPrefix + '[' + response.id + '].header',
-              schemaPathPrefix + '.responses.' + responsePathPrefix, components, options, schemaResolutionCache, cb);
+              schemaPathPrefix + '.responses.' + responsePathPrefix, components, options, schemaCache, cb);
           },
           body: (cb) => {
             // assume it's JSON at this point
             this.checkResponseBody(thisSchemaResponse, response.body,
               transactionPathPrefix + '[' + response.id + '].body',
-              schemaPathPrefix + '.responses.' + responsePathPrefix, components, options, schemaResolutionCache, cb);
+              schemaPathPrefix + '.responses.' + responsePathPrefix, components, options, schemaCache, cb);
           }
         }, (err, result) => {
           return responseCallback(null, {
@@ -2924,5 +3050,48 @@ module.exports = {
       score: null,
       pathVars: []
     };
+  },
+
+  getSuggestedValue: function (fakedValue, actualValue, ajvValidationErrorObj) {
+    var suggestedValue,
+      tempSuggestedValue,
+      dataPath = ajvValidationErrorObj.dataPath.slice(1),
+      targetActualValue = _.get(actualValue, dataPath, {}),
+      targetFakedValue = _.get(fakedValue, dataPath, {});
+
+    switch (ajvValidationErrorObj.keyword) {
+
+      // to do: check for minItems, maxItems
+
+      case 'minProperties':
+        suggestedValue = _.assign({}, targetActualValue,
+          _.pick(targetFakedValue, _.difference(_.keys(targetFakedValue), _.keys(targetActualValue))));
+        break;
+
+      case 'maxProperties':
+        suggestedValue = _.pick(targetActualValue, _.intersection(_.keys(targetActualValue), _.keys(targetFakedValue)));
+        break;
+
+      // to do: check for multiple i j ones
+      case 'dependencies':
+      case 'required':
+        suggestedValue = _.assign({}, targetActualValue,
+          _.pick(targetFakedValue, ajvValidationErrorObj.params.missingProperty));
+        break;
+
+      // to do: check for multiple i j ones
+      case 'uniqueItems':
+        tempSuggestedValue = _.cloneDeep(targetActualValue);
+        tempSuggestedValue[ajvValidationErrorObj.params.j] = targetFakedValue[ajvValidationErrorObj.params.j];
+        suggestedValue = tempSuggestedValue;
+        break;
+
+      // minLength, maxLength, format, const, minimum, maximum, type, multipleOf, pattern,
+      default:
+        suggestedValue = _.get(fakedValue, dataPath, 'ERR');
+        break;
+    }
+
+    return suggestedValue;
   }
 };

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2583,7 +2583,7 @@ module.exports = {
       expectedReqDesc,
       reqNameMismatch,
       actualReqName = _.get(transaction, 'name'),
-      actualReqDesc = _.get(transaction, 'request.name'),
+      actualReqDesc = _.get(transaction, 'request.description'),
       mismatches = [],
       mismatchObj,
       reqUrl;

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2494,8 +2494,9 @@ module.exports = {
       return (param.in === 'path');
     });
 
-    async.eachOf(determinedPathVariables, (pathVar, index, cb) => {
-      let mismatches = [];
+    async.map(determinedPathVariables, (pathVar, cb) => {
+      let mismatches = [],
+        index = _.findIndex(determinedPathVariables, pathVar);
 
       schemaPathVar = _.find(schemaPathVariables, (param) => {
         return param.name === pathVar.key;
@@ -2611,8 +2612,10 @@ module.exports = {
       return callback(urlMalformedError);
     }
 
-    return async.eachOf(requestQueryParams, (pQuery, index, cb) => {
-      let mismatches = [];
+    return async.map(requestQueryParams, (pQuery, cb) => {
+      let mismatches = [],
+        index = _.findIndex(requestQueryParams, pQuery);
+
       const schemaParam = _.find(schemaParams, (param) => { return param.name === pQuery.key; });
 
       if (!schemaParam) {
@@ -2684,8 +2687,10 @@ module.exports = {
     }
     // 1. for each header, find relevant schemaPath property
 
-    return async.eachOf(headers, (pHeader, index, cb) => {
-      let mismatches = [];
+    return async.map(headers, (pHeader, cb) => {
+      let mismatches = [],
+        index = _.findIndex(headers, pHeader);
+
       const schemaHeader = _.find(schemaHeaders, (header) => { return header.name === pHeader.key; });
 
       if (!schemaHeader) {
@@ -2765,8 +2770,10 @@ module.exports = {
 
     schemaHeaders = schemaResponse.headers;
 
-    return async.eachOf(headers, (pHeader, index, cb) => {
-      let mismatches = [];
+    return async.map(headers, (pHeader, cb) => {
+      let mismatches = [],
+        index = _.findIndex(headers, pHeader);
+
       const schemaHeader = schemaHeaders[pHeader.key];
 
       if (!schemaHeader) {

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2808,13 +2808,13 @@ module.exports = {
         return h.required;
       }), (header) => {
         if (!_.find(headers, (param) => { return param.key === header.name; })) {
-          mismatches.push({
+          mismatchObj = {
             property: mismatchProperty,
             transactionJsonPath: null,
             schemaJsonPath: schemaPathPrefix + '.headers[\'' + header.name + '\']',
             reasonCode: 'MISSING_IN_REQUEST',
             reason: `The required response header "${header.name}" was not found in the transaction`
-          });
+          };
 
           if (options.suggestAvailableFixes) {
             mismatchObj.suggestedFix = {

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2583,7 +2583,7 @@ module.exports = {
       expectedReqDesc,
       reqNameMismatch,
       actualReqName = _.get(transaction, 'name'),
-      actualReqDesc = _.get(transaction, 'request.description'),
+      actualReqDesc,
       mismatches = [],
       mismatchObj,
       reqUrl;
@@ -2599,6 +2599,10 @@ module.exports = {
     // convert all /{{one}}/{{two}} to /:one/:two
     // Doesn't touch /{{file}}.{{format}}
     reqUrl = this.sanitizeUrlPathParams(reqUrl, []).url;
+
+    // description can be one of following two
+    actualReqDesc = _.isObject(_.get(transaction, 'request.description')) ?
+      _.get(transaction, 'request.description.content') : _.get(transaction, 'request.description');
     expectedReqDesc = schemaPath.description;
 
     switch (options.requestNameSource) {

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -375,6 +375,9 @@ class SchemaPack {
           return async.map(matchedPaths, (matchedPath, pathsCallback) => {
             // 3. validation involves checking these individual properties
             async.parallel({
+              metadata: function(cb) {
+                schemaUtils.checkMetadata(transaction, '$', matchedPath.path, matchedPath.name, options, cb);
+              },
               path: function(cb) {
                 schemaUtils.checkPathVariables(matchedPath.pathVariables, '$.request.url.variable', matchedPath.path,
                   componentsAndPaths, options, schemaCache, cb);
@@ -396,7 +399,8 @@ class SchemaPack {
                   matchedPath.path, componentsAndPaths, options, schemaCache, cb);
               }
             }, (err, result) => {
-              let allMismatches = _.concat(result.queryparams, result.headers, result.path, result.requestBody),
+              let allMismatches = _.concat(result.metadata, result.queryparams, result.headers, result.path,
+                  result.requestBody),
                 responseMismatchesPresent = false,
                 retVal;
 

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -309,7 +309,11 @@ class SchemaPack {
     let schema = this.openapi,
       componentsAndPaths,
       options = this.computedOptions,
-      schemaResolutionCache = this.schemaResolutionCache;
+      schemaCache = {
+        schemaResolutionCache: this.schemaResolutionCache,
+        schemaFakerCache: this.schemaFakerCache
+      };
+      // schemaResolutionCache = this.schemaResolutionCache;
 
 
     if (!this.validated) {
@@ -372,24 +376,24 @@ class SchemaPack {
             // 3. validation involves checking these individual properties
             async.parallel({
               path: function(cb) {
-                schemaUtils.checkPathVariables(matchedPath.pathVariables, '$.request.url', matchedPath.path,
-                  componentsAndPaths, options, schemaResolutionCache, cb);
+                schemaUtils.checkPathVariables(matchedPath.pathVariables, '$.request.url.variable', matchedPath.path,
+                  componentsAndPaths, options, schemaCache, cb);
               },
               queryparams: function(cb) {
                 schemaUtils.checkQueryParams(requestUrl, '$.request.url.query', matchedPath.path,
-                  componentsAndPaths, options, schemaResolutionCache, cb);
+                  componentsAndPaths, options, schemaCache, cb);
               },
               headers: function(cb) {
                 schemaUtils.checkRequestHeaders(transaction.request.header, '$.request.header', matchedPath.path,
-                  componentsAndPaths, options, schemaResolutionCache, cb);
+                  componentsAndPaths, options, schemaCache, cb);
               },
               requestBody: function(cb) {
                 schemaUtils.checkRequestBody(transaction.request.body, '$.request.body', matchedPath.jsonPath,
-                  matchedPath.path, componentsAndPaths, options, schemaResolutionCache, cb);
+                  matchedPath.path, componentsAndPaths, options, schemaCache, cb);
               },
               responses: function (cb) {
                 schemaUtils.checkResponses(transaction.response, '$.responses', matchedPath.jsonPath,
-                  matchedPath.path, componentsAndPaths, options, schemaResolutionCache, cb);
+                  matchedPath.path, componentsAndPaths, options, schemaCache, cb);
               }
             }, (err, result) => {
               let allMismatches = _.concat(result.queryparams, result.headers, result.path, result.requestBody),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-to-postmanv2",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-to-postmanv2",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "description": "Convert a given OpenAPI specification to Postman Collection v2.0",
   "homepage": "https://github.com/postmanlabs/openapi-to-postman",
   "bugs": "https://github.com/postmanlabs/openapi-to-postman/issues",

--- a/test/system/structure.test.js
+++ b/test/system/structure.test.js
@@ -12,7 +12,8 @@ const optionIds = [
     'validationPropertiesToIgnore',
     'showMissingInSchemaErrors',
     'detailedBlobValidation',
-    'suggestAvailableFixes'
+    'suggestAvailableFixes',
+    'validateMetadata'
   ],
   expectedOptions = {
     collapseFolders: {
@@ -99,6 +100,12 @@ const optionIds = [
       type: 'boolean',
       default: false,
       description: 'Whether to provide fixes for patching corresponding mismatches.'
+    },
+    validateMetadata: {
+      name: 'Show Metadata validation messages',
+      type: 'boolean',
+      default: false,
+      description: 'Whether to show mismatches for incorrect name and description of request'
     }
   };
 

--- a/test/system/structure.test.js
+++ b/test/system/structure.test.js
@@ -11,7 +11,8 @@ const optionIds = [
     'shortValidationErrors',
     'validationPropertiesToIgnore',
     'showMissingInSchemaErrors',
-    'detailedBlobValidation'
+    'detailedBlobValidation',
+    'suggestAvailableFixes'
   ],
   expectedOptions = {
     collapseFolders: {
@@ -92,6 +93,12 @@ const optionIds = [
       default: false,
       description: 'Determines whether to show detailed mismatch information for application/json content ' +
         'in the request/response body.'
+    },
+    suggestAvailableFixes: {
+      name: 'Suggest fixes if available',
+      type: 'boolean',
+      default: false,
+      description: 'Whether to provide fixes for patching corresponding mismatches.'
     }
   };
 

--- a/test/unit/deref.test.js
+++ b/test/unit/deref.test.js
@@ -117,8 +117,7 @@ describe('DEREF FUNCTION TESTS ', function() {
     expect(output_validationTypeArray).to.deep.include({
       type: 'array',
       items: {
-        type: 'string',
-        default: '<string>'
+        type: 'string'
       },
       minItems: 5,
       maxItems: 55

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -66,9 +66,11 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           }
         },
         parameterSource = 'REQUEST',
-        resolveTo = 'schema';
+        resolveTo = 'schema',
+        resolveFor = 'CONVERSION';
 
-      expect(SchemaUtils.safeSchemaFaker(schema, resolveTo, parameterSource, { components })).to.equal('<string>');
+      expect(SchemaUtils.safeSchemaFaker(schema, resolveTo, resolveFor, parameterSource, { components }))
+        .to.equal('<string>');
       done();
     });
 
@@ -96,8 +98,9 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         },
         parameterSource = 'REQUEST',
         resolveTo = 'schema',
+        resolveFor = 'CONVERSION',
 
-        result = SchemaUtils.safeSchemaFaker(schema, resolveTo, parameterSource, { components }),
+        result = SchemaUtils.safeSchemaFaker(schema, resolveTo, resolveFor, parameterSource, { components }),
         tooManyLevelsString = result[0].c.value;
 
       expect(result).to.not.equal(null);
@@ -135,7 +138,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         },
         parameterSource = 'REQUEST',
         resolveTo = 'schema',
-        fakedSchema = SchemaUtils.safeSchemaFaker(schema, resolveTo, parameterSource, { components });
+        resolveFor = 'CONVERSION',
+        fakedSchema = SchemaUtils.safeSchemaFaker(schema, resolveTo, resolveFor, parameterSource, { components });
 
       expect(fakedSchema.value).to.equal('reference #/components/schem2 not found in the OpenAPI spec');
       done();
@@ -158,13 +162,14 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         },
         parameterSource = 'REQUEST',
         resolveTo = 'schema',
-        resolvedSchema = deref.resolveRefs(schema, parameterSource, { components }, {}),
+        resolveFor = 'CONVERSION',
+        resolvedSchema = deref.resolveRefs(schema, parameterSource, { components }, {}, resolveFor),
         schemaCache = {
           schemaFakerCache: {},
           schemaResolutionCache: {}
         },
         key = hash('resolveToSchema ' + JSON.stringify(resolvedSchema)),
-        fakedSchema = SchemaUtils.safeSchemaFaker(schema, resolveTo, parameterSource,
+        fakedSchema = SchemaUtils.safeSchemaFaker(schema, resolveTo, resolveFor, parameterSource,
           { components }, 'default', '  ', schemaCache);
 
       expect(schemaCache.schemaFakerCache).to.have.property(key);
@@ -194,13 +199,15 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         },
         parameterSource = 'RESPONSE',
         resolveTo = 'example',
+        resolveFor = 'CONVERSION',
         schemaCache = {
           schemaFakerCache: {},
           schemaResolutionCache: {}
         },
-        resolvedSchema = deref.resolveRefs(schema, parameterSource, { components }, schemaCache.schemaResolutionCache),
+        resolvedSchema = deref.resolveRefs(schema, parameterSource, { components }, schemaCache.schemaResolutionCache,
+          resolveFor),
         key = hash('resolveToExample ' + JSON.stringify(resolvedSchema)),
-        fakedSchema = SchemaUtils.safeSchemaFaker(schema, resolveTo, parameterSource,
+        fakedSchema = SchemaUtils.safeSchemaFaker(schema, resolveTo, resolveFor, parameterSource,
           { components }, 'default', '  ', schemaCache);
 
       expect(schemaCache.schemaFakerCache).to.have.property(key);


### PR DESCRIPTION
This PR includes support for validating metadata (request name and description for now) with an option `validateMetadata`.