### PR TITLE
#204 Path variables example support

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -761,13 +761,21 @@ module.exports = {
     }
     else {
       _.forEach(commonPathVars, (variable) => {
-        let description = this.getParameterDescription(variable);
+        let description = this.getParameterDescription(variable),
+          paramValue = options.schemaFaker ?
+            safeSchemaFaker(variable.schema || {}, 'schema', components, 'REQUEST',
+              SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache) : '';
+
+        // Use path variable example value as param value
+        // Reference to https://github.com/postmanlabs/openapi-to-postman/issues/204
+        if (options.requestParametersResolution === 'example' && variable.schema && variable.schema.example) {
+          paramValue = variable.schema.example;
+        }
+
         variables.push({
           key: variable.name,
           // we only fake the schema for param-level pathVars
-          value: options.schemaFaker ?
-            safeSchemaFaker(variable.schema || {}, 'schema', components, 'REQUEST',
-              SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache) : '',
+          value: paramValue,
           description: description
         });
       });


### PR DESCRIPTION
#204 Added support for path variables, using examples based on the configuration option "requestParametersResolution"

To support the proper usage, it would suggested to allow the management convertion configurations using a "config" file, like proposed in https://github.com/postmanlabs/openapi-to-postman/pull/218