### PR TITLE
Fixed dataPath handling for root property when dataPath is empty string

### DIFF
--- a/lib/ajvValidation.js
+++ b/lib/ajvValidation.js
@@ -72,7 +72,8 @@ function validateSchema (schema, valueToUse, options = {}) {
     }
 
     // Ignore unresolved variables from mismatch if option is set
-    else if (options.ignoreUnresolvedVariables && isPmVariable(_.get(valueToUse, dataPath))) {
+    else if (options.ignoreUnresolvedVariables &&
+      isPmVariable(dataPath === '' ? valueToUse : _.get(valueToUse, dataPath))) {
       return false;
     }
     return true;

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2425,7 +2425,7 @@ module.exports = {
                 if (options.suggestAvailableFixes) {
                   mismatchObj.suggestedFix = {
                     key: _.split(dataPath, '.').pop(),
-                    actualValue: _.get(valueToUse, dataPath, null),
+                    actualValue: (dataPath === '' ? valueToUse : _.get(valueToUse, dataPath, null)),
                     suggestedValue: this.getSuggestedValue(fakedValue, valueToUse, ajvError)
                   };
                 }
@@ -2457,7 +2457,14 @@ module.exports = {
                   if (dataPath[0] === '.') {
                     dataPath = dataPath.slice(1);
                   }
-                  _.set(suggestedValue, dataPath, this.getSuggestedValue(fakedValue, valueToUse, ajvError));
+
+                  // for empty string _.set creates new key with empty string '', so separate handling
+                  if (dataPath === '') {
+                    suggestedValue = this.getSuggestedValue(fakedValue, valueToUse, ajvError);
+                  }
+                  else {
+                    _.set(suggestedValue, dataPath, this.getSuggestedValue(fakedValue, valueToUse, ajvError));
+                  }
                 });
 
                 mismatchObj.suggestedFix = {
@@ -3408,13 +3415,16 @@ module.exports = {
     var suggestedValue,
       tempSuggestedValue,
       dataPath = ajvValidationErrorObj.dataPath || '',
-      targetActualValue = _.get(actualValue, dataPath, {}),
-      targetFakedValue = _.get(fakedValue, dataPath, {});
+      targetActualValue,
+      targetFakedValue;
 
     // discard the leading '.' if it exists
     if (dataPath[0] === '.') {
       dataPath = dataPath.slice(1);
     }
+
+    targetActualValue = (dataPath === '' ? actualValue : _.get(actualValue, dataPath, {}));
+    targetFakedValue = (dataPath === '' ? fakedValue : _.get(fakedValue, dataPath, {}));
 
     switch (ajvValidationErrorObj.keyword) {
 
@@ -3450,7 +3460,7 @@ module.exports = {
 
       // Keywords: minLength, maxLength, format, minimum, maximum, type, multipleOf, pattern
       default:
-        suggestedValue = _.get(fakedValue, dataPath, null);
+        suggestedValue = (dataPath === '' ? fakedValue : _.get(fakedValue, dataPath, null));
         break;
     }
 

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2285,6 +2285,19 @@ module.exports = {
   },
 
   /**
+   * This function is little modified version of lodash _.get()
+   * where if path is empty it will return source object instead undefined/fallback value
+   *
+   * @param {Object} sourceValue - source from where value is to be extracted
+   * @param {String} dataPath - json path to value that is to be extracted
+   * @param {*} fallback - fallback value if sourceValue doesn't contain value at dataPath
+   * @returns {*} extracted value
+   */
+  getPathValue: function (sourceValue, dataPath, fallback) {
+    return (dataPath === '' ? sourceValue : _.get(sourceValue, dataPath, fallback));
+  },
+
+  /**
    *
    * @param {String} property - one of QUERYPARAM, PATHVARIABLE, HEADER, BODY, RESPONSE_HEADER, RESPONSE_BODY
    * @param {String} jsonPathPrefix - this will be prepended to all JSON schema paths on the request
@@ -2425,7 +2438,7 @@ module.exports = {
                 if (options.suggestAvailableFixes) {
                   mismatchObj.suggestedFix = {
                     key: _.split(dataPath, '.').pop(),
-                    actualValue: (dataPath === '' ? valueToUse : _.get(valueToUse, dataPath, null)),
+                    actualValue: this.getPathValue(valueToUse, dataPath, null),
                     suggestedValue: this.getSuggestedValue(fakedValue, valueToUse, ajvError)
                   };
                 }
@@ -3423,8 +3436,8 @@ module.exports = {
       dataPath = dataPath.slice(1);
     }
 
-    targetActualValue = (dataPath === '' ? actualValue : _.get(actualValue, dataPath, {}));
-    targetFakedValue = (dataPath === '' ? fakedValue : _.get(fakedValue, dataPath, {}));
+    targetActualValue = this.getPathValue(actualValue, dataPath, {});
+    targetFakedValue = this.getPathValue(fakedValue, dataPath, {});
 
     switch (ajvValidationErrorObj.keyword) {
 
@@ -3460,7 +3473,7 @@ module.exports = {
 
       // Keywords: minLength, maxLength, format, minimum, maximum, type, multipleOf, pattern
       default:
-        suggestedValue = (dataPath === '' ? fakedValue : _.get(fakedValue, dataPath, null));
+        suggestedValue = this.getPathValue(fakedValue, dataPath, null);
         break;
     }
 


### PR DESCRIPTION
This PR fixes incorrect handling of wrong /same value suggested when `dataPath` from Ajv validation error is empty.