### PR TITLE
Fixed issue where exmples which had non-truthy value were not present in converted collection.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -399,7 +399,7 @@ module.exports = {
     else if (examples) {
       let exampleToUse = _.get(examples, '[0].value');
 
-      exampleToUse && (_.set(parameter, 'schema.example', exampleToUse));
+      !_.isUndefined(exampleToUse) && (_.set(parameter, 'schema.example', exampleToUse));
     }
   },
 

--- a/test/data/valid_openapi/examples_outside_schema.json
+++ b/test/data/valid_openapi/examples_outside_schema.json
@@ -7,6 +7,26 @@
   "paths": {
     "/pet": {
       "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "example": 25
+            },
+            "examples": {
+              "zero": {
+                "value": 0,
+                "summary": "A sample limit value  # Optional description"
+              },
+              "max": {
+                "value": 50,
+                "summary": "A sample limit value"
+              }
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -409,6 +409,20 @@ describe('CONVERT FUNCTION TESTS ', function() {
             done();
           });
       });
+
+      it('[Github #338] Should contain non-truthy example from examples outside of schema instead of faked value' +
+      examplesOutsideSchema, function(done) {
+        Converter.convert({ type: 'file', data: examplesOutsideSchema },
+          { schemaFaker: true, requestParametersResolution: 'example', exampleParametersResolution: 'example' },
+          (err, conversionResult) => {
+            let rootRequest = conversionResult.output[0].data.item[0].request;
+
+            expect(err).to.be.null;
+            expect(rootRequest.url.query[0].key).to.eql('limit');
+            expect(rootRequest.url.query[0].value).to.eql('0');
+            done();
+          });
+      });
     });
     it('[Github #117]- Should add the description in body params in case of urlencoded' +
     descriptionInBodyParams, function(done) {


### PR DESCRIPTION
This PR fixes issue https://github.com/postmanlabs/openapi-to-postman/issues/338.