### PR TITLE
Add supported formats for schema resolution (deref).

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -20,7 +20,18 @@ const _ = require('lodash'),
   PARAMETER_SOURCE = {
     REQUEST: 'REQUEST',
     RESPONSE: 'RESPONSE'
-  };
+  },
+  // All formats supported by both ajv and json-schema-faker
+  SUPPORTED_FORMATS = [
+    'date', 'time', 'date-time',
+    'uri', 'uri-reference', 'uri-template',
+    'email',
+    'hostname',
+    'ipv4', 'ipv6',
+    'regex',
+    'uuid',
+    'json-pointer'
+  ];
 
 module.exports = {
   /**
@@ -308,8 +319,8 @@ module.exports = {
         schema.type = 'string';
       }
 
-      // For VALIDATION - Keep format as is to perform ajv validation on format
-      if (resolveFor !== 'VALIDATION') {
+      // Discard format if not supported by both json-schema-faker and ajv
+      if (!_.includes(SUPPORTED_FORMATS, schema.format)) {
         delete schema.format;
       }
     }

--- a/test/unit/deref.test.js
+++ b/test/unit/deref.test.js
@@ -1,166 +1,209 @@
 var expect = require('chai').expect,
+  _ = require('lodash'),
   deref = require('../../lib/deref.js');
 
 describe('DEREF FUNCTION TESTS ', function() {
-  it('resolveRefs Function should return schema with resolved references.', function(done) {
-    var schema = {
-        $ref: '#/components/schemas/schema1'
-      },
-      schemaWithDotInKey = {
-        $ref: '#/components/schemas/schema.four'
-      },
-      schemaWithCustomFormat = {
-        $ref: '#/components/schemas/schema3'
-      },
-      schemaWithAllOf = {
-        allOf: [{
-          $ref: '#/components/schemas/schema2'
+  describe('resolveRefs Function', function () {
+    it('should return schema with resolved references.', function(done) {
+      var schema = {
+          $ref: '#/components/schemas/schema1'
         },
-        {
-          properties: {
-            test_prop: {
-              type: 'string'
-            }
-          }
-        }]
-      },
-      schemaWithTypeArray = {
-        $ref: '#/components/schemas/schemaTypeArray'
-      },
-      componentsAndPaths = {
-        components: {
-          schemas: {
-            schema1: {
-              anyOf: [{
-                $ref: '#/components/schemas/schema2'
-              },
-              {
-                $ref: '#/components/schemas/schema3'
-              }
-              ]
-            },
-            schema2: {
-              type: 'object',
-              required: [
-                'id'
-              ],
-              description: 'Schema 2',
-              properties: {
-                id: {
-                  type: 'integer',
-                  format: 'int64'
-                }
-              }
-            },
-            'schema.four': {
-              type: 'object',
-              required: [
-                'id'
-              ],
-              properties: {
-                id: {
-                  type: 'integer',
-                  format: 'int64'
-                }
-              }
-            },
-            schema3: {
-              type: 'object',
-              properties: {
-                emailField: {
-                  type: 'string',
-                  format: 'email'
-                }
-              }
-            },
-            schemaTypeArray: {
-              type: 'array',
-              items: {
+        schemaWithDotInKey = {
+          $ref: '#/components/schemas/schema.four'
+        },
+        schemaWithCustomFormat = {
+          $ref: '#/components/schemas/schema3'
+        },
+        schemaWithAllOf = {
+          allOf: [{
+            $ref: '#/components/schemas/schema2'
+          },
+          {
+            properties: {
+              test_prop: {
                 type: 'string'
+              }
+            }
+          }]
+        },
+        schemaWithTypeArray = {
+          $ref: '#/components/schemas/schemaTypeArray'
+        },
+        componentsAndPaths = {
+          components: {
+            schemas: {
+              schema1: {
+                anyOf: [{
+                  $ref: '#/components/schemas/schema2'
+                },
+                {
+                  $ref: '#/components/schemas/schema3'
+                }
+                ]
               },
-              minItems: 5,
-              maxItems: 55
+              schema2: {
+                type: 'object',
+                required: [
+                  'id'
+                ],
+                description: 'Schema 2',
+                properties: {
+                  id: {
+                    type: 'integer',
+                    format: 'int64'
+                  }
+                }
+              },
+              'schema.four': {
+                type: 'object',
+                required: [
+                  'id'
+                ],
+                properties: {
+                  id: {
+                    type: 'integer',
+                    format: 'int64'
+                  }
+                }
+              },
+              schema3: {
+                type: 'object',
+                properties: {
+                  emailField: {
+                    type: 'string',
+                    format: 'email'
+                  }
+                }
+              },
+              schemaTypeArray: {
+                type: 'array',
+                items: {
+                  type: 'string'
+                },
+                minItems: 5,
+                maxItems: 55
+              }
             }
           }
+        },
+        parameterSource = 'REQUEST',
+        output = deref.resolveRefs(schema, parameterSource, componentsAndPaths),
+        output_withdot = deref.resolveRefs(schemaWithDotInKey, parameterSource, componentsAndPaths),
+        output_customFormat = deref.resolveRefs(schemaWithCustomFormat, parameterSource, componentsAndPaths),
+        output_withAllOf = deref.resolveRefs(schemaWithAllOf, parameterSource, componentsAndPaths),
+        output_validationTypeArray = deref.resolveRefs(schemaWithTypeArray, parameterSource, componentsAndPaths,
+          {}, 'VALIDATION');
+
+      expect(output).to.deep.include({ type: 'object',
+        required: ['id'],
+        properties: { id: { default: '<long>', type: 'integer' } } });
+
+      expect(output_withdot).to.deep.include({ type: 'object',
+        required: ['id'],
+        properties: { id: { default: '<long>', type: 'integer' } } });
+
+      expect(output_customFormat).to.deep.include({ type: 'object',
+        properties: { emailField: { default: '<email>', format: 'email', type: 'string' } } });
+
+      expect(output_withAllOf).to.deep.include({
+        type: 'object',
+        description: 'Schema 2',
+        properties: {
+          id: { default: '<long>', type: 'integer' },
+          test_prop: { default: '<string>', type: 'string' }
         }
-      },
-      parameterSource = 'REQUEST',
-      output = deref.resolveRefs(schema, parameterSource, componentsAndPaths),
-      output_withdot = deref.resolveRefs(schemaWithDotInKey, parameterSource, componentsAndPaths),
-      output_customFormat = deref.resolveRefs(schemaWithCustomFormat, parameterSource, componentsAndPaths),
-      output_withAllOf = deref.resolveRefs(schemaWithAllOf, parameterSource, componentsAndPaths),
-      output_validationTypeArray = deref.resolveRefs(schemaWithTypeArray, parameterSource, componentsAndPaths,
-        {}, 'VALIDATION');
+      });
 
+      // deref.resolveRef() should not change minItems and maxItems for VALIDATION
+      expect(output_validationTypeArray).to.deep.include({
+        type: 'array',
+        items: {
+          type: 'string'
+        },
+        minItems: 5,
+        maxItems: 55
+      });
 
-    expect(output).to.deep.include({ type: 'object',
-      required: ['id'],
-      properties: { id: { default: '<long>', type: 'integer' } } });
-
-    expect(output_withdot).to.deep.include({ type: 'object',
-      required: ['id'],
-      properties: { id: { default: '<long>', type: 'integer' } } });
-
-    expect(output_customFormat).to.deep.include({ type: 'object',
-      properties: { emailField: { default: '<email>', type: 'string' } } });
-
-    expect(output_withAllOf).to.deep.include({
-      type: 'object',
-      description: 'Schema 2',
-      properties: {
-        id: { default: '<long>', type: 'integer' },
-        test_prop: { default: '<string>', type: 'string' }
-      }
+      done();
     });
 
-    // deref.resolveRef() should not change minItems and maxItems for VALIDATION
-    expect(output_validationTypeArray).to.deep.include({
-      type: 'array',
-      items: {
-        type: 'string'
-      },
-      minItems: 5,
-      maxItems: 55
-    });
-
-    done();
-  });
-
-  it('should populate schemaResolutionCache having key as the ref provided', function (done) {
-    var schema = {
-        $ref: '#/components/schema/request'
-      },
-      componentsAndPaths = {
-        components: {
-          schema: {
-            request: {
-              properties: {
-                name: {
-                  type: 'string',
-                  example: 'example name'
+    it('should populate schemaResolutionCache having key as the ref provided', function (done) {
+      var schema = {
+          $ref: '#/components/schema/request'
+        },
+        componentsAndPaths = {
+          components: {
+            schema: {
+              request: {
+                properties: {
+                  name: {
+                    type: 'string',
+                    example: 'example name'
+                  }
                 }
               }
             }
           }
+        },
+        parameterSource = 'REQUEST',
+        schemaResolutionCache = {},
+        resolvedSchema = deref.resolveRefs(schema, parameterSource, componentsAndPaths, schemaResolutionCache);
+      expect(schemaResolutionCache).to.deep.equal({
+        '#/components/schema/request': resolvedSchema
+      });
+      expect(resolvedSchema).to.deep.equal({
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            example: 'example name',
+            default: '<string>'
+          }
         }
-      },
-      parameterSource = 'REQUEST',
-      schemaResolutionCache = {},
-      resolvedSchema = deref.resolveRefs(schema, parameterSource, componentsAndPaths, schemaResolutionCache);
-    expect(schemaResolutionCache).to.deep.equal({
-      '#/components/schema/request': resolvedSchema
+      });
+      done();
     });
-    expect(resolvedSchema).to.deep.equal({
-      type: 'object',
-      properties: {
-        name: {
-          type: 'string',
-          example: 'example name',
-          default: '<string>'
-        }
-      }
+
+    it('should only contain format property in resolved schema for supported formats', function(done) {
+      var schema = {
+          $ref: '#/components/schemas/schemaWithFormat'
+        },
+        allSupportedFormats = [
+          'date', 'time', 'date-time', 'uri', 'uri-reference', 'uri-template', 'email',
+          'hostname', 'ipv4', 'ipv6', 'regex', 'uuid', 'json-pointer'
+        ],
+        nonSupportedFormats = [
+          { type: 'integer', format: 'int32' },
+          { type: 'integer', format: 'int64' },
+          { type: 'number', format: 'float' },
+          { type: 'number', format: 'double' },
+          { type: 'string', format: 'byte' },
+          { type: 'string', format: 'binary' },
+          { type: 'string', format: 'password' },
+          { type: 'string', format: 'nonExistentFormat' }
+        ],
+        parameterSource = 'REQUEST',
+        output;
+
+      // check for supported formats
+      _.forEach(allSupportedFormats, (supportedFormat) => {
+        output = deref.resolveRefs(schema, parameterSource,
+          { components: { schemas: { schemaWithFormat: { type: 'string', format: supportedFormat } } } });
+
+        expect(output.type).to.equal('string');
+        expect(output.format).to.equal(supportedFormat);
+      });
+
+      // check for not supported formats
+      _.forEach(nonSupportedFormats, (nonSupportedFormat) => {
+        output = deref.resolveRefs(schema, parameterSource,
+          { components: { schemas: { schemaWithFormat: nonSupportedFormat } } });
+
+        expect(output.type).to.equal(nonSupportedFormat.type);
+        expect(output.format).to.be.undefined;
+      });
+      done();
     });
-    done();
   });
 
   describe('_getEscaped should', function() {


### PR DESCRIPTION
This PR addresses issue regarding discrepency of formats b/w conversion and validation flows. Only formats that are supported is will have `format` property in resolved schema. 

Formats currently present in faker: https://github.com/postmanlabs/openapi-to-postman/blob/develop/assets/json-schema-faker.js#L24487.