### PR TITLE
Small install instructions update

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ To use the converter as a Node module, you need to have a copy of the NodeJS run
 $ npm install openapi-to-postmanv2
 ```
 
+If you want to use the converter in the CLI, install it globally with NPM:
+
+```terminal
+$ npm i -g openapi-to-postmanv2
+```
 
 ## Using the converter as a NodeJS module
 


### PR DESCRIPTION
Adding global installation instructions for someone who wants to use the CLI and not the node module. I got stuck and found the support article here really helpful, so I thought it would be worth suggesting adding it to the main instructions - https://community.postman.com/t/openapi-to-postman-not-working/13713