### PR TITLE
Fixed wrongly defined maxLength option for schemaFaker.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -99,8 +99,7 @@ const async = require('async'),
 schemaFaker.option({
   requiredOnly: false,
   optionalsProbability: 1.0, // always add optional fields
-  minLength: 4, // for faked strings
-  maxLength: 4,
+  maxLength: 256,
   minItems: 1, // for arrays
   maxItems: 20, // limit on maximum number of items faked for (type: arrray)
   useDefaultValue: true,


### PR DESCRIPTION
This PR fixes issue were maxLength in schema was overridden with small value (4) defined as schemafaker option.