### PR TITLE
Fixed TypeError happening when empty parameter is provided.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2147,6 +2147,14 @@ module.exports = {
         return true;
       }
 
+      // filter empty parameters
+      pathItemObject.parameters = _.reduce(pathItemObject.parameters, (accumulator, param) => {
+        if (!_.isEmpty(param)) {
+          accumulator.push(param);
+        }
+        return accumulator;
+      }, []);
+
       // check if path and pathToMatch match (non-null)
       let schemaMatchResult = this.getPostmanUrlSchemaMatchScore(pathToMatch, path, options);
       if (!schemaMatchResult.match) {
@@ -2183,9 +2191,13 @@ module.exports = {
 
       matchedPathJsonPath = `$.paths[${path}]`;
 
-      if (!matchedPath.parameters) {
-        matchedPath.parameters = [];
-      }
+      // filter empty parameters
+      matchedPath.parameters = _.reduce(matchedPath.parameters, (accumulator, param) => {
+        if (!_.isEmpty(param)) {
+          accumulator.push(param);
+        }
+        return accumulator;
+      }, []);
 
       // aggregate local + global parameters for this path
       matchedPath.parameters = _.map(matchedPath.parameters, (commonParam) => {


### PR DESCRIPTION
When parameters property for OpenAPI PathItem or OperationItem object is defined and empty parameter exist, module throws TypeError as we are accessing property of parameter object.

Fixed error by filtering empty parameters first.