### PR TITLE
Fixed collection variable ignoring when pattern property is present

### DIFF
--- a/lib/ajvValidation.js
+++ b/lib/ajvValidation.js
@@ -61,8 +61,8 @@ function validateSchema (schema, valueToUse, options = {}) {
     }
 
     // for invalid `propertyNames` two error are thrown by Ajv, which include error with `pattern` keyword
-    if (validationError.keyword === 'pattern') {
-      return !_.has(validationError, 'propertyName');
+    if (validationError.keyword === 'pattern' && _.has(validationError, 'propertyName')) {
+      return false;
     }
 
     // As OAS only supports some of Json Schema keywords, and Ajv is supporting all keywords from Draft 7


### PR DESCRIPTION
Currently implemented `ignoreUnresolvedVariables` option ignores mismatch when value is variable. Meanwhile user is facing issue where mismatch is provided even when value is variable.

Community Issue - [here](https://community.postman.com/t/api-designer-collection-validation-incorrect-with-body-field-value/13609) 