### PR TITLE
Added support for validating content type header.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2779,9 +2779,124 @@ module.exports = {
     });
   },
 
-  checkRequestHeaders: function (headers, transactionPathPrefix, schemaPath, components, options,
-    schemaCache, callback) {
+  /**
+   * Gives mismtach for content type header for request/response
+   *
+   * @param {Array} headers - Transaction Headers
+   * @param {String} transactionPathPrefix - Transaction Path to headers
+   * @param {String} schemaPathPrefix - Schema path to content object
+   * @param {Object} contentObj - Corresponding Schema content object
+   * @param {String} mismatchProperty - Mismatch property (HEADER / RESPONSE_HEADER)
+   * @param {*} options - OAS options, check lib/options.js for more
+   * @returns {Array} found mismatch objects
+   */
+  checkContentTypeHeader: function (headers, transactionPathPrefix, schemaPathPrefix, contentObj,
+    mismatchProperty, options) {
+    let mediaTypes = _.map(_.keys(contentObj), _.toLower), // as media types are case insensitive
+      contentHeader,
+      contentHeaderIndex,
+      suggestedContentHeader,
+      hasComputedType,
+      humanPropName = mismatchProperty === 'HEADER' ? 'header' : 'response header',
+      mismatches = [];
+
+    // prefer JSON > XML > Other media types for suggested header.
+    _.forEach(mediaTypes, (mediaType) => {
+      let headerFamily = this.getHeaderFamily(mediaType);
+
+      if (headerFamily !== HEADER_TYPE.INVALID) {
+        suggestedContentHeader = mediaType;
+        hasComputedType = true;
+        if (headerFamily === HEADER_TYPE.JSON) {
+          return false;
+        }
+      }
+    });
+
+    // if no JSON or XML, take whatever we have
+    if (!hasComputedType && mediaTypes.length > 0) {
+      suggestedContentHeader = mediaTypes[0];
+      hasComputedType = true;
+    }
+
+    _.forEach(headers, (header, index) => {
+      if (_.toLower(header.key) === 'content-type') {
+        contentHeader = header;
+        contentHeaderIndex = index;
+        return false;
+      }
+    });
+
+    // Schema body content has no media type objects
+    if (!_.isEmpty(contentHeader) && _.isEmpty(mediaTypes)) {
+      // ignore mismatch for default header (text/plain) added by conversion
+      if (options.showMissingInSchemaErrors && _.toLower(contentHeader.value) !== TEXT_PLAIN) {
+        mismatches.push({
+          property: mismatchProperty,
+          transactionJsonPath: transactionPathPrefix + `[${contentHeaderIndex}]`,
+          schemaJsonPath: null,
+          reasonCode: 'MISSING_IN_SCHEMA',
+          // Reason for missing in schema suggests that certain media type in req/res body is not present
+          reason: `The ${mismatchProperty === 'HEADER' ? 'request' : 'response'} body should contain` +
+            ` Media type "${contentHeader.value}"`
+        });
+      }
+    }
+
+    // No request/response content-type header
+    else if (_.isEmpty(contentHeader) && !_.isEmpty(mediaTypes)) {
+      let mismatchObj = {
+        property: mismatchProperty,
+        transactionJsonPath: transactionPathPrefix,
+        schemaJsonPath: schemaPathPrefix,
+        reasonCode: 'MISSING_IN_REQUEST',
+        reason: `The ${humanPropName} "Content-Type" was not found in the transaction`
+      };
+
+      if (options.suggestAvailableFixes) {
+        mismatchObj.suggestedFix = {
+          key: 'Content-Type',
+          actualValue: null,
+          suggestedValue: {
+            key: 'Content-Type',
+            value: suggestedContentHeader
+          }
+        };
+      }
+      mismatches.push(mismatchObj);
+    }
+
+    // Invalid type of header found
+    else if (!_.isEmpty(contentHeader) && !_.includes(mediaTypes, contentHeader.value)) {
+      let mismatchObj = {
+        property: mismatchProperty,
+        transactionJsonPath: transactionPathPrefix + `[${contentHeaderIndex}].value`,
+        schemaJsonPath: schemaPathPrefix,
+        reasonCode: 'INVALID_TYPE',
+        reason: `The ${humanPropName} "Content-Type" needs to be "${suggestedContentHeader}",` +
+          ` but we found "${contentHeader.value}" instead`
+      };
+
+      if (options.suggestAvailableFixes) {
+        mismatchObj.suggestedFix = {
+          key: 'Content-Type',
+          actualValue: contentHeader,
+          suggestedValue: {
+            key: 'Content-Type',
+            value: suggestedContentHeader
+          }
+        };
+      }
+      mismatches.push(mismatchObj);
+    }
+    return mismatches;
+  },
+
+  checkRequestHeaders: function (headers, transactionPathPrefix, schemaPathPrefix, schemaPath,
+    components, options, schemaCache, callback) {
     let schemaHeaders = _.filter(schemaPath.parameters, (param) => { return param.in === 'header'; }),
+      reqHeaders = _.filter(headers, (header) => { return _.toLower(_.get(header, 'key')) !== 'content-type'; }),
+      // reqHeaders = _.filter(headers, (header) => { return true; }),
       mismatchProperty = 'HEADER';
 
     if (options.validationPropertiesToIgnore.includes(mismatchProperty)) {
@@ -2789,9 +2904,9 @@ module.exports = {
     }
     // 1. for each header, find relevant schemaPath property
 
-    return async.map(headers, (pHeader, cb) => {
+    return async.map(reqHeaders, (pHeader, cb) => {
       let mismatches = [],
-        index = _.findIndex(headers, pHeader);
+        index = _.findIndex(reqHeaders, pHeader);
 
       const schemaHeader = _.find(schemaHeaders, (header) => { return header.name === pHeader.key; });
 
@@ -2827,10 +2942,13 @@ module.exports = {
       }, 0);
     }, (err, res) => {
       let mismatches = [],
-        mismatchObj;
+        mismatchObj,
+        contentHeaderMismatches = this.checkContentTypeHeader(headers, transactionPathPrefix,
+          schemaPathPrefix + '.requestBody.content', _.get(schemaPath, 'requestBody.content'),
+          mismatchProperty, options);
 
       _.each(_.filter(schemaHeaders, (h) => { return h.required; }), (header) => {
-        if (!_.find(headers, (param) => { return param.key === header.name; })) {
+        if (!_.find(reqHeaders, (param) => { return param.key === header.name; })) {
           mismatchObj = {
             property: mismatchProperty,
             transactionJsonPath: transactionPathPrefix,
@@ -2853,7 +2971,7 @@ module.exports = {
           mismatches.push(mismatchObj);
         }
       });
-      return callback(null, _.concat(_.flatten(res), mismatches));
+      return callback(null, _.concat(contentHeaderMismatches, _.flatten(res), mismatches));
     });
   },
 
@@ -2861,6 +2979,7 @@ module.exports = {
     components, options, schemaCache, callback) {
     // 0. Need to find relevant response from schemaPath.responses
     let schemaHeaders,
+      resHeaders = _.filter(headers, (header) => { return _.toLower(_.get(header, 'key')) !== 'content-type'; }),
       mismatchProperty = 'RESPONSE_HEADER';
 
     if (options.validationPropertiesToIgnore.includes(mismatchProperty)) {
@@ -2874,9 +2993,9 @@ module.exports = {
 
     schemaHeaders = schemaResponse.headers;
 
-    return async.map(headers, (pHeader, cb) => {
+    return async.map(resHeaders, (pHeader, cb) => {
       let mismatches = [],
-        index = _.findIndex(headers, pHeader);
+        index = _.findIndex(resHeaders, pHeader);
 
       const schemaHeader = _.get(schemaHeaders, pHeader.key);
 
@@ -2912,13 +3031,15 @@ module.exports = {
       }, 0);
     }, (err, res) => {
       let mismatches = [],
-        mismatchObj;
+        mismatchObj,
+        contentHeaderMismatches = this.checkContentTypeHeader(headers, transactionPathPrefix,
+          schemaPathPrefix + '.content', _.get(schemaResponse, 'content'), mismatchProperty, options);
 
       _.each(_.filter(schemaHeaders, (h, hName) => {
         h.name = hName;
         return h.required;
       }), (header) => {
-        if (!_.find(headers, (param) => { return param.key === header.name; })) {
+        if (!_.find(resHeaders, (param) => { return param.key === header.name; })) {
           mismatchObj = {
             property: mismatchProperty,
             transactionJsonPath: transactionPathPrefix,
@@ -2941,7 +3062,7 @@ module.exports = {
           mismatches.push(mismatchObj);
         }
       });
-      callback(null, _.concat(_.flatten(res), mismatches));
+      callback(null, _.concat(contentHeaderMismatches, _.flatten(res), mismatches));
     });
   },
 

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2837,7 +2837,7 @@ module.exports = {
           schemaJsonPath: null,
           reasonCode: 'MISSING_IN_SCHEMA',
           // Reason for missing in schema suggests that certain media type in req/res body is not present
-          reason: `The ${mismatchProperty === 'HEADER' ? 'request' : 'response'} body should contain` +
+          reason: `The ${mismatchProperty === 'HEADER' ? 'request' : 'response'} body should have content of` +
             ` Media type "${contentHeader.value}"`
         });
       }

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2880,11 +2880,8 @@ module.exports = {
       if (options.suggestAvailableFixes) {
         mismatchObj.suggestedFix = {
           key: 'Content-Type',
-          actualValue: contentHeader,
-          suggestedValue: {
-            key: 'Content-Type',
-            value: suggestedContentHeader
-          }
+          actualValue: contentHeader.value,
+          suggestedValue: suggestedContentHeader
         };
       }
       mismatches.push(mismatchObj);

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -75,6 +75,12 @@ const async = require('async'),
   // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#pathItemObject
   METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'],
 
+  // These headers are to be validated explicitly
+  // As these are not defined under usual parameters object and need special handling
+  IMPLICIT_HEADERS = [
+    'content-type' // 'content-type' is defined based on content/media-type of req/res body
+  ],
+
   /* eslint-disable arrow-body-style */
   schemaTypeToJsValidator = {
     'string': (d) => typeof d === 'string',
@@ -2837,8 +2843,8 @@ module.exports = {
           schemaJsonPath: null,
           reasonCode: 'MISSING_IN_SCHEMA',
           // Reason for missing in schema suggests that certain media type in req/res body is not present
-          reason: `The ${mismatchProperty === 'HEADER' ? 'request' : 'response'} body should have content of` +
-            ` Media type "${contentHeader.value}"`
+          reason: `The ${mismatchProperty === 'HEADER' ? 'request' : 'response'} body should have media type` +
+            ` "${contentHeader.value}"`
         });
       }
     }
@@ -2892,8 +2898,10 @@ module.exports = {
   checkRequestHeaders: function (headers, transactionPathPrefix, schemaPathPrefix, schemaPath,
     components, options, schemaCache, callback) {
     let schemaHeaders = _.filter(schemaPath.parameters, (param) => { return param.in === 'header'; }),
-      reqHeaders = _.filter(headers, (header) => { return _.toLower(_.get(header, 'key')) !== 'content-type'; }),
-      // reqHeaders = _.filter(headers, (header) => { return true; }),
+      // filter out headers which need explicit handling according to schema (other than parameters object)
+      reqHeaders = _.filter(headers, (header) => {
+        return !_.includes(IMPLICIT_HEADERS, _.toLower(_.get(header, 'key')));
+      }),
       mismatchProperty = 'HEADER';
 
     if (options.validationPropertiesToIgnore.includes(mismatchProperty)) {
@@ -2976,7 +2984,10 @@ module.exports = {
     components, options, schemaCache, callback) {
     // 0. Need to find relevant response from schemaPath.responses
     let schemaHeaders,
-      resHeaders = _.filter(headers, (header) => { return _.toLower(_.get(header, 'key')) !== 'content-type'; }),
+      // filter out headers which need explicit handling according to schema (other than parameters object)
+      resHeaders = _.filter(headers, (header) => {
+        return !_.includes(IMPLICIT_HEADERS, _.toLower(_.get(header, 'key')));
+      }),
       mismatchProperty = 'RESPONSE_HEADER';
 
     if (options.validationPropertiesToIgnore.includes(mismatchProperty)) {

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -411,8 +411,8 @@ class SchemaPack {
                   componentsAndPaths, options, schemaCache, cb);
               },
               headers: function(cb) {
-                schemaUtils.checkRequestHeaders(transaction.request.header, '$.request.header', matchedPath.path,
-                  componentsAndPaths, options, schemaCache, cb);
+                schemaUtils.checkRequestHeaders(transaction.request.header, '$.request.header', matchedPath.jsonPath,
+                  matchedPath.path, componentsAndPaths, options, schemaCache, cb);
               },
               requestBody: function(cb) {
                 schemaUtils.checkRequestBody(transaction.request.body, '$.request.body', matchedPath.jsonPath,


### PR DESCRIPTION
This PR adds support for validating content type header based on media type object of request/response body. Similar to how headers are generated via conversion flow.