### PR TITLE
[WIP] External reference for examples - ES6 Async Await for functions in schemaUtils

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,11 +4,11 @@ const SchemaPack = require('./lib/schemapack.js').SchemaPack;
 
 module.exports = {
   // Old API wrapping the new API
-  convert: function(input, options, cb) {
+  convert: async function(input, options, cb) {
     var schema = new SchemaPack(input, options);
 
     if (schema.validated) {
-      return schema.convert(cb);
+      return await schema.convert(cb);
     }
     return cb(null, schema.validationResult);
   },

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -7,6 +7,7 @@ const async = require('async'),
   sdk = require('postman-collection'),
   schemaFaker = require('../assets/json-schema-faker.js'),
   parse = require('./parse.js'),
+  fetch = require('isomorphic-fetch')
   deref = require('./deref.js'),
   _ = require('lodash'),
   xmlFaker = require('./xmlSchemaFaker.js'),
@@ -686,7 +687,7 @@ module.exports = {
    * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @returns {void} - generatedStore is modified in-place
    */
-  addCollectionItemsUsingPaths: function (spec, generatedStore, components, options, schemaCache) {
+  addCollectionItemsUsingPaths: async function (spec, generatedStore, components, options, schemaCache) {
     var folderTree,
       folderObj,
       child,
@@ -727,7 +728,7 @@ module.exports = {
       // requestCount is a property added to each node (folder/request) while constructing the trie
       if (folderTree.root.children.hasOwnProperty(child) && folderTree.root.children[child].requestCount > 0) {
         generatedStore.collection.items.add(
-          this.convertChildToItemGroup(spec, folderTree.root.children[child],
+          await this.convertChildToItemGroup(spec, folderTree.root.children[child],
             components, options, schemaCache, variableStore)
         );
       }
@@ -946,7 +947,7 @@ module.exports = {
    * @returns {*} Postman itemGroup or request
    * @no-unit-test
    */
-  convertChildToItemGroup: function (openapi, child, components, options, schemaCache, variableStore) {
+  convertChildToItemGroup: async function (openapi, child, components, options, schemaCache, variableStore) {
     options = _.merge({}, defaultOptions, options);
 
     var resource = child,
@@ -974,14 +975,14 @@ module.exports = {
           resourceSubChild = resource.children[subChild];
 
         resourceSubChild.name = resource.name + '/' + resourceSubChild.name;
-        return this.convertChildToItemGroup(openapi, resourceSubChild, components, options, schemaCache, variableStore);
+        return await this.convertChildToItemGroup(openapi, resourceSubChild, components, options, schemaCache, variableStore);
       }
       /* eslint-enable */
       // recurse over child leaf nodes
       // and add as children to this folder
       for (i = 0, requestCount = resource.requests.length; i < requestCount; i++) {
         itemGroup.items.add(
-          this.convertRequestToItem(openapi, resource.requests[i], components, options, schemaCache, variableStore)
+          await this.convertRequestToItem(openapi, resource.requests[i], components, options, schemaCache, variableStore)
         );
       }
 
@@ -991,7 +992,7 @@ module.exports = {
       for (subChild in resource.children) {
         if (resource.children.hasOwnProperty(subChild) && resource.children[subChild].requestCount > 0) {
           itemGroup.items.add(
-            this.convertChildToItemGroup(openapi, resource.children[subChild], components, options, schemaCache,
+            await this.convertChildToItemGroup(openapi, resource.children[subChild], components, options, schemaCache,
               variableStore)
           );
         }
@@ -1003,14 +1004,14 @@ module.exports = {
 
     // 2. it has only 1 direct request of its own
     if (resource.requests.length === 1) {
-      return this.convertRequestToItem(openapi, resource.requests[0], components, options, schemaCache, variableStore);
+      return await this.convertRequestToItem(openapi, resource.requests[0], components, options, schemaCache, variableStore);
     }
 
     // 3. it's a folder that has no child request
     // but one request somewhere in its child folders
     for (subChild in resource.children) {
       if (resource.children.hasOwnProperty(subChild) && resource.children[subChild].requestCount === 1) {
-        return this.convertChildToItemGroup(openapi, resource.children[subChild], components, options, schemaCache,
+        return await this.convertChildToItemGroup(openapi, resource.children[subChild], components, options, schemaCache,
           variableStore);
       }
     }
@@ -1222,7 +1223,7 @@ module.exports = {
   * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @return {object} responseBody, contentType header needed
    */
-  convertToPmResponseBody: function(contentObj, components, options, schemaCache) {
+  convertToPmResponseBody: async function(contentObj, components, options, schemaCache) {
     options = _.merge({}, defaultOptions, options);
 
     var responseBody, cTypeHeader, hasComputedType, cTypes;
@@ -1260,7 +1261,7 @@ module.exports = {
         };
       }
     }
-    responseBody = this.convertToPmBodyData(contentObj[cTypeHeader], REQUEST_TYPE.EXAMPLE, cTypeHeader,
+    responseBody = await this.convertToPmBodyData(contentObj[cTypeHeader], REQUEST_TYPE.EXAMPLE, cTypeHeader,
       PARAMETER_SOURCE.RESPONSE, options.indentCharacter, components, options, schemaCache);
     if (this.getHeaderFamily(cTypeHeader) === HEADER_TYPE.JSON) {
       responseBody = JSON.stringify(responseBody, null, options.indentCharacter);
@@ -1310,7 +1311,7 @@ module.exports = {
    * @param {*} exampleObj map[string, exampleObject]
    * @returns {*} first example in the input map type
    */
-  getExampleData: function(exampleObj, components, options) {
+  getExampleData: async function(exampleObj, components, options) {
     options = _.merge({}, defaultOptions, options);
 
     var example,
@@ -1328,8 +1329,15 @@ module.exports = {
       example = this.getRefObject(example.$ref, components, options);
     }
 
-    if (example.hasOwnProperty('value')) {
+    else if (example.hasOwnProperty('value')) {
       example = example.value;
+    }
+
+    else if(example.hasOwnProperty('externalValue')) {
+      data = await fetch(example.externalValue)
+      example = await data.json()
+      example = example[0]
+      console.log(example)
     }
 
     return example;
@@ -1352,7 +1360,7 @@ module.exports = {
   // and generate the body accordingly
   // right now, even if the content-type was XML, we'll generate
   // a JSON example/schema
-  convertToPmBodyData: function(bodyObj, requestType, contentType, parameterSourceOption,
+  convertToPmBodyData: async function(bodyObj, requestType, contentType, parameterSourceOption,
     indentCharacter, components, options, schemaCache) {
 
     options = _.merge({}, defaultOptions, options);
@@ -1384,7 +1392,7 @@ module.exports = {
     }
     else if (!_.isEmpty(bodyObj.examples) && (resolveTo === 'example' || !bodyObj.schema)) {
       // take one of the examples as the body and not all
-      bodyData = this.getExampleData(bodyObj.examples, components, options);
+      bodyData = await this.getExampleData(bodyObj.examples, components, options);
     }
     else if (bodyObj.schema) {
       if (bodyObj.schema.hasOwnProperty('$ref')) {
@@ -1655,7 +1663,7 @@ module.exports = {
   * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @returns {Object} - Postman requestBody and Content-Type Header
    */
-  convertToPmBody: function(requestBody, requestType, components, options, schemaCache) {
+  convertToPmBody: async function(requestBody, requestType, components, options, schemaCache) {
     options = _.merge({}, defaultOptions, options);
     var contentObj, // content is required
       bodyData,
@@ -1691,7 +1699,7 @@ module.exports = {
       if (contentObj[URLENCODED].hasOwnProperty('schema') && contentObj[URLENCODED].schema.hasOwnProperty('$ref')) {
         contentObj[URLENCODED].schema = this.getRefObject(contentObj[URLENCODED].schema.$ref, components, options);
       }
-      bodyData = this.convertToPmBodyData(contentObj[URLENCODED], requestType, URLENCODED,
+      bodyData = await this.convertToPmBodyData(contentObj[URLENCODED], requestType, URLENCODED,
         PARAMETER_SOURCE.REQUEST, options.indentCharacter, components, options, schemaCache);
       encoding = contentObj[URLENCODED].encoding ? contentObj[URLENCODED].encoding : {};
       // create query parameters and add it to the request body object
@@ -1750,7 +1758,7 @@ module.exports = {
     }
     else if (contentObj.hasOwnProperty(FORM_DATA)) {
       rDataMode = 'formdata';
-      bodyData = this.convertToPmBodyData(contentObj[FORM_DATA], requestType, FORM_DATA,
+      bodyData = await this.convertToPmBodyData(contentObj[FORM_DATA], requestType, FORM_DATA,
         PARAMETER_SOURCE.REQUEST, options.indentCharacter, components, options, schemaCache);
       encoding = contentObj[FORM_DATA].encoding ? contentObj[FORM_DATA].encoding : {};
       // create the form parameters and add it to the request body object
@@ -1832,7 +1840,7 @@ module.exports = {
         }
       }
 
-      bodyData = this.convertToPmBodyData(contentObj[bodyType], requestType, bodyType,
+      bodyData = await this.convertToPmBodyData(contentObj[bodyType], requestType, bodyType,
         PARAMETER_SOURCE.REQUEST, options.indentCharacter, components, options, schemaCache);
 
       updateOptions = {
@@ -1865,7 +1873,7 @@ module.exports = {
   * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @returns {Object} postman response
    */
-  convertToPmResponse: function(response, code, originalRequest, components, options, schemaCache) {
+  convertToPmResponse: async function(response, code, originalRequest, components, options, schemaCache) {
     options = _.merge({}, defaultOptions, options);
     var responseHeaders = [],
       previewLanguage = 'text',
@@ -1895,7 +1903,7 @@ module.exports = {
       }
     });
 
-    responseBodyWrapper = this.convertToPmResponseBody(response.content, components, options, schemaCache);
+    responseBodyWrapper = await this.convertToPmResponseBody(response.content, components, options, schemaCache);
 
     if (responseBodyWrapper.contentTypeHeader) {
       // we could infer the content-type header from the body
@@ -2096,7 +2104,7 @@ module.exports = {
   * @returns {Object} postman request Item
   * @no-unit-test
   */
-  convertRequestToItem: function(openapi, operationItem, components, options, schemaCache, variableStore) {
+  convertRequestToItem: async function(openapi, operationItem, components, options, schemaCache, variableStore) {
     options = _.merge({}, defaultOptions, options);
     var reqName,
       pathVariables = openapi.baseUrlVariables,
@@ -2313,7 +2321,7 @@ module.exports = {
       if (reqBody.$ref) {
         reqBody = this.getRefObject(reqBody.$ref, components, options);
       }
-      pmBody = this.convertToPmBody(reqBody, REQUEST_TYPE.ROOT, components, options, schemaCache);
+      pmBody = await this.convertToPmBody(reqBody, REQUEST_TYPE.ROOT, components, options, schemaCache);
       item.request.body = pmBody.body;
       item.request.addHeader(pmBody.contentHeader);
       // extra form headers if encoding is present in request Body.
@@ -2344,57 +2352,58 @@ module.exports = {
         });
       }
 
-      _.forOwn(operation.responses, (response, code) => {
-        let originalRequestHeaders = [],
-          originalRequestQueryParams = this.convertToPmQueryArray(reqParams, REQUEST_TYPE.EXAMPLE,
+      let result = await Promise.all(
+        _.map(operation.responses, async (response, code) => {
+          let originalRequestHeaders = [],
+            originalRequestQueryParams = this.convertToPmQueryArray(reqParams, REQUEST_TYPE.EXAMPLE,
+              components, options, schemaCache);
+
+          swagResponse = response;
+          if (response.$ref) {
+            swagResponse = this.getRefObject(response.$ref, components, options);
+          }
+
+          if (options.includeAuthInfoInExample) {
+            // add Authorization params if present
+            originalRequestQueryParams = _.concat(originalRequestQueryParams, authQueryParams);
+            originalRequestHeaders = _.concat(originalRequestHeaders, responseAuthHelper.header);
+          }
+
+          // Try and set fields for originalRequest (example.request)
+          thisOriginalRequest.method = item.request.method;
+          // setting URL
+          thisOriginalRequest.url = displayUrl;
+
+          // setting query params
+          if (originalRequestQueryParams.length) {
+            thisOriginalRequest.url += '?';
+            thisOriginalRequest.url += originalRequestQueryParams.join('&');
+          }
+
+          // setting headers
+          _.forEach(reqParams.header, (header) => {
+            originalRequestHeaders.push(this.convertToPmHeader(header, REQUEST_TYPE.EXAMPLE,
+              PARAMETER_SOURCE.REQUEST, components, options, schemaCache));
+          });
+
+          thisOriginalRequest.header = originalRequestHeaders;
+          // setting request body
+          try {
+            exampleRequestBody = await this.convertToPmBody(operationItem.properties.requestBody,
+              REQUEST_TYPE.EXAMPLE, components, options, schemaCache);
+            thisOriginalRequest.body = exampleRequestBody.body ? exampleRequestBody.body.toJSON() : {};
+          }
+          catch (e) {
+            // console.warn('Exception thrown while trying to json-ify body for item.request.body:', item.request.body,
+            // 'Exception:', e);
+            thisOriginalRequest.body = {};
+          }
+          convertedResponse = await this.convertToPmResponse(swagResponse, code, thisOriginalRequest,
             components, options, schemaCache);
-
-        swagResponse = response;
-        if (response.$ref) {
-          swagResponse = this.getRefObject(response.$ref, components, options);
-        }
-
-        if (options.includeAuthInfoInExample) {
-          // add Authorization params if present
-          originalRequestQueryParams = _.concat(originalRequestQueryParams, authQueryParams);
-          originalRequestHeaders = _.concat(originalRequestHeaders, responseAuthHelper.header);
-        }
-
-        // Try and set fields for originalRequest (example.request)
-        thisOriginalRequest.method = item.request.method;
-        // setting URL
-        thisOriginalRequest.url = displayUrl;
-
-        // setting query params
-        if (originalRequestQueryParams.length) {
-          thisOriginalRequest.url += '?';
-          thisOriginalRequest.url += originalRequestQueryParams.join('&');
-        }
-
-        // setting headers
-        _.forEach(reqParams.header, (header) => {
-          originalRequestHeaders.push(this.convertToPmHeader(header, REQUEST_TYPE.EXAMPLE,
-            PARAMETER_SOURCE.REQUEST, components, options, schemaCache));
-        });
-
-        thisOriginalRequest.header = originalRequestHeaders;
-        // setting request body
-        try {
-          exampleRequestBody = this.convertToPmBody(operationItem.properties.requestBody,
-            REQUEST_TYPE.EXAMPLE, components, options, schemaCache);
-          thisOriginalRequest.body = exampleRequestBody.body ? exampleRequestBody.body.toJSON() : {};
-        }
-        catch (e) {
-          // console.warn('Exception thrown while trying to json-ify body for item.request.body:', item.request.body,
-          // 'Exception:', e);
-          thisOriginalRequest.body = {};
-        }
-        convertedResponse = this.convertToPmResponse(swagResponse, code, thisOriginalRequest,
-          components, options, schemaCache);
-        convertedResponse && item.responses.add(convertedResponse);
-      });
+          convertedResponse && item.responses.add(convertedResponse);
+        })
+      )
     }
-
     return item;
   },
 
@@ -4325,7 +4334,7 @@ module.exports = {
    * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @returns {Array} - Array of all MISSING_ENDPOINT objects
    */
-  getMissingSchemaEndpoints: function (schema, matchedEndpoints, components, options, schemaCache) {
+  getMissingSchemaEndpoints: async function (schema, matchedEndpoints, components, options, schemaCache) {
     let endpoints = [],
       schemaPaths = schema.paths,
       rootCollectionVariables,

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -7,7 +7,7 @@ const async = require('async'),
   sdk = require('postman-collection'),
   schemaFaker = require('../assets/json-schema-faker.js'),
   parse = require('./parse.js'),
-  fetch = require('isomorphic-fetch')
+  fetch = require('isomorphic-fetch'),
   deref = require('./deref.js'),
   _ = require('lodash'),
   xmlFaker = require('./xmlSchemaFaker.js'),
@@ -975,14 +975,18 @@ module.exports = {
           resourceSubChild = resource.children[subChild];
 
         resourceSubChild.name = resource.name + '/' + resourceSubChild.name;
-        return await this.convertChildToItemGroup(openapi, resourceSubChild, components, options, schemaCache, variableStore);
+        return await this.convertChildToItemGroup(
+          openapi, resourceSubChild, components, options, schemaCache, variableStore
+        );
       }
       /* eslint-enable */
       // recurse over child leaf nodes
       // and add as children to this folder
       for (i = 0, requestCount = resource.requests.length; i < requestCount; i++) {
         itemGroup.items.add(
-          await this.convertRequestToItem(openapi, resource.requests[i], components, options, schemaCache, variableStore)
+          await this.convertRequestToItem(
+            openapi, resource.requests[i], components, options, schemaCache, variableStore
+          )
         );
       }
 
@@ -1004,15 +1008,18 @@ module.exports = {
 
     // 2. it has only 1 direct request of its own
     if (resource.requests.length === 1) {
-      return await this.convertRequestToItem(openapi, resource.requests[0], components, options, schemaCache, variableStore);
+      return await this.convertRequestToItem(
+        openapi, resource.requests[0], components, options, schemaCache, variableStore
+      );
     }
 
     // 3. it's a folder that has no child request
     // but one request somewhere in its child folders
     for (subChild in resource.children) {
       if (resource.children.hasOwnProperty(subChild) && resource.children[subChild].requestCount === 1) {
-        return await this.convertChildToItemGroup(openapi, resource.children[subChild], components, options, schemaCache,
-          variableStore);
+        return await this.convertChildToItemGroup(
+          openapi, resource.children[subChild], components, options, schemaCache, variableStore
+        );
       }
     }
   },
@@ -1333,11 +1340,10 @@ module.exports = {
       example = example.value;
     }
 
-    else if(example.hasOwnProperty('externalValue')) {
-      data = await fetch(example.externalValue)
-      example = await data.json()
-      example = example[0]
-      console.log(example)
+    else if (example.hasOwnProperty('externalValue')) {
+      let data = await fetch(example.externalValue);
+      example = await data.json();
+      example = example[0];
     }
 
     return example;
@@ -2352,7 +2358,7 @@ module.exports = {
         });
       }
 
-      let result = await Promise.all(
+      await Promise.all(
         _.map(operation.responses, async (response, code) => {
           let originalRequestHeaders = [],
             originalRequestQueryParams = this.convertToPmQueryArray(reqParams, REQUEST_TYPE.EXAMPLE,
@@ -2402,7 +2408,7 @@ module.exports = {
             components, options, schemaCache);
           convertedResponse && item.responses.add(convertedResponse);
         })
-      )
+      );
     }
     return item;
   },

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -221,7 +221,7 @@ class SchemaPack {
 
   // convert method, this is called when you want to convert a schema that you've already loaded
   // in the constructor
-  convert (callback) {
+  async convert (callback) {
     let openapi,
       options = this.computedOptions,
       analysis,
@@ -302,7 +302,7 @@ class SchemaPack {
         schemaUtils.addCollectionItemsUsingTags(openapi, generatedStore, componentsAndPaths, options, schemaCache);
       }
       else {
-        schemaUtils.addCollectionItemsUsingPaths(openapi, generatedStore, componentsAndPaths, options, schemaCache);
+        const res = await schemaUtils.addCollectionItemsUsingPaths(openapi, generatedStore, componentsAndPaths, options, schemaCache);
       }
     }
     catch (e) {

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -302,7 +302,9 @@ class SchemaPack {
         schemaUtils.addCollectionItemsUsingTags(openapi, generatedStore, componentsAndPaths, options, schemaCache);
       }
       else {
-        const res = await schemaUtils.addCollectionItemsUsingPaths(openapi, generatedStore, componentsAndPaths, options, schemaCache);
+        await schemaUtils.addCollectionItemsUsingPaths(
+          openapi, generatedStore, componentsAndPaths, options, schemaCache
+        );
       }
     }
     catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1220,6 +1220,15 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "requires": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
     "istanbul-lib-coverage": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
@@ -1630,6 +1639,11 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-fetch-h2": {
       "version": "2.3.0",
@@ -2724,6 +2738,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
       "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg="
+    },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "ajv": "6.12.3",
     "async": "3.2.0",
     "commander": "2.20.3",
+    "isomorphic-fetch": "^3.0.0",
     "js-yaml": "3.13.1",
     "json-schema-merge-allof": "0.7.0",
     "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "ajv": "6.12.3",
     "async": "3.2.0",
     "commander": "2.20.3",
-    "isomorphic-fetch": "^3.0.0",
+    "isomorphic-fetch": "3.0.0",
     "js-yaml": "3.13.1",
     "json-schema-merge-allof": "0.7.0",
     "lodash": "4.17.21",

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -646,30 +646,30 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
   });
 
   describe('convertToPmBodyData', function() {
-    it('should work for schemas', function() {
+    it('should work for schemas', async function() {
       var bodyWithSchema = {
           schema: {
             type: 'integer',
             format: 'int32'
           }
         },
-        retValSchema = SchemaUtils.convertToPmBodyData(bodyWithSchema, 'ROOT', 'application/json');
+        retValSchema = await SchemaUtils.convertToPmBodyData(bodyWithSchema, 'ROOT', 'application/json');
 
       expect(retValSchema).to.be.equal('<integer>');
     });
 
-    it('should work for example', function() {
+    it('should work for example', async function() {
       var bodyWithExample = {
           example: {
             value: 'This is a sample value'
           }
         },
-        retValExample = SchemaUtils.convertToPmBodyData(bodyWithExample, 'application/json');
+        retValExample = await SchemaUtils.convertToPmBodyData(bodyWithExample, 'application/json');
 
       expect(retValExample).to.equal('This is a sample value');
     });
 
-    it('should work for examples', function() {
+    it('should work for examples', async function() {
       var bodyWithExamples = {
           examples: {
             foo: {
@@ -680,19 +680,19 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           }
         },
-        retValExamples = SchemaUtils.convertToPmBodyData(bodyWithExamples, 'ROOT', 'application/json',
+        retValExamples = await SchemaUtils.convertToPmBodyData(bodyWithExamples, 'ROOT', 'application/json',
           'request', ' ', null, { requestParametersResolution: 'example' });
       expect(retValExamples.foo).to.equal(1);
       expect(retValExamples.bar).to.equal(2);
     });
 
-    it('should work for examples with a $ref for non-json requests', function() {
+    it('should work for examples with a $ref for non-json requests', async function() {
       var bodyWithExamples = {
           'example': {
             '$ref': '#/components/examples/SampleExample/value'
           }
         },
-        retValExample = SchemaUtils.convertToPmBodyData(bodyWithExamples, 'ROOT', 'text/plain',
+        retValExample = await SchemaUtils.convertToPmBodyData(bodyWithExamples, 'ROOT', 'text/plain',
           'request', ' ', {
             components: {
               examples: {
@@ -708,13 +708,13 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
       expect(retValExample).to.equal('Hello');
     });
 
-    it('should work for examples with a $ref for json requests', function() {
+    it('should work for examples with a $ref for json requests', async function() {
       var bodyWithExamples = {
           'example': {
             '$ref': '#/components/examples/SampleExample/value'
           }
         },
-        retValExample = SchemaUtils.convertToPmBodyData(bodyWithExamples, 'ROOT', 'application/json',
+        retValExample = await SchemaUtils.convertToPmBodyData(bodyWithExamples, 'ROOT', 'application/json',
           'request', ' ', {
             'components': {
               'examples': {
@@ -1508,7 +1508,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
 
   describe('convertToPmBody function', function() {
     describe('should convert requestbody of media type', function() {
-      it(' application/json', function(done) {
+      it(' application/json', async function() {
         var requestBody = {
             description: 'body description',
             content: {
@@ -1537,14 +1537,13 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           result, resultBody;
-        result = SchemaUtils.convertToPmBody(requestBody);
+        result = await SchemaUtils.convertToPmBody(requestBody);
         resultBody = JSON.parse(result.body.raw);
         expect(resultBody.id).to.equal('<long>');
         expect(resultBody.name).to.equal('<string>');
         expect(result.contentHeader).to.deep.include({ key: 'Content-Type', value: 'application/json' });
-        done();
       });
-      it(' application/x-www-form-urlencoded', function(done) {
+      it(' application/x-www-form-urlencoded', async function() {
         var requestBody = {
             description: 'body description',
             content: {
@@ -1554,14 +1553,13 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           result, resultBody;
-        result = SchemaUtils.convertToPmBody(requestBody);
+        result = await SchemaUtils.convertToPmBody(requestBody);
         resultBody = (result.body.urlencoded.toJSON());
         expect(resultBody).to.eql([]);
         expect(result.contentHeader).to.deep.include(
           { key: 'Content-Type', value: 'application/x-www-form-urlencoded' });
-        done();
       });
-      it(' multipart/form-data', function(done) {
+      it(' multipart/form-data', async function() {
         var requestBody = {
             description: 'body description',
             content: {
@@ -1582,14 +1580,13 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           result, resultBody;
-        result = SchemaUtils.convertToPmBody(requestBody);
+        result = await SchemaUtils.convertToPmBody(requestBody);
         resultBody = (result.body.formdata.toJSON());
         expect(resultBody[0].key).to.equal('file');
         expect(result.contentHeader).to.deep.include(
           { key: 'Content-Type', value: 'multipart/form-data' });
-        done();
       });
-      it(' text/xml', function(done) { // not properly done
+      it(' text/xml', async function() { // not properly done
         var requestBody = {
             description: 'body description',
             content: {
@@ -1604,16 +1601,15 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           result, resultBody;
-        result = SchemaUtils.convertToPmBody(requestBody, 'ROOT', {}, {
+        result = await SchemaUtils.convertToPmBody(requestBody, 'ROOT', {}, {
           requestParametersResolution: 'example'
         });
         resultBody = (result.body.raw);
         expect(resultBody).to.equal('"text/plain description"');
         expect(result.contentHeader).to.deep.include(
           { key: 'Content-Type', value: 'text/xml' });
-        done();
       });
-      it(' text/plain', function(done) {
+      it(' text/plain', async function() {
         var requestBody = {
             description: 'body description',
             content: {
@@ -1626,14 +1622,13 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           result, resultBody;
-        result = SchemaUtils.convertToPmBody(requestBody);
+        result = await SchemaUtils.convertToPmBody(requestBody);
         resultBody = result.body.raw;
         expect(resultBody).to.equal('"text/plain description"');
         expect(result.contentHeader).to.deep.include(
           { key: 'Content-Type', value: 'text/plain' });
-        done();
       });
-      it(' text/html', function(done) {
+      it(' text/html', async function() {
         var requestBody = {
             description: 'body description',
             content: {
@@ -1646,14 +1641,13 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           result, resultBody;
-        result = SchemaUtils.convertToPmBody(requestBody);
+        result = await SchemaUtils.convertToPmBody(requestBody);
         resultBody = (result.body.raw);
         expect(resultBody).to.equal('"<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>"');
         expect(result.contentHeader).to.deep.include(
           { key: 'Content-Type', value: 'text/html' });
-        done();
       });
-      it(' application/javascript', function(done) { // not properly done
+      it(' application/javascript', async function() { // not properly done
         var requestBody = {
             description: 'body description',
             content: {
@@ -1662,12 +1656,11 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           result, resultBody;
-        result = SchemaUtils.convertToPmBody(requestBody);
+        result = await SchemaUtils.convertToPmBody(requestBody);
         resultBody = (result.body.raw);
         expect(typeof resultBody).to.equal('string');
         expect(result.contentHeader).to.deep.include(
           { key: 'Content-Type', value: 'application/javascript' });
-        done();
       });
       // things remaining : application/xml
     });
@@ -1675,13 +1668,14 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
 
   describe('convertToPmResponseBody function', function() {
     describe('should convert content object to response body data', function() {
-      it('with undefined ContentObj', function() {
+      it('with undefined ContentObj', async function() {
         var contentObj,
           pmResponseBody;
-        pmResponseBody = SchemaUtils.convertToPmResponseBody(contentObj).responseBody;
+        pmResponseBody = await SchemaUtils.convertToPmResponseBody(contentObj);
+        pmResponseBody = pmResponseBody.responseBody;
         expect(pmResponseBody).to.equal('');
       });
-      it('with Content-Type application/json', function() {
+      it('with Content-Type application/json', async function() {
         var contentObj = {
             'application/json': {
               'schema': {
@@ -1703,11 +1697,12 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           pmResponseBody;
-        pmResponseBody = JSON.parse(SchemaUtils.convertToPmResponseBody(contentObj).responseBody);
+        pmResponseBody = await SchemaUtils.convertToPmResponseBody(contentObj);
+        pmResponseBody = JSON.parse(pmResponseBody.responseBody);
         expect(pmResponseBody.id).to.equal('<long>');
         expect(pmResponseBody.name).to.equal('<string>');
       });
-      it('with Content-Type application/vnd.retailer.v2+json', function() {
+      it('with Content-Type application/vnd.retailer.v2+json', async function() {
         var contentObj = {
             'application/vnd.retailer.v2+json': {
               'schema': {
@@ -1729,11 +1724,12 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           pmResponseBody;
-        pmResponseBody = JSON.parse(SchemaUtils.convertToPmResponseBody(contentObj).responseBody);
+        pmResponseBody = await SchemaUtils.convertToPmResponseBody(contentObj);
+        pmResponseBody = JSON.parse(pmResponseBody.responseBody);
         expect(pmResponseBody.id).to.equal('<long>');
         expect(pmResponseBody.name).to.equal('<string>');
       });
-      it('with Content-Type application/vnd.api+json', function() {
+      it('with Content-Type application/vnd.api+json', async function() {
         var contentObj = {
             'application/vnd.api+json': {
               'schema': {
@@ -1755,11 +1751,12 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           pmResponseBody;
-        pmResponseBody = JSON.parse(SchemaUtils.convertToPmResponseBody(contentObj).responseBody);
+        pmResponseBody = await SchemaUtils.convertToPmResponseBody(contentObj);
+        pmResponseBody = JSON.parse(pmResponseBody.responseBody);
         expect(pmResponseBody.id).to.equal('<long>');
         expect(pmResponseBody.name).to.equal('<string>');
       });
-      it('with Content-Type application/json and specified indentCharacter', function() {
+      it('with Content-Type application/json and specified indentCharacter', async function() {
         var contentObj = {
             'application/json': {
               'schema': {
@@ -1773,12 +1770,13 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           pmResponseBody;
-        pmResponseBody = SchemaUtils.convertToPmResponseBody(contentObj, {}, {
+        pmResponseBody = await SchemaUtils.convertToPmResponseBody(contentObj, {}, {
           indentCharacter: '\t'
-        }).responseBody;
+        });
+        pmResponseBody = pmResponseBody.responseBody;
         expect(pmResponseBody).to.equal('{\n\t"id": "<integer>"\n}');
       });
-      it('with Content-Type text/plain', function() {
+      it('with Content-Type text/plain', async function() {
         var contentObj = {
             'text/plain': {
               'schema': {
@@ -1787,10 +1785,11 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           pmResponseBody;
-        pmResponseBody = SchemaUtils.convertToPmResponseBody(contentObj).responseBody;
+        pmResponseBody = await SchemaUtils.convertToPmResponseBody(contentObj);
+        pmResponseBody = pmResponseBody.responseBody;
         expect(typeof pmResponseBody).to.equal('string');
       });
-      it('with Content-Type application/xml', function() {
+      it('with Content-Type application/xml', async function() {
         var contentObj = {
             'application/xml': {
               'schema': {
@@ -1813,9 +1812,10 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           pmResponseBody;
-        pmResponseBody = SchemaUtils.convertToPmResponseBody(contentObj, {}, {
+        pmResponseBody = await SchemaUtils.convertToPmResponseBody(contentObj, {}, {
           indentCharacter: ' '
-        }).responseBody;
+        });
+        pmResponseBody = pmResponseBody.responseBody;
         expect(pmResponseBody).to.equal(
           [
             '<Person id="(integer)">',
@@ -1829,16 +1829,17 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             '</Person>'
           ].join('\n'));
       });
-      it('with Content-Type application/javascript', function() {
+      it('with Content-Type application/javascript', async function() {
         var contentObj = {
             'application/javascript': {
             }
           },
           pmResponseBody;
-        pmResponseBody = SchemaUtils.convertToPmResponseBody(contentObj).responseBody;
+        pmResponseBody = await SchemaUtils.convertToPmResponseBody(contentObj);
+        pmResponseBody = pmResponseBody.responseBody;
         expect(typeof pmResponseBody).to.equal('string');
       });
-      it('with Content-Type unsupported', function() {
+      it('with Content-Type unsupported', async function() {
         var contentObj = {
             'application/vnd.api+json+unsupported': {
               'schema': {
@@ -1860,7 +1861,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           pmResponseBody;
-        pmResponseBody = SchemaUtils.convertToPmResponseBody(contentObj).responseBody;
+        pmResponseBody = await SchemaUtils.convertToPmResponseBody(contentObj);
+        pmResponseBody = pmResponseBody.responseBody;
         expect(pmResponseBody).to.equal('');
       });
       // things remaining application/xml, application/javascript
@@ -1868,7 +1870,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
   });
 
   describe('convertToPmResponse function', function() {
-    it('should convert response with JSON content field', function(done) {
+    it('should convert response with JSON content field', async function() {
       var response = {
           'description': 'A list of pets.',
           'content': {
@@ -1895,7 +1897,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         code = '20X',
         pmResponse, responseBody;
 
-      pmResponse = SchemaUtils.convertToPmResponse(response, code).toJSON();
+      pmResponse = await SchemaUtils.convertToPmResponse(response, code);
+      pmResponse = pmResponse.toJSON();
       responseBody = JSON.parse(pmResponse.body);
       expect(pmResponse.name).to.equal(response.description);
       expect(pmResponse.code).to.equal(200);
@@ -1906,9 +1909,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
       });
       expect(responseBody.id).to.equal('<long>');
       expect(responseBody.name).to.equal('<string>');
-      done();
     });
-    it('should convert response with XML content field', function(done) {
+    it('should convert response with XML content field', async function() {
       var response = {
           'description': 'A list of pets.',
           'content': {
@@ -1935,7 +1937,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         code = '20X',
         pmResponse;
 
-      pmResponse = SchemaUtils.convertToPmResponse(response, code).toJSON();
+      pmResponse = await SchemaUtils.convertToPmResponse(response, code);
+      pmResponse = pmResponse.toJSON();
       expect(pmResponse.body).to.equal('<element>\n <id>(integer)</id>\n <name>(string)</name>\n</element>');
       expect(pmResponse.name).to.equal(response.description);
       expect(pmResponse.code).to.equal(200);
@@ -1944,16 +1947,16 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         'key': 'Content-Type',
         'value': 'application/xml'
       });
-      done();
     });
-    it('should convert response without content field', function(done) {
+    it('should convert response without content field', async function() {
       var response = {
           'description': 'A list of pets.'
         },
         code = '201',
         pmResponse;
 
-      pmResponse = SchemaUtils.convertToPmResponse(response, code).toJSON();
+      pmResponse = await SchemaUtils.convertToPmResponse(response, code);
+      pmResponse = pmResponse.toJSON();
       expect(pmResponse.name).to.equal(response.description);
       expect(pmResponse.code).to.equal(201);
       expect(pmResponse.body).to.equal('');
@@ -1961,9 +1964,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         'key': 'Content-Type',
         'value': 'text/plain'
       });
-      done();
     });
-    it('should convert headers with refs', function(done) {
+    it('should convert headers with refs', async function() {
       var response = {
           'description': '`Too Many Requests`\\n',
           'headers': {
@@ -1973,7 +1975,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           }
         },
         code = '200',
-        pmResponse = SchemaUtils.convertToPmResponse(response, code, null, {
+        pmResponse = await SchemaUtils.convertToPmResponse(response, code, null, {
           components: {
             'responses': {
               'TooManyRequests': {
@@ -2006,7 +2008,6 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
 
       expect(pmResponse.headers.members[0].key).to.equal('Retry-After');
       expect(pmResponse.headers.members[0].description).to.equal('Some description');
-      done();
     });
   });
 


### PR DESCRIPTION
I'm trying to refactor the functions in schemaUtils to follow the ES6 Async-Await syntax. This will help fetch examples from externalRef values.

Fixed a lot of tests, 7 are yet to be fixed.

It would be helpful if someone can review and let me know if this approach is acceptable.