### PR TITLE
Fixed invalid transaction json path for headers.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2911,7 +2911,7 @@ module.exports = {
 
     return async.map(reqHeaders, (pHeader, cb) => {
       let mismatches = [],
-        index = _.findIndex(reqHeaders, pHeader);
+        index = _.findIndex(headers, pHeader); // find actual index from collection request headers
 
       const schemaHeader = _.find(schemaHeaders, (header) => { return header.name === pHeader.key; });
 
@@ -3003,7 +3003,7 @@ module.exports = {
 
     return async.map(resHeaders, (pHeader, cb) => {
       let mismatches = [],
-        index = _.findIndex(resHeaders, pHeader);
+        index = _.findIndex(headers, pHeader); // find actual index from collection response headers
 
       const schemaHeader = _.get(schemaHeaders, pHeader.key);
 


### PR DESCRIPTION
Transaction path was wrong when `content-type` header was present. So this PR makes changes to use actual index of headers in transactionJson path.