### PR TITLE
Readme Version Flag Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The converter can be used as a CLI tool as well. The following [command line opt
 `openapi2postmanv2 [options]`
 
 ### Options
-- `-V`, `--version`  
+- `-v`, `--version`  
   Specifies the version of the converter
 
 - `-s <source>`, `--spec <source>`  


### PR DESCRIPTION
Fixes capitalization typo for command line version flag (-v not -V).