### PR TITLE
Fixed incorrect handling for explodable parameters for resolution schema.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1483,15 +1483,22 @@ module.exports = {
           });
           return pmParams;
         }
+
+        // handle free-form parameter correctly
+        if (explode && (_.get(param, 'schema.type') === 'object') && _.isEmpty(_.get(param, 'schema.properties'))) {
+          return pmParams;
+        }
         break;
       case 'deepObject':
-        _.forOwn(paramValue, (value, key) => {
-          pmParams.push({
-            key: param.name + '[' + key + ']',
-            value: (value === undefined ? '' : value),
-            description
+        if (_.isObject(paramValue)) {
+          _.forOwn(paramValue, (value, key) => {
+            pmParams.push({
+              key: param.name + '[' + key + ']',
+              value: (value === undefined ? '' : value),
+              description
+            });
           });
-        });
+        }
         return pmParams;
       default:
         break;

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -1483,6 +1483,27 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         });
       });
     });
+
+    describe('Should convert queryParam with schema {type:object, properties: undefined, explode: true, ', function() {
+      let emptyObjParam = {
+        name: 'empty-obj',
+        in: 'query',
+        description: 'query param',
+        schema: { type: 'object' }
+      };
+
+      it('style:deepObject } to pm param', function (done) {
+        let pmParam = SchemaUtils.convertToPmQueryParameters(_.assign(emptyObjParam, { style: 'deepObject' }));
+        expect(pmParam).to.eql([]);
+        done();
+      });
+
+      it('style:form } to pm param', function (done) {
+        let pmParam = SchemaUtils.convertToPmQueryParameters(_.assign(emptyObjParam, { style: 'form' }));
+        expect(pmParam).to.eql([]);
+        done();
+      });
+    });
   });
 
   describe('convertToPmBody function', function() {


### PR DESCRIPTION
This PR fixes handling of empty objects (free form parameters) for parameters with explodable styles (i.e. `deepobject` and `form`).

Fixes: https://github.com/postmanlabs/openapi-to-postman/issues/69