### PR TITLE
Fixed an issue where transaction was not matching if path had segment with fix and variable parts during valiadtion.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1815,6 +1815,50 @@ module.exports = {
     return path.match(/(\{\{[^\/\{\}]+\}\})/g);
   },
 
+  /**
+   * Finds all the possible path variables conversion from schema path,
+   * and excludes path variable that are converted to collection variable
+   * @param {string} path Path string
+   * @returns {array} Array of path variables.
+   */
+  findPathVariablesFromSchemaPath: function (path) {
+    // /{path}/{file}.{format}/{hello} return [ '/{path}', '/{hello}' ]
+    // https://regex101.com/r/aFRWQD/4
+    let matches = path.match(/(\/\{[^\/\{\}]+\}(?=[\/\0]|$))/g);
+
+    // remove leading '/' and starting and ending curly braces
+    return _.map(matches, (match) => { return match.slice(2, -1); });
+  },
+
+  /**
+   * Finds fixed parts present in path segment of collection or schema.
+   *
+   * @param {String} segment - Path segment
+   * @param {String} pathType - Path type (one of 'collection' / 'schema')
+   * @returns {Array} - Array of strings where each element is fixed part in order of their occurence
+   */
+  getFixedPartsFromPathSegment: function (segment, pathType = 'collection') {
+    var tempSegment = segment,
+      // collection is default
+      varMatches = segment.match(pathType === 'schema' ? /(\{[^\/\{\}]+\})/g : /(\{\{[^\/\{\}]+\}\})/g),
+      fixedParts = [];
+
+    _.forEach(varMatches, (match) => {
+      let matchedIndex = tempSegment.indexOf(match);
+
+      // push fixed part before collection variable if present
+      (matchedIndex !== 0) && (fixedParts.push(tempSegment.slice(0, matchedIndex)));
+
+      // substract starting fixed and variable part from tempSegment
+      tempSegment = tempSegment.substr(matchedIndex + match.length);
+    });
+
+    // add last fixed part if present
+    (tempSegment.length > 0) && (fixedParts.push(tempSegment));
+
+    return fixedParts;
+  },
+
   /** Separates out collection and path variables from the reqUrl
    *
    * @param {string} reqUrl Request Url
@@ -2294,7 +2338,8 @@ module.exports = {
       retVal.push({
         // using path instead of operationId / sumamry since it's widely understood
         name: method + ' ' + path,
-        path: matchedPath,
+        // assign path as schemaPathName property to use path in path object
+        path: _.assign(matchedPath, { schemaPathName: path }),
         jsonPath: matchedPathJsonPath + '.' + method.toLowerCase(),
         pathVariables: pathVars,
         score: score
@@ -2794,14 +2839,18 @@ module.exports = {
     var mismatchProperty = 'PATHVARIABLE',
       // all path variables defined in this path. acc. to the spec, all path params are required
       schemaPathVariables,
+      pmPathVariables,
       schemaPathVar;
 
     if (options.validationPropertiesToIgnore.includes(mismatchProperty)) {
       return callback(null, []);
     }
 
+    // find all schema path variables that can be present as collection path variables
+    pmPathVariables = this.findPathVariablesFromSchemaPath(schemaPath.schemaPathName);
     schemaPathVariables = _.filter(schemaPath.parameters, (param) => {
-      return (param.in === 'path');
+      // exclude path variables stored as collection variable from being validated further
+      return (param.in === 'path' && _.includes(pmPathVariables, param.name));
     });
 
     async.map(determinedPathVariables, (pathVar, cb) => {
@@ -3642,7 +3691,14 @@ module.exports = {
       // No. of fixed segment matches between schema and postman url path
       fixedMatchedSegments = 0,
       // No. of variable segment matches between schema and postman url path
-      variableMatchedSegments = 0;
+      variableMatchedSegments = 0,
+      // checks if schema segment provided is path variable
+      isSchemaSegmentPathVar = (segment) => {
+        return segment.startsWith('{') &&
+        segment.endsWith('}') &&
+        // check that only one path variable is present as collection path variable can contain only one var
+        segment.indexOf('}') === segment.lastIndexOf('}');
+      };
 
     if (options.strictRequestMatching && pmSuffix.length !== schemaPath.length) {
       return {
@@ -3656,28 +3712,31 @@ module.exports = {
     // segments match if the schemaPath segment is {..} or the postmanPathStr is :<anything> or {{anything}}
     // for (let i = pmSuffix.length - 1; i >= 0; i--) {
     for (let i = 0; i < minLength; i++) {
+      let schemaFixedParts = this.getFixedPartsFromPathSegment(schemaPath[sMax - i], 'schema'),
+        collectionFixedParts = this.getFixedPartsFromPathSegment(pmSuffix[pMax - i], 'collection');
+
       if (
-        (schemaPath[sMax - i] === pmSuffix[pMax - i]) || // exact match
-        (schemaPath[sMax - i].startsWith('{') && schemaPath[sMax - i].endsWith('}')) || // schema segment is a pathVar
+        (_.isEqual(schemaFixedParts, collectionFixedParts)) || // exact fixed parts match
+        (isSchemaSegmentPathVar(schemaPath[sMax - i])) || // schema segment is a pathVar
         (pmSuffix[pMax - i].startsWith(':')) || // postman segment is a pathVar
         (this.isPmVariable(pmSuffix[pMax - i])) // postman segment is an env/collection var
       ) {
 
         // for variable match increase variable matched segments count (used for determining order for multiple matches)
         if (
-          (schemaPath[sMax - i].startsWith('{') && schemaPath[sMax - i].endsWith('}')) && // schema segment is a pathVar
+          (isSchemaSegmentPathVar(schemaPath[sMax - i])) && // schema segment is a pathVar
           ((pmSuffix[pMax - i].startsWith(':')) || // postman segment is a pathVar
             (this.isPmVariable(pmSuffix[pMax - i]))) // postman segment is an env/collection var
         ) {
           variableMatchedSegments++;
         }
         // for exact match increase fix matched segments count (used for determining order for multiple matches)
-        else if (schemaPath[sMax - i] === pmSuffix[pMax - i]) {
+        else if (_.isEqual(schemaFixedParts, collectionFixedParts)) {
           fixedMatchedSegments++;
         }
 
-        // add a matched path variable only if the schema one was a pathVar
-        if (schemaPath[sMax - i].startsWith('{') && schemaPath[sMax - i].endsWith('}')) {
+        // add a matched path variable only if the schema one was a pathVar and only one path variable is in segment
+        if (isSchemaSegmentPathVar(schemaPath[sMax - i])) {
           variables.push({
             key: schemaPath[sMax - i].substring(1, schemaPath[sMax - i].length - 1),
             value: pmSuffix[pMax - i]

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -2248,4 +2248,27 @@ describe('getPostmanUrlSchemaMatchScore function', function() {
     expect(endpointMatchScore.match).to.eql(true);
     expect(endpointMatchScore.score).to.eql(1);
   });
+
+  it('Should correctly match path with fixed and variable path segment to matching request endpoint', function () {
+    let schemaPath = '/user/send-sms.{format}',
+      pmPath = '/user/send-sms.{{format}}',
+      endpointMatchScore = SchemaUtils.getPostmanUrlSchemaMatchScore(pmPath, schemaPath, {});
+
+    // both paths should match with max score
+    expect(endpointMatchScore.match).to.eql(true);
+    expect(endpointMatchScore.score).to.eql(1);
+    // no path var should be identified as format will be stored as collection variable
+    expect(endpointMatchScore.pathVars).to.have.lengthOf(0);
+
+    schemaPath = '/spaces/{spaceId}/{path}_{pathSuffix}';
+    pmPath = '/spaces/:spaceId/{{path}}_{{pathSuffix}}';
+    endpointMatchScore = SchemaUtils.getPostmanUrlSchemaMatchScore(pmPath, schemaPath, {});
+
+    // both paths should match with max score
+    expect(endpointMatchScore.match).to.eql(true);
+    expect(endpointMatchScore.score).to.eql(1);
+    // only one path var (spaceId) should be identified as others will be stored as collection variable
+    expect(endpointMatchScore.pathVars).to.have.lengthOf(1);
+    expect(endpointMatchScore.pathVars[0]).to.eql({ key: 'spaceId', value: ':spaceId' });
+  });
 });


### PR DESCRIPTION
This PR fixes issue where transaction with path which had segment with fix and variable part was not matching. This PR also excludes validation for path variables which are stored as collection variable during conversion.

Example:

Schema Path | Converted Collection path
-- | --
/user/send-sms.{format} | /user/send-sms.{{format}}
/spaces/{spaceId}/{path}_{pathSuffix} | /spaces/:spaceId/{{path}}_{{pathSuffix}}

In example 1, validator currently fails to identify match as `send-sms.{{format}}` is treated as fixed segment according to current logic and doesn't identify `{{format}}` as variable.

In example 2, validator matches path but treats entire `path}}_{{pathSuffix` as path variable. and same is checked further and expected that this path variable to be present in schema.