### PR TITLE
Released v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # OpenAPI-Postman Changelog
+#### v2.0.0 (October 15, 2020)
+* Updated minimum supported node version to v8.
+* Fixed issue where schemas in allOf were not resolved correctly.
+* Added support for options in CLI converter.
+* Bumped up few dev-dependency versions.
+
 #### v1.2.7 (September 9, 2020)
 * Fixed issue where schema type object with no properties reolved to string.
 * Fix for [#8474](https://github.com/postmanlabs/postman-app-support/issues/8474) - Unable to validate primitive data types in req/res body.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-to-postmanv2",
-  "version": "1.2.7",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-to-postmanv2",
-  "version": "1.2.7",
+  "version": "2.0.0",
   "description": "Convert a given OpenAPI specification to Postman Collection v2.0",
   "homepage": "https://github.com/postmanlabs/openapi-to-postman",
   "bugs": "https://github.com/postmanlabs/openapi-to-postman/issues",


### PR DESCRIPTION
* Updated minimum supported node version to v8.
* Fixed issue where schemas in `allOf` were not resolved correctly.
* Added support for options in CLI converter.
* Bumped up few dev-dependency versions.