### PR TITLE
Fixed issue where mismatches were present when only primitive data types in body were present

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -88,7 +88,7 @@ const async = require('async'),
     'string': (d) => typeof d === 'string',
     'number': (d) => !isNaN(d),
     'integer': (d) => !isNaN(d) && Number.isInteger(Number(d)),
-    'boolean': (d) => d === 'true' || d === 'false',
+    'boolean': (d) => _.isBoolean(d) || d === 'true' || d === 'false',
     'array': (d) => Array.isArray(d),
     'object': (d) => typeof d === 'object' && !Array.isArray(d)
   },
@@ -2684,7 +2684,7 @@ module.exports = {
 
         // only do AJV if type is array or object
         // simpler cases are handled by a type check
-        if (schema.type === 'array' || schema.type === 'object') {
+        if (isCorrectType && needJsonMatching) {
           let filteredValidationError = validateSchema(schema, valueToUse, options);
 
           if (!_.isEmpty(filteredValidationError)) {

--- a/test/data/validationData/primitiveDataTypeBodyCollection.json
+++ b/test/data/validationData/primitiveDataTypeBodyCollection.json
@@ -1,0 +1,90 @@
+{
+  "item": [
+    {
+      "id": "69d7005c-6a60-4a30-b71f-7d88f9341898",
+      "name": "Demo invalid type",
+      "request": {
+        "name": "Demo invalid type",
+        "description": {},
+        "url": {
+          "path": [
+            "api"
+          ],
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "query": [],
+          "variable": []
+        },
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "method": "POST",
+        "auth": null,
+        "body": {
+          "mode": "raw",
+          "raw": "false"
+        }
+      },
+      "response": [
+        {
+          "id": "c457a34e-3b7d-4052-a034-3a2fe1cf7e24",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "api"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [
+                {
+                  "key": "",
+                  "value": null
+                }
+              ],
+              "variable": []
+            },
+            "method": "POST",
+            "body": {
+              "mode": "raw",
+              "raw": "true"
+            }
+          },
+          "status": "OK",
+          "code": 200,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "body": "123",
+          "cookie": [],
+          "_postman_previewlanguage": "json"
+        }
+      ],
+      "event": []
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "id": "baseUrl",
+      "type": "string",
+      "value": "/"
+    }
+  ],
+  "info": {
+    "_postman_id": "f12b0220-20c0-4619-bfae-7b8d7c7574cf",
+    "name": "Demo API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "",
+      "type": "text/plain"
+    }
+  }
+}

--- a/test/data/validationData/primitiveDataTypeBodySpec.yaml
+++ b/test/data/validationData/primitiveDataTypeBodySpec.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.0
+info:
+  version: 1.0
+  title: Demo API
+paths:
+  /api:
+    post:
+      summary: 'Demo invalid type'
+      requestBody:
+        description: 'Cannot use type boolean'
+        content:
+          application/json:
+              schema:
+                type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+                schema:
+                  type: integer
+                  minimum: 5
+                  maximum: 10

--- a/test/unit/validator.test.js
+++ b/test/unit/validator.test.js
@@ -515,5 +515,41 @@ describe('VALIDATE FUNCTION TESTS ', function () {
         done();
       });
     });
+
+    it('Should be able to validate and suggest correct value for body with primitive data type', function (done) {
+      let primitiveDataTypeBodySpec = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
+          '/primitiveDataTypeBodySpec.yaml'), 'utf-8'),
+        primitiveDataTypeBodyCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
+          '/primitiveDataTypeBodyCollection.json'), 'utf-8'),
+        resultObj,
+        responseObj,
+        historyRequest = [],
+        options = {
+          showMissingInSchemaErrors: true,
+          strictRequestMatching: true,
+          ignoreUnresolvedVariables: true,
+          validateMetadata: true,
+          suggestAvailableFixes: true,
+          detailedBlobValidation: false
+        },
+        schemaPack = new Converter.SchemaPack({ type: 'string', data: primitiveDataTypeBodySpec }, options);
+
+      getAllTransactions(JSON.parse(primitiveDataTypeBodyCollection), historyRequest);
+
+      schemaPack.validateTransaction(historyRequest, (err, result) => {
+        expect(err).to.be.null;
+        expect(result).to.be.an('object');
+
+        // request body is boolean
+        resultObj = result.requests[historyRequest[0].id].endpoints[0];
+        expect(resultObj.mismatches).to.have.lengthOf(0);
+
+        // request body is integer
+        responseObj = resultObj.responses[_.keys(resultObj.responses)[0]];
+        expect(responseObj.mismatches).to.have.lengthOf(1);
+        expect(responseObj.mismatches[0].suggestedFix.suggestedValue).to.be.within(5, 10);
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR fixes issue https://github.com/postmanlabs/postman-app-support/issues/8474. Also adds support for validating Request/Response Body with only primitive data types.