### PR TITLE
Fixed issue where certain parameter were not converted to variables in conversion.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -306,11 +306,15 @@ module.exports = {
     // All complicated logic removed
     // This simply replaces all instances of {text} with {{text}}
     // text cannot have any of these 3 chars: /{}
-    // and {text} cannot be followed by a }
     // {{text}} will not be converted
-    // https://regex101.com/r/9N1520/1
-    return url
-      .replace(/(\{[^\/\{\}]+\})(?!\})/g, '{$1}');
+
+    let replacer = function (match, p1, offset, string) {
+      if (string[offset - 1] === '{' && string[offset + match.length + 1] !== '}') {
+        return match;
+      }
+      return '{' + p1 + '}';
+    };
+    return url.replace(/(\{[^\/\{\}]+\})/g, replacer);
   },
 
   /**

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -2017,6 +2017,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
 
       expect(SchemaUtils.fixPathVariablesInUrl('{{a}}')).to.equal('{{a}}');
 
+      expect(SchemaUtils.fixPathVariablesInUrl('/agents/{agentId}}')).to.equal('/agents/{{agentId}}}');
+
       expect(SchemaUtils.fixPathVariablesInUrl('{{a}}://{b}.com/{pathvar}/{morevar}'))
         .to.equal('{{a}}://{{b}}.com/{{pathvar}}/{{morevar}}');
 


### PR DESCRIPTION
This PR fixes issue where if path contained double closing curly braces but only one opening curly braces, conversion didn't treat parameter as variable and as simple text.