### PR TITLE
Fixed incorrect Url and collection variable when path level server is present.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -3528,7 +3528,7 @@ module.exports = {
               // add path level server object's URL as collection variable
               variables = this.convertToPmCollectionVariables(
                 pathLevelServers[0].variables, // these are path variables in the server block
-                path + 'Url', // the name of the variable
+                this.fixPathVariableName(path), // the name of the variable
                 this.fixPathVariablesInUrl(pathLevelServers[0].url)
               );
             }

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -222,8 +222,8 @@ module.exports = {
    * @returns {string} - string after replacing {itemId} with :itemId
    */
   fixPathVariableName: function (path) {
-    // Replaces structure like 'item/{itemId}' into 'item/:itemId'
-    return _.camelCase(path.replace(/[\/{}]/g, ' ') + 'Url');
+    // Replaces structure like 'item/{itemId}' into 'item-itemId-Url'
+    return path.replace(/\//g, '-').replace(/[{}]/g, '') + '-Url';
   },
 
   /**

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -215,6 +215,18 @@ module.exports = {
   },
 
   /**
+   * Changes path structure that contains {var} to :var and '/' to '_'
+   * This is done so generated collection variable is in correct format
+   * i.e. variable '{{item/{itemId}}}' is considered separates variable in URL by collection sdk
+   * @param {string} path - path defined in openapi spec
+   * @returns {string} - string after replacing {itemId} with :itemId
+   */
+  fixPathVariableName: function (path) {
+    // Replaces structure like 'item/{itemId}' into 'item/:itemId'
+    return _.camelCase(path.replace(/[\/{}]/g, ' ') + 'Url');
+  },
+
+  /**
    * Returns a description that's usable at the collection-level
    * Adds the collection description and uses any relevant contact info
    * @param {*} openapi The JSON representation of the OAS spec
@@ -502,7 +514,7 @@ module.exports = {
         // storing common path/collection vars from the server object at the path item level
         if (currentPathObject.hasOwnProperty('servers')) {
           pathLevelServers = currentPathObject.servers;
-          collectionVariables[path + 'Url'] = pathLevelServers[0];
+          collectionVariables[this.fixPathVariableName(path)] = pathLevelServers[0];
           delete currentPathObject.servers;
         }
 
@@ -654,7 +666,7 @@ module.exports = {
         // add path level server object's URL as collection variable
         collectionVariables = this.convertToPmCollectionVariables(
           pathLevelServers[0].variables, // these are path variables in the server block
-          path + 'Url', // the name of the variable
+          this.fixPathVariableName(path), // the name of the variable
           this.fixPathVariablesInUrl(pathLevelServers[0].url)
         );
 
@@ -1946,7 +1958,7 @@ module.exports = {
       if (Array.isArray(globalServers) && globalServers.length) {
         // All the global servers present at the path level are taken care of in generateTrieFromPaths
         // Just adding the same structure of the url as the display URL.
-        displayUrl = '{{' + operationItem.path + 'Url}}' + reqUrl;
+        displayUrl = '{{' + this.fixPathVariableName(operationItem.path) + '}}' + reqUrl;
       }
       // In case there are no server available use the baseUrl
       else {

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -172,7 +172,7 @@ describe('CONVERT FUNCTION TESTS ', function() {
         expect(conversionResult.output[0].type).to.equal('collection');
         expect(conversionResult.output[0].data).to.have.property('info');
         expect(conversionResult.output[0].data).to.have.property('item');
-        expect(conversionResult.output[0].data.item[0].item[0].request.url.host[0]).to.equal('{{petsUrl}}');
+        expect(conversionResult.output[0].data.item[0].item[0].request.url.host[0]).to.equal('{{pets-Url}}');
         done();
       });
     });

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -539,7 +539,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
       expect(root.children.nonpet.children, 'Nonpet should have direct requests, not a child')
         .to.not.have.any.keys('');
       expect(root.children.nonpet.requestCount).to.equal(2);
-      expect(collectionVariables).to.have.key('petUrl');
+      expect(collectionVariables).to.have.key('pet-Url');
       done();
     });
 


### PR DESCRIPTION
This PR fixes Problem where if there is path level server present Url and Variable for server is simply Url append to path. Now when path in spec has more than one segment ('/' is present) than result Url is invalid as each segment can't have segment separator in one segment.