### PR TITLE
Fixed issue where parameter resolution was "schema" when "example" was specified.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2418,7 +2418,7 @@ module.exports = {
    */
   getParamSerialisationInfo: function (param, parameterSource, components, schemaCache) {
     var paramName = _.get(param, 'name'),
-      paramSchema = deref.resolveRefs(param.schema, parameterSource, components,
+      paramSchema = deref.resolveRefs(_.cloneDeep(param.schema), parameterSource, components,
         _.get(schemaCache, 'schemaResolutionCache')),
       style, // style property defined/inferred from schema
       explode, // explode property defined/inferred from schema
@@ -2507,7 +2507,7 @@ module.exports = {
    */
   deserialiseParamValue: function (param, paramValue, parameterSource, components, schemaCache) {
     var constructedValue,
-      paramSchema = deref.resolveRefs(param.schema, parameterSource, components,
+      paramSchema = deref.resolveRefs(_.cloneDeep(param.schema), parameterSource, components,
         _.get(schemaCache, 'schemaResolutionCache')),
       isEvenNumber = (num) => {
         return (num % 2 === 0);
@@ -3093,7 +3093,7 @@ module.exports = {
     // below will make sure for exploded params actual schema of property present in collection is present
     _.forEach(schemaParams, (param) => {
       let pathPrefix = param.pathPrefix,
-        paramSchema = deref.resolveRefs(param.schema, PARAMETER_SOURCE.REQUEST, components, schemaCache),
+        paramSchema = deref.resolveRefs(_.cloneDeep(param.schema), PARAMETER_SOURCE.REQUEST, components, schemaCache),
         { style, explode } = this.getParamSerialisationInfo(param, PARAMETER_SOURCE.REQUEST, components, schemaCache),
         isPropSeparable = _.includes(['form', 'deepObject'], style);
 

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -2169,6 +2169,52 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         expect(retVal).to.eql(deserialisedParamValue);
       });
     });
+
+    it('should not override original parameter schema after execution', function () {
+      let param = {
+        name: 'id',
+        in: 'query',
+        description: 'ID of the object to fetch',
+        required: false,
+        schema: {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        },
+        style: 'form',
+        explode: true
+      };
+
+      SchemaUtils.deserialiseParamValue(param, 'id=id1&id=id2', 'REQUEST', {}, {});
+      expect(param.schema).to.have.property('type', 'array');
+      expect(param.schema.items).to.have.property('type', 'string');
+      expect(param.schema).to.not.have.property('default');
+    });
+  });
+
+  describe('getParamSerialisationInfo function', function () {
+    it('should not override original parameter schema after execution', function () {
+      let param = {
+        name: 'id',
+        in: 'query',
+        description: 'ID of the object to fetch',
+        required: false,
+        schema: {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        },
+        style: 'form',
+        explode: true
+      };
+
+      SchemaUtils.getParamSerialisationInfo(param, 'REQUEST', {}, {});
+      expect(param.schema).to.have.property('type', 'array');
+      expect(param.schema.items).to.have.property('type', 'string');
+      expect(param.schema).to.not.have.property('default');
+    });
   });
 });
 


### PR DESCRIPTION
This PR fixes incorrect resolution happening for parameter schema where after execution of some functions, parameter contained incorrectly resolved schema.