### PR TITLE
Bumped up package-lock version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-to-postmanv2",
-  "version": "1.1.19",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Updated package-lock version from `1.1.19` to `1.2.0`.