### PR TITLE
Added optional support for remote refs resolution.

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -108,6 +108,24 @@ module.exports = {
         usage: ['CONVERSION']
       },
       {
+        name: 'Resolve remote references',
+        id: 'resolveRemoteRefs',
+        type: 'boolean',
+        default: false,
+        description: 'Select whether to resolve remote references.',
+        external: true,
+        usage: ['CONVERSION']
+      },
+      {
+        name: 'Source URL of definition',
+        id: 'sourceUrl',
+        type: 'string',
+        default: '',
+        description: 'Specify source URL of definition to resolve remote references mentioned in it.',
+        external: true,
+        usage: ['CONVERSION']
+      },
+      {
         name: 'Enable Schema Faking',
         id: 'schemaFaker',
         type: 'boolean',

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -183,6 +183,34 @@ module.exports = {
     });
   },
 
+  /**
+   * Resolves remote and URL $ref from OpenAPI definition based on given options
+   *
+   * @param {*} openapi - OpenAPI definition
+   * @param {*} options - options
+   * @param {*} cb - callback function
+   * @return {*} - err if present
+   */
+  resolveRemoteRefs: function (openapi, options, cb) {
+    if (options.resolveRemoteRefs) {
+      resolver.resolve(openapi, options.sourceUrl, {
+        resolve: true,
+        externals: [],
+        externalRefs: {},
+        openapi: openapi
+      })
+        .then(function() {
+          return cb(null);
+        })
+        .catch(function(err) {
+          return cb(err);
+        });
+    }
+    else {
+      return cb(null);
+    }
+  },
+
   /** Resolves all OpenAPI file references and returns a single OAS Object
    *
    * @param {Object} source Root file path

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -237,90 +237,99 @@ class SchemaPack {
       return callback(new OpenApiErr('The schema must be validated before attempting conversion'));
     }
 
-    // this cannot be attempted before validation
-    componentsAndPaths = {
-      components: this.openapi.components,
-      paths: this.openapi.paths
-    };
-
-    // create and sanitize basic spec
-    openapi = this.openapi;
-    openapi.servers = _.isEmpty(openapi.servers) ? [{ url: '/' }] : openapi.servers;
-    openapi.securityDefs = _.get(openapi, 'components.securitySchemes', {});
-    openapi.baseUrl = _.get(openapi, 'servers.0.url', '{{baseURL}}');
-
-    // TODO: Multiple server variables need to be saved as environments
-    openapi.baseUrlVariables = _.get(openapi, 'servers.0.variables');
-
-    // Fix {scheme} and {path} vars in the URL to :scheme and :path
-    openapi.baseUrl = schemaUtils.fixPathVariablesInUrl(openapi.baseUrl);
-
-    // Creating a new instance of a Postman collection
-    // All generated folders and requests will go inside this
-    generatedStore.collection = new sdk.Collection({
-      info: {
-        name: _.get(openapi, 'info.title', COLLECTION_NAME)
+    parse.resolveRemoteRefs(this.openapi, options, (err) => {
+      if (err) {
+        return callback(null, {
+          result: false,
+          reason: err.name + ': ' + err.message
+        });
       }
-    });
 
-    if (openapi.security) {
-      authHelper = schemaUtils.getAuthHelper(openapi, openapi.security);
-      if (authHelper) {
-        generatedStore.collection.auth = authHelper;
+      // this cannot be attempted before validation
+      componentsAndPaths = {
+        components: this.openapi.components,
+        paths: this.openapi.paths
+      };
+
+      // create and sanitize basic spec
+      openapi = this.openapi;
+      openapi.servers = _.isEmpty(openapi.servers) ? [{ url: '/' }] : openapi.servers;
+      openapi.securityDefs = _.get(openapi, 'components.securitySchemes', {});
+      openapi.baseUrl = _.get(openapi, 'servers.0.url', '{{baseURL}}');
+
+      // TODO: Multiple server variables need to be saved as environments
+      openapi.baseUrlVariables = _.get(openapi, 'servers.0.variables');
+
+      // Fix {scheme} and {path} vars in the URL to :scheme and :path
+      openapi.baseUrl = schemaUtils.fixPathVariablesInUrl(openapi.baseUrl);
+
+      // Creating a new instance of a Postman collection
+      // All generated folders and requests will go inside this
+      generatedStore.collection = new sdk.Collection({
+        info: {
+          name: _.get(openapi, 'info.title', COLLECTION_NAME)
+        }
+      });
+
+      if (openapi.security) {
+        authHelper = schemaUtils.getAuthHelper(openapi, openapi.security);
+        if (authHelper) {
+          generatedStore.collection.auth = authHelper;
+        }
       }
-    }
-    // ---- Collection Variables ----
-    // adding the collection variables for all the necessary root level variables
-    // and adding them to the collection variables
-    schemaUtils.convertToPmCollectionVariables(
-      openapi.baseUrlVariables,
-      'baseUrl',
-      openapi.baseUrl
-    ).forEach((element) => {
-      generatedStore.collection.variables.add(element);
-    });
+      // ---- Collection Variables ----
+      // adding the collection variables for all the necessary root level variables
+      // and adding them to the collection variables
+      schemaUtils.convertToPmCollectionVariables(
+        openapi.baseUrlVariables,
+        'baseUrl',
+        openapi.baseUrl
+      ).forEach((element) => {
+        generatedStore.collection.variables.add(element);
+      });
 
-    generatedStore.collection.describe(schemaUtils.getCollectionDescription(openapi));
+      generatedStore.collection.describe(schemaUtils.getCollectionDescription(openapi));
 
-    // Only change the stack limit if the optimizeConversion option is true
-    if (options.optimizeConversion) {
-      // Deciding stack limit based on size of the schema, number of refs and number of paths.
-      analysis = schemaUtils.analyzeSpec(openapi);
+      // Only change the stack limit if the optimizeConversion option is true
+      if (options.optimizeConversion) {
+        // Deciding stack limit based on size of the schema, number of refs and number of paths.
+        analysis = schemaUtils.analyzeSpec(openapi);
 
-      // Update options on the basis of analysis.
-      options = schemaUtils.determineOptions(analysis, options);
-    }
-
-
-    // ---- Collection Items ----
-    // Adding the collection items from openapi spec based on folderStrategy option
-    // For tags, All operations are grouped based on respective tags object
-    // For paths, All operations are grouped based on corresponding paths
-    try {
-      if (options.folderStrategy === 'tags') {
-        schemaUtils.addCollectionItemsUsingTags(openapi, generatedStore, componentsAndPaths, options, schemaCache);
+        // Update options on the basis of analysis.
+        options = schemaUtils.determineOptions(analysis, options);
       }
-      else {
-        schemaUtils.addCollectionItemsUsingPaths(openapi, generatedStore, componentsAndPaths, options, schemaCache);
+
+
+      // ---- Collection Items ----
+      // Adding the collection items from openapi spec based on folderStrategy option
+      // For tags, All operations are grouped based on respective tags object
+      // For paths, All operations are grouped based on corresponding paths
+      try {
+        if (options.folderStrategy === 'tags') {
+          schemaUtils.addCollectionItemsUsingTags(openapi, generatedStore, componentsAndPaths, options, schemaCache);
+        }
+        else {
+          schemaUtils.addCollectionItemsUsingPaths(openapi, generatedStore, componentsAndPaths, options, schemaCache);
+        }
       }
-    }
-    catch (e) {
-      return callback(e);
-    }
+      catch (e) {
+        return callback(e);
+      }
 
-    collectionJSON = generatedStore.collection.toJSON();
+      collectionJSON = generatedStore.collection.toJSON();
 
-    // this needs to be deleted as even if version is not specified to sdk,
-    // it returns a version property with value set as undefined
-    // this fails validation against v2.1 collection schema definition.
-    delete collectionJSON.info.version;
+      // this needs to be deleted as even if version is not specified to sdk,
+      // it returns a version property with value set as undefined
+      // this fails validation against v2.1 collection schema definition.
+      delete collectionJSON.info.version;
 
-    return callback(null, {
-      result: true,
-      output: [{
-        type: 'collection',
-        data: collectionJSON
-      }]
+      return callback(null, {
+        result: true,
+        output: [{
+          type: 'collection',
+          data: collectionJSON
+        }]
+      });
     });
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -22,6 +22,7 @@ module.exports = {
 
         // check the type of the value of that option came from the user
         switch (defaultOptions[id].type) {
+          case 'string':
           case 'boolean':
             if (typeof userOptions[id] === defaultOptions[id].type) {
               retVal[id] = userOptions[id];


### PR DESCRIPTION
This PR adds support for resolution of Remote and URL refs (see [here](https://swagger.io/docs/specification/using-ref/#ref-syntax) for docs) via options `resolveRemoteRefs` and `sourceUrl`.