### PR TITLE
Fixed an issue in schema faker where schema with property named deafult was faked incorrectly.

### DIFF
--- a/assets/json-schema-faker.js
+++ b/assets/json-schema-faker.js
@@ -24576,8 +24576,12 @@ function extend() {
           return schema.example;
         }
       }
+      // use deafult as faked value if found as keyword in schema
       if (optionAPI('useDefaultValue') && 'default' in schema) {
-          return schema.default;
+        // to not use default as faked value in case it is actual property of schema
+        if (!(_.has(schema.default, 'type') && _.includes(ALL_TYPES, schema.default.type))) {
+          return schema.default; 
+        }
       }
       if (schema.not && typeof schema.not === 'object') {
           schema = utils.notValue(schema.not, utils.omitProps(schema, ['not']));

--- a/assets/json-schema-faker.js
+++ b/assets/json-schema-faker.js
@@ -24576,7 +24576,7 @@ function extend() {
           return schema.example;
         }
       }
-      // use deafult as faked value if found as keyword in schema
+      // use default as faked value if found as keyword in schema
       if (optionAPI('useDefaultValue') && 'default' in schema) {
         // to not use default as faked value in case it is actual property of schema
         if (!(_.has(schema.default, 'type') && _.includes(ALL_TYPES, schema.default.type))) {

--- a/test/unit/faker.test.js
+++ b/test/unit/faker.test.js
@@ -41,4 +41,21 @@ describe('JSON SCHEMA FAKER TESTS', function () {
       expect(fakedData).to.deep.equal(schema.example);
     });
   });
+
+  it('Should not use actual property named "default" as faked value', function () {
+    const schema = {
+      type: 'object',
+      properties: {
+        default: {
+          type: 'string',
+          example: 'This is actual property and not JSON schema defined "default" keyword'
+        }
+      }
+    };
+
+    var fakedData = schemaFaker(schema);
+    expect(fakedData).to.deep.equal({
+      default: 'This is actual property and not JSON schema defined "default" keyword'
+    });
+  });
 });


### PR DESCRIPTION
This PR fixes issue where schema faker was not handling schema correctly when there was property named `deafult` present. It caused json-schema-faker to understand it as JSON schema defined keyword instead of actual property.