### PR TITLE
Fixed TypeError happening when null parameter value provided.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -3413,6 +3413,10 @@ module.exports = {
           schemaPathPrefix + '.content', _.get(schemaResponse, 'content'), mismatchProperty, options);
 
       _.each(_.filter(schemaHeaders, (h, hName) => {
+        // exclude empty headers fron validation
+        if (_.isEmpty(h)) {
+          return false;
+        }
         h.name = hName;
         return h.required;
       }), (header) => {

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2475,7 +2475,7 @@ module.exports = {
       };
 
     // for invalid param object return null
-    if (!_.isObject(param)) {
+    if (!_.isObject(param) || !_.isString(paramValue)) {
       return null;
     }
 


### PR DESCRIPTION
This PR fixes following TypeErrors.
- When schema contains empty parameter object.
- When collection has null as parameter value when string is expected.