### PR TITLE
Use faked value for example if example is invalid.

### DIFF
--- a/assets/json-schema-faker.js
+++ b/assets/json-schema-faker.js
@@ -10,6 +10,8 @@
  * Date: 2018-04-09 17:23:23.954Z
  */
 
+var validateSchema = require('../lib/ajvValidation').validateSchema;
+
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
   typeof define === 'function' && define.amd ? define(factory) :
@@ -24547,7 +24549,12 @@ function extend() {
           return;
       }
       if (optionAPI('useExamplesValue') && 'example' in schema) {
-        return schema.example;
+        var result = validateSchema(schema, schema.example);
+
+        // Use example only if valid 
+        if (result && result.length === 0) {
+          return schema.example;
+        }
       }
       if (optionAPI('useDefaultValue') && 'default' in schema) {
           return schema.default;

--- a/lib/ajvValidation.js
+++ b/lib/ajvValidation.js
@@ -1,0 +1,89 @@
+var _ = require('lodash'),
+  Ajv = require('ajv');
+
+// Following keyword are supoorted for Ajv but not by OAS
+const IGNORED_KEYWORDS = ['propertyNames', 'const', 'additionalItems', 'dependencies'];
+
+/**
+ * Checks if value is postman variable or not
+ *
+ * @param {*} value - Value to check for
+ * @returns {Boolean} postman variable or not
+ */
+function isPmVariable (value) {
+  // collection/environment variables are in format - {{var}}
+  return _.isString(value) && _.startsWith(value, '{{') && _.endsWith(value, '}}');
+}
+
+/**
+ * Used to validate schema against a value.
+ * NOTE: Used in assets/json-schema-faker.js to validate schema example
+ *
+ * @param {*} schema - schema to validate
+ * @param {*} valueToUse - value to validate schema against
+ * @param {*} options - a standard list of options that's globally passed around. Check options.js for more.
+ * @returns {*} - Found Validation Errors
+ */
+function validateSchema (schema, valueToUse, options = {}) {
+  var ajv,
+    validate,
+    filteredValidationError;
+
+  try {
+    // add Ajv options to support validation of OpenAPI schema.
+    // For more details see https://ajv.js.org/#options
+    ajv = new Ajv({
+      // the unknown formats are ones that are allowed in OAS, but not JSON schema.
+      unknownFormats: ['int32', 'int64'],
+
+      // check all rules collecting all errors. instead returning after the first error.
+      allErrors: true,
+
+      // supports keyword "nullable" from Open API 3 specification.
+      nullable: true
+    });
+    validate = ajv.compile(schema);
+    validate(valueToUse);
+  }
+  catch (e) {
+    // something went wrong validating the schema
+    // input was invalid. Don't throw mismatch
+    return filteredValidationError;
+  }
+
+  // Filter validation errors for following cases
+  filteredValidationError = _.filter(_.get(validate, 'errors', []), (validationError) => {
+    let dataPath = _.get(validationError, 'dataPath', '');
+
+    // discard the leading '.' if it exists
+    if (dataPath[0] === '.') {
+      dataPath = dataPath.slice(1);
+    }
+
+    // for invalid `propertyNames` two error are thrown by Ajv, which include error with `pattern` keyword
+    if (validationError.keyword === 'pattern') {
+      return !_.has(validationError, 'propertyName');
+    }
+
+    // As OAS only supports some of Json Schema keywords, and Ajv is supporting all keywords from Draft 7
+    // Remove keyword currently not supported in OAS to make both compatible with each other
+    else if (_.includes(IGNORED_KEYWORDS, validationError.keyword)) {
+      return false;
+    }
+
+    // Ignore unresolved variables from mismatch if option is set
+    else if (options.ignoreUnresolvedVariables && isPmVariable(_.get(valueToUse, dataPath))) {
+      return false;
+    }
+    return true;
+  });
+
+  // sort errors based on dataPath, as this will ensure no overriding later
+  filteredValidationError = _.sortBy(filteredValidationError, ['dataPath']);
+
+  return filteredValidationError;
+}
+
+module.exports = {
+  validateSchema
+};

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -55,12 +55,14 @@ module.exports = {
    * @param {*} components components in openapi spec.
    * @param {object} schemaResolutionCache stores already resolved references
    * @param {*} resolveFor - resolve refs for validation/conversion (value to be one of VALIDATION/CONVERSION)
+   * @param {string} resolveTo The desired JSON-generation mechanism (schema: prefer using the JSONschema to
+    generate a fake object, example: use specified examples as-is). Default: schema
    * @param {*} stack counter which keeps a tab on nested schemas
    * @param {*} seenRef References that are repeated. Used to identify circular references.
    * @returns {*} schema - schema that adheres to all individual schemas in schemaArr
    */
   resolveAllOf: function (schemaArr, parameterSourceOption, components, schemaResolutionCache,
-    resolveFor = 'CONVERSION', stack = 0, seenRef) {
+    resolveFor = 'CONVERSION', resolveTo = 'schema', stack = 0, seenRef) {
 
     if (!(schemaArr instanceof Array)) {
       return null;
@@ -69,13 +71,13 @@ module.exports = {
     if (schemaArr.length === 1) {
       // for just one entry in allOf, don't need to enforce type: object restriction
       return this.resolveRefs(schemaArr[0], parameterSourceOption, components, schemaResolutionCache, resolveFor,
-        stack, seenRef);
+        resolveTo, stack, seenRef);
     }
 
     // generate one object for each schema
     let indivObjects = schemaArr.map((schema) => {
         return this.resolveRefs(schema, parameterSourceOption, components, schemaResolutionCache, resolveFor,
-          stack, seenRef);
+          resolveTo, stack, seenRef);
       }).filter((schema) => {
         return schema.type === 'object';
       }),
@@ -113,13 +115,15 @@ module.exports = {
    * @param {*} components components in openapi spec.
    * @param {object} schemaResolutionCache stores already resolved references
    * @param {*} resolveFor - resolve refs for validation/conversion (value to be one of VALIDATION/CONVERSION)
+   * @param {string} resolveTo The desired JSON-generation mechanism (schema: prefer using the JSONschema to
+    generate a fake object, example: use specified examples as-is). Default: schema
    * @param {*} stack counter which keeps a tab on nested schemas
    * @param {*} seenRef - References that are repeated. Used to identify circular references.
    * @returns {*} schema satisfying JSON-schema-faker.
    */
 
   resolveRefs: function (schema, parameterSourceOption, components, schemaResolutionCache,
-    resolveFor = 'CONVERSION', stack = 0, seenRef = {}) {
+    resolveFor = 'CONVERSION', resolveTo = 'schema', stack = 0, seenRef = {}) {
     var resolvedSchema, prop, splitRef,
       ERR_TOO_MANY_LEVELS = '<Error: Too many levels of nesting to fake this schema>';
 
@@ -136,15 +140,15 @@ module.exports = {
 
     if (schema.anyOf) {
       return this.resolveRefs(schema.anyOf[0], parameterSourceOption, components, schemaResolutionCache, resolveFor,
-        stack, _.cloneDeep(seenRef));
+        resolveTo, stack, _.cloneDeep(seenRef));
     }
     if (schema.oneOf) {
       return this.resolveRefs(schema.oneOf[0], parameterSourceOption, components, schemaResolutionCache, resolveFor,
-        stack, _.cloneDeep(seenRef));
+        resolveTo, stack, _.cloneDeep(seenRef));
     }
     if (schema.allOf) {
       return this.resolveAllOf(schema.allOf, parameterSourceOption, components, schemaResolutionCache, resolveFor,
-        stack, _.cloneDeep(seenRef));
+        resolveTo, stack, _.cloneDeep(seenRef));
     }
     if (schema.$ref && _.isFunction(schema.$ref.split)) {
       let refKey = schema.$ref;
@@ -186,7 +190,7 @@ module.exports = {
 
       if (resolvedSchema) {
         let refResolvedSchema = this.resolveRefs(resolvedSchema, parameterSourceOption,
-          components, schemaResolutionCache, resolveFor, stack, _.cloneDeep(seenRef));
+          components, schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef));
 
         if (refResolvedSchema && refResolvedSchema.value !== ERR_TOO_MANY_LEVELS) {
           schemaResolutionCache[refKey] = refResolvedSchema;
@@ -221,8 +225,8 @@ module.exports = {
               continue;
             }
             /* eslint-enable */
-            tempSchema.properties[prop] = this.resolveRefs(property,
-              parameterSourceOption, components, schemaResolutionCache, resolveFor, stack, _.cloneDeep(seenRef));
+            tempSchema.properties[prop] = this.resolveRefs(property, parameterSourceOption, components,
+              schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef));
           }
         }
         return tempSchema;
@@ -260,13 +264,13 @@ module.exports = {
       // without this, schemas with circular references aren't faked correctly
       let tempSchema = _.omit(schema, 'items');
       tempSchema.items = this.resolveRefs(schema.items, parameterSourceOption,
-        components, schemaResolutionCache, resolveFor, stack, _.cloneDeep(seenRef));
+        components, schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef));
       return tempSchema;
     }
     else if (!schema.hasOwnProperty('default')) {
       if (schema.hasOwnProperty('type')) {
-        // Don't override default value to schema for validation
-        if (resolveFor === 'CONVERSION') {
+        // Override default value to schema for CONVERSION only for parmeter resolution set to schema
+        if (resolveFor === 'CONVERSION' && resolveTo === 'schema') {
           if (!schema.hasOwnProperty('format')) {
             schema.default = '<' + schema.type + '>';
           }

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -4,7 +4,6 @@
  */
 
 const async = require('async'),
-  Ajv = require('ajv'),
   sdk = require('postman-collection'),
   schemaFaker = require('../assets/json-schema-faker.js'),
   parse = require('./parse.js'),
@@ -16,6 +15,7 @@ const async = require('async'),
   utils = require('./utils.js'),
   defaultOptions = require('../lib/options.js').getOptions('use'),
   { Node, Trie } = require('./trie.js'),
+  { validateSchema } = require('./ajvValidation'),
   SCHEMA_FORMATS = {
     DEFAULT: 'default', // used for non-request-body data and json
     XML: 'xml' // used for request-body XMLs
@@ -75,9 +75,6 @@ const async = require('async'),
   // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#pathItemObject
   METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'],
 
-  // Following keyword are supoorted for Ajv but not by OAS
-  IGNORED_KEYWORDS = ['propertyNames', 'const', 'additionalItems', 'dependencies'],
-
   /* eslint-disable arrow-body-style */
   schemaTypeToJsValidator = {
     'string': (d) => typeof d === 'string',
@@ -132,7 +129,7 @@ function safeSchemaFaker(oldSchema, resolveTo, resolveFor, parameterSourceOption
     schemaFakerCache = _.get(schemaCache, 'schemaFakerCache', {});
 
   resolvedSchema = deref.resolveRefs(oldSchema, parameterSourceOption, components, schemaResolutionCache,
-    resolveFor);
+    resolveFor, resolveTo);
   key = JSON.stringify(resolvedSchema);
 
   if (resolveTo === 'schema') {
@@ -2248,12 +2245,11 @@ module.exports = {
       humanPropName = propNames[property],
       needJsonMatching = (property === 'BODY' || property === 'RESPONSE_BODY'),
       invalidJson = false,
-      ajv, validate,
       valueToUse = value,
 
       // This is dereferenced schema (converted to JSON schema for validation)
       schema = deref.resolveRefs(openApiSchemaObj, parameterSourceOption, components,
-        schemaCache.schemaResolutionCache, PROCESSING_TYPE.VALIDATION);
+        schemaCache.schemaResolutionCache, PROCESSING_TYPE.VALIDATION, 'example');
 
     if (needJsonMatching) {
       try {
@@ -2338,59 +2334,7 @@ module.exports = {
         // only do AJV if type is array or object
         // simpler cases are handled by a type check
         if (schema.type === 'array' || schema.type === 'object') {
-          let filteredValidationError;
-
-          try {
-            // add Ajv options to support validation of OpenAPI schema.
-            // For more details see https://ajv.js.org/#options
-            ajv = new Ajv({
-              // the unknown formats are ones that are allowed in OAS, but not JSON schema.
-              unknownFormats: ['int32', 'int64'],
-
-              // check all rules collecting all errors. instead returning after the first error.
-              allErrors: true,
-
-              // supports keyword "nullable" from Open API 3 specification.
-              nullable: true
-            });
-            validate = ajv.compile(schema);
-            validate(valueToUse);
-          }
-          catch (e) {
-            // something went wrong validating the schema
-            // input was invalid. Don't throw mismatch
-          }
-
-          // Filter validation errors for following cases
-          filteredValidationError = _.filter(_.get(validate, 'errors', []), (validationError) => {
-            let dataPath = _.get(validationError, 'dataPath', '');
-
-            // discard the leading '.' if it exists
-            if (dataPath[0] === '.') {
-              dataPath = dataPath.slice(1);
-            }
-
-            // for invalid `propertyNames` two error are thrown by Ajv, which include error with `pattern` keyword
-            if (validationError.keyword === 'pattern') {
-              return !_.has(validationError, 'propertyName');
-            }
-
-            // As OAS only supports some of Json Schema keywords, and Ajv is supporting all keywords from Draft 7
-            // Remove keyword currently not supported in OAS to make both compatible with each other
-            else if (_.includes(IGNORED_KEYWORDS, validationError.keyword)) {
-              return false;
-            }
-
-            // Ignore unresolved variables from mismatch if option is set
-            else if (options.ignoreUnresolvedVariables &&
-              this.isPmVariable(_.get(valueToUse, dataPath))) {
-              return false;
-            }
-            return true;
-          });
-
-          // sort errors based on dataPath, as this will ensure no overriding later
-          filteredValidationError = _.sortBy(filteredValidationError, ['dataPath']);
+          let filteredValidationError = validateSchema(schema, valueToUse, options);
 
           if (!_.isEmpty(filteredValidationError)) {
             let mismatchObj,

--- a/test/data/valid_openapi/example_in_schema.json
+++ b/test/data/valid_openapi/example_in_schema.json
@@ -16,7 +16,7 @@
             "schema": {
               "type": "integer",
               "format": "int32",
-              "example": "header example"
+              "example": 123
             }
           },
           {
@@ -29,7 +29,7 @@
               "items": {
                 "type": "integer",
                 "format": "int64",
-                "example": "queryParamExample"
+                "example": 123
               }
             }
           },
@@ -43,7 +43,7 @@
               "items": {
                 "type": "integer",
                 "format": "int64",
-                "example": "queryParamExample1"
+                "example": 456
               }
             }
           }

--- a/test/data/valid_openapi/multiple_refs.json
+++ b/test/data/valid_openapi/multiple_refs.json
@@ -81,7 +81,7 @@
           "responseId": {
             "type": "integer",
             "format": "int64",
-            "example": "234"
+            "example": 234
           },
           "responseName": {
             "type":"string",

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -2130,7 +2130,7 @@ describe('convertToPmQueryArray function', function() {
           items: {
             type: 'integer',
             format: 'int64',
-            example: 'queryParamExample'
+            example: 123
           } } },
       { name: 'variable3',
         in: 'query',
@@ -2140,7 +2140,7 @@ describe('convertToPmQueryArray function', function() {
           items: {
             type: 'integer',
             format: 'int64',
-            example: 'queryParamExample1'
+            example: 456
           } } }] },
       requestType = 'EXAMPLE',
       result;
@@ -2149,7 +2149,7 @@ describe('convertToPmQueryArray function', function() {
       exampleParametersResolution: 'example',
       requestParametersResolution: 'schema'
     });
-    expect(result[0]).to.equal('variable2=queryParamExample queryParamExample');
-    expect(result[1]).to.equal('variable3=queryParamExample1 queryParamExample1');
+    expect(result[0]).to.equal('variable2=123 123');
+    expect(result[1]).to.equal('variable3=456 456');
   });
 });


### PR DESCRIPTION
This PR contains changes for using faked example when example property mentioned in schema is not adhering to schema.

The change is in schemaFaker() which makes sure for conversion and validation that during faking valid example is generated/suggested. 