### PR TITLE
Fixed issue where root path was not matched during validation.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -3610,6 +3610,15 @@ module.exports = {
       }
     });
 
+    // handle root path '/'
+    if (postmanPath === '/' && schemaPath === '/') {
+      anyMatchFound = true;
+      maxScoreFound = 1; // assign max possible score
+      matchedPathVars = []; // no path variables present
+      fixedMatchedSegments = 0;
+      variableMatchedSegments = 0;
+    }
+
     if (anyMatchFound) {
       return {
         match: true,

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -2136,3 +2136,15 @@ describe('convertToPmQueryArray function', function() {
     expect(result[1]).to.equal('variable3=456%20456');
   });
 });
+
+describe('getPostmanUrlSchemaMatchScore function', function() {
+  it('Should correctly match root level path with matching request endpoint', function () {
+    let schemaPath = '/',
+      pmPath = '/',
+      endpointMatchScore = SchemaUtils.getPostmanUrlSchemaMatchScore(schemaPath, pmPath, {});
+
+    // root level paths should match with max score
+    expect(endpointMatchScore.match).to.eql(true);
+    expect(endpointMatchScore.score).to.eql(1);
+  });
+});


### PR DESCRIPTION
This PR fixes no endpoints matched found issue when schema and request contains root path. (i.e. `/`)