### PR TITLE
Fixed issue where for type array examples with more than 2 elements were not used.

### DIFF
--- a/assets/json-schema-faker.js
+++ b/assets/json-schema-faker.js
@@ -24561,7 +24561,7 @@ function extend() {
 
         // avoid minItems and maxItems while checking for valid examples
         if (optionAPI('avoidExampleItemsLength') && _.get(schema, 'type') === 'array') {
-          clonedSchema = _.cloneDeep(schema);
+          clonedSchema = _.clone(schema);
           _.unset(clonedSchema, 'minItems');
           _.unset(clonedSchema, 'maxItems');
 

--- a/assets/json-schema-faker.js
+++ b/assets/json-schema-faker.js
@@ -10,7 +10,8 @@
  * Date: 2018-04-09 17:23:23.954Z
  */
 
-var validateSchema = require('../lib/ajvValidation').validateSchema;
+var _ = require('lodash'),
+  validateSchema = require('../lib/ajvValidation').validateSchema;
 
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
@@ -23566,6 +23567,7 @@ function extend() {
               data['optionalsProbability'] = 0.0;
               data['useDefaultValue'] = false;
               data['useExamplesValue'] = false;
+              data['avoidExampleItemsLength'] = false;
               data['requiredOnly'] = false;
               data['minItems'] = 0;
               data['maxItems'] = null;
@@ -24554,7 +24556,20 @@ function extend() {
           return;
       }
       if (optionAPI('useExamplesValue') && 'example' in schema) {
-        var result = validateSchema(schema, schema.example);
+        var clonedSchema,
+          result;
+
+        // avoid minItems and maxItems while checking for valid examples
+        if (optionAPI('avoidExampleItemsLength') && _.get(schema, 'type') === 'array') {
+          clonedSchema = _.cloneDeep(schema);
+          _.unset(clonedSchema, 'minItems');
+          _.unset(clonedSchema, 'maxItems');
+
+          result = validateSchema(clonedSchema, schema.example);
+        }
+        else {
+          result = validateSchema(schema, schema.example);
+        }
 
         // Use example only if valid 
         if (result && result.length === 0) {

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -104,7 +104,8 @@ schemaFaker.option({
   minItems: 1, // for arrays
   maxItems: 20, // limit on maximum number of items faked for (type: arrray)
   useDefaultValue: true,
-  ignoreMissingRefs: true
+  ignoreMissingRefs: true,
+  avoidExampleItemsLength: true // option to avoid validating type array schema example's minItems and maxItems props.
 });
 
 /**
@@ -156,7 +157,8 @@ function safeSchemaFaker(oldSchema, resolveTo, resolveFor, parameterSourceOption
 
   if (resolveFor === PROCESSING_TYPE.VALIDATION) {
     schemaFaker.option({
-      useDefaultValue: false
+      useDefaultValue: false,
+      avoidExampleItemsLength: false
     });
   }
 

--- a/test/unit/faker.test.js
+++ b/test/unit/faker.test.js
@@ -1,0 +1,44 @@
+const expect = require('chai').expect,
+  schemaFaker = require('../../assets/json-schema-faker.js');
+
+// define options used similar while faking in schemaUtils.safeSchemFaker()
+schemaFaker.option({
+  requiredOnly: false,
+  optionalsProbability: 1.0,
+  minLength: 4,
+  maxLength: 4,
+  minItems: 1,
+  maxItems: 20,
+  useDefaultValue: true,
+  useExamplesValue: true,
+  ignoreMissingRefs: true,
+  avoidExampleItemsLength: false
+});
+
+describe('JSON SCHEMA FAKER TESTS', function () {
+  describe('Custom defined option "avoidExampleItemsLength"', function () {
+    const schema = {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          timebase: { type: 'string' },
+          linkid: { type: 'string' },
+          chartRef: { type: 'string' }
+        }
+      },
+      example: [
+        { timebase: 'q', linkid: '250', chartRef: '5f123' },
+        { timebase: 'p', linkid: '251', chartRef: '5f623' },
+        { timebase: 'r', linkid: '252', chartRef: '5f183' }
+      ]
+    };
+
+    it('Should use example with more than two elements for type array schema in faking. GitHub#9344', function () {
+      var fakedData = schemaFaker(schema);
+
+      schemaFaker.option({ avoidExampleItemsLength: true });
+      expect(fakedData).to.deep.equal(schema.example);
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes issue with schema example validation before assignment for type array.

https://github.com/postmanlabs/postman-app-support/issues/9344