### PR TITLE
Fixed issue where parameter examples were not used in faked data.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -382,6 +382,26 @@ module.exports = {
   },
 
   /**
+   * Given parameter objects, it assigns example/examples of parameter object as schema example.
+   *
+   * @param {Object} parameter - parameter object
+   * @returns {null} - null
+   */
+  assignParameterExamples: function (parameter) {
+    let example = _.get(parameter, 'example'),
+      examples = _.values(_.get(parameter, 'examples'));
+
+    if (example) {
+      _.set(parameter, 'schema.example', example);
+    }
+    else if (examples) {
+      let exampleToUse = _.get(examples, '[0].value');
+
+      exampleToUse && (_.set(parameter, 'schema.example', exampleToUse));
+    }
+  },
+
+  /**
    * Converts the neccessary server variables to the
    * something that can be added to the collection
    * TODO: Figure out better description
@@ -887,12 +907,18 @@ module.exports = {
     }
     else {
       _.forEach(commonPathVars, (variable) => {
-        let fakedData = options.schemaFaker ?
-            safeSchemaFaker(variable.schema || {}, options.requestParametersResolution, PROCESSING_TYPE.CONVERSION,
-              PARAMETER_SOURCE.REQUEST, components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache,
-              options.stackLimit) : '',
-          convertedPathVar = this.convertParamsWithStyle(variable, fakedData, PARAMETER_SOURCE.REQUEST,
-            components, schemaCache);
+        let fakedData,
+          convertedPathVar;
+
+        this.assignParameterExamples(variable);
+
+        fakedData = options.schemaFaker ?
+          safeSchemaFaker(variable.schema || {}, options.requestParametersResolution, PROCESSING_TYPE.CONVERSION,
+            PARAMETER_SOURCE.REQUEST, components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache,
+            options.stackLimit) : '';
+
+        convertedPathVar = this.convertParamsWithStyle(variable, fakedData, PARAMETER_SOURCE.REQUEST,
+          components, schemaCache);
 
         variables = _.concat(variables, convertedPathVar);
       });
@@ -1412,6 +1438,8 @@ module.exports = {
     }
     // check for existence of schema
     if (param.hasOwnProperty('schema')) {
+      this.assignParameterExamples(param);
+
       // fake data generated
       paramValue = options.schemaFaker ?
         safeSchemaFaker(param.schema, resolveTo, PROCESSING_TYPE.CONVERSION, PARAMETER_SOURCE.REQUEST,
@@ -1549,6 +1577,8 @@ module.exports = {
         fakeData = '';
       }
       else {
+        this.assignParameterExamples(header);
+
         fakeData = safeSchemaFaker(header.schema || {}, resolveTo, PROCESSING_TYPE.CONVERSION, parameterSource,
           components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache, options.stackLimit);
       }
@@ -3054,6 +3084,9 @@ module.exports = {
         return cb(null, mismatches);
       }
 
+      // assign parameter example(s) as schema examples
+      this.assignParameterExamples(schemaPathVar);
+
       resolvedParamValue = this.deserialiseParamValue(schemaPathVar, pathVar.value, PARAMETER_SOURCE.REQUEST,
         components, schemaCache);
 
@@ -3083,6 +3116,10 @@ module.exports = {
       // go through required schemaPathVariables, and params that aren't found in the given transaction are errors
       _.each(schemaPathVariables, (pathVar) => {
         if (!_.find(determinedPathVariables, (param) => { return param.key === pathVar.name; })) {
+
+          // assign parameter example(s) as schema examples;
+          this.assignParameterExamples(pathVar);
+
           mismatchObj = {
             property: mismatchProperty,
             transactionJsonPath: transactionPathPrefix,
@@ -3316,6 +3353,9 @@ module.exports = {
         return cb(null, mismatches);
       }
 
+      // assign parameter example(s) as schema examples;
+      this.assignParameterExamples(schemaParam);
+
       if (!schemaParam.isResolvedParam) {
         resolvedParamValue = this.deserialiseParamValue(schemaParam, pQuery.value, PARAMETER_SOURCE.REQUEST,
           components, schemaCache);
@@ -3343,6 +3383,10 @@ module.exports = {
 
       _.each(_.filter(schemaParams, (q) => { return q.required; }), (qp) => {
         if (!_.find(requestQueryParams, (param) => { return param.key === qp.name; })) {
+
+          // assign parameter example(s) as schema examples;
+          this.assignParameterExamples(qp);
+
           mismatchObj = {
             property: mismatchProperty,
             transactionJsonPath: transactionPathPrefix,
@@ -3532,6 +3576,9 @@ module.exports = {
         return cb(null, mismatches);
       }
 
+      // assign parameter example(s) as schema examples;
+      this.assignParameterExamples(schemaHeader);
+
       resolvedParamValue = this.deserialiseParamValue(schemaHeader, pHeader.value, PARAMETER_SOURCE.REQUEST,
         components, schemaCache);
 
@@ -3560,6 +3607,10 @@ module.exports = {
 
       _.each(_.filter(schemaHeaders, (h) => { return h.required; }), (header) => {
         if (!_.find(reqHeaders, (param) => { return param.key === header.name; })) {
+
+          // assign parameter example(s) as schema examples;
+          this.assignParameterExamples(header);
+
           mismatchObj = {
             property: mismatchProperty,
             transactionJsonPath: transactionPathPrefix,
@@ -3628,6 +3679,9 @@ module.exports = {
         return cb(null, mismatches);
       }
 
+      // assign parameter example(s) as schema examples;
+      this.assignParameterExamples(schemaHeader);
+
       // header found in spec. check header's schema
       setTimeout(() => {
         if (!schemaHeader.schema) {
@@ -3659,6 +3713,10 @@ module.exports = {
         return h.required;
       }), (header) => {
         if (!_.find(resHeaders, (param) => { return param.key === header.name; })) {
+
+          // assign parameter example(s) as schema examples;
+          this.assignParameterExamples(header);
+
           mismatchObj = {
             property: mismatchProperty,
             transactionJsonPath: transactionPathPrefix,

--- a/test/data/valid_openapi/parameteres_with_examples.yaml
+++ b/test/data/valid_openapi/parameteres_with_examples.yaml
@@ -1,0 +1,47 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+            format: uuid
+            example: 8bjbjbbjh-3b7-4bad-9bdd-2b0d7b3dcb6d
+          example: 9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+          examples:
+            example1:
+              value: 123
+            example2:
+              value: 456
+        - name: x-date
+          in: header
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: string
+            format: date
+          example: '2003-02-17'
+      responses:
+        '200':
+          description: Expected response to a valid request

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -40,7 +40,8 @@ describe('CONVERT FUNCTION TESTS ', function() {
       tagsFolderSpec = path.join(__dirname, VALID_OPENAPI_PATH + '/petstore-detailed.yaml'),
       securityTestCases = path.join(__dirname, VALID_OPENAPI_PATH + '/security-test-cases.yaml'),
       emptySecurityTestCase = path.join(__dirname, VALID_OPENAPI_PATH + '/empty-security-test-case.yaml'),
-      rootUrlServerWithVariables = path.join(__dirname, VALID_OPENAPI_PATH + '/root_url_server_with_variables.json');
+      rootUrlServerWithVariables = path.join(__dirname, VALID_OPENAPI_PATH + '/root_url_server_with_variables.json'),
+      parameterExamples = path.join(__dirname, VALID_OPENAPI_PATH + '/parameteres_with_examples.yaml');
 
 
     it('Should add collection level auth with type as `bearer`' +
@@ -904,6 +905,24 @@ describe('CONVERT FUNCTION TESTS ', function() {
         expect(_.find(collectionVars, { id: 'BASE_URI' }).value).to.eql('https://api.example.com');
         done();
       });
+    });
+
+    it('Should prefer and use example from parameter object over schema example while faking schema', function(done) {
+      Converter.convert({ type: 'file', data: parameterExamples },
+        { schemaFaker: true, requestParametersResolution: 'example' },
+        (err, conversionResult) => {
+          let rootRequest = conversionResult.output[0].data.item[0].request;
+
+          expect(rootRequest.url.query[0].key).to.equal('limit');
+          expect(rootRequest.url.query[0].value).to.equal('123');
+
+          expect(rootRequest.url.variable[0].key).to.equal('petId');
+          expect(rootRequest.url.variable[0].value).to.equal('9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d');
+
+          expect(rootRequest.header[0].key).to.equal('x-date');
+          expect(rootRequest.header[0].value).to.equal('2003-02-17');
+          done();
+        });
     });
   });
 


### PR DESCRIPTION
This PR fixes issue where during conversion and validation, parameter example(s) were not considered in param value schema faking and were ignored all together.

Fixes: https://github.com/postmanlabs/postman-app-support/issues/9080