### PR TITLE
Support multiple AnyOf & OneOf items for schema validation

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -138,12 +138,22 @@ module.exports = {
     }
 
     if (schema.anyOf) {
-      return this.resolveRefs(schema.anyOf[0], parameterSourceOption, components, schemaResolutionCache, resolveFor,
-        resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
+      let anyOfSchemas = []
+      _.forOwn(schema.anyOf, (item, itemKey) => {
+        let itemSchema = this.resolveRefs(item, parameterSourceOption, components, schemaResolutionCache, resolveFor,
+          resolveTo, stack, _.cloneDeep(seenRef), stackLimit)
+          anyOfSchemas.push(itemSchema);
+      })
+      return {"anyOf": anyOfSchemas}
     }
     if (schema.oneOf) {
-      return this.resolveRefs(schema.oneOf[0], parameterSourceOption, components, schemaResolutionCache, resolveFor,
-        resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
+      let oneOfSchemas = []
+      _.forOwn(schema.oneOf, (item, itemKey) => {
+        let itemSchema = this.resolveRefs(item, parameterSourceOption, components, schemaResolutionCache, resolveFor,
+          resolveTo, stack, _.cloneDeep(seenRef), stackLimit)
+        oneOfSchemas.push(itemSchema);
+      })
+      return {"oneOf": oneOfSchemas}
     }
     if (schema.allOf) {
       return this.resolveAllOf(schema.allOf, parameterSourceOption, components, schemaResolutionCache, resolveFor,

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -139,7 +139,7 @@ module.exports = {
 
     if (schema.anyOf) {
       let anyOfSchemas = [];
-      _.forOwn(schema.anyOf, (item, itemKey) => {
+      _.forOwn(schema.anyOf, (item) => {
         let itemSchema = this.resolveRefs(item, parameterSourceOption, components, schemaResolutionCache, resolveFor,
           resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
         anyOfSchemas.push(itemSchema);
@@ -148,7 +148,7 @@ module.exports = {
     }
     if (schema.oneOf) {
       let oneOfSchemas = [];
-      _.forOwn(schema.oneOf, (item, itemKey) => {
+      _.forOwn(schema.oneOf, (item) => {
         let itemSchema = this.resolveRefs(item, parameterSourceOption, components, schemaResolutionCache, resolveFor,
           resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
         oneOfSchemas.push(itemSchema);

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -138,22 +138,22 @@ module.exports = {
     }
 
     if (schema.anyOf) {
-      let anyOfSchemas = []
+      let anyOfSchemas = [];
       _.forOwn(schema.anyOf, (item, itemKey) => {
         let itemSchema = this.resolveRefs(item, parameterSourceOption, components, schemaResolutionCache, resolveFor,
-          resolveTo, stack, _.cloneDeep(seenRef), stackLimit)
-          anyOfSchemas.push(itemSchema);
-      })
-      return {"anyOf": anyOfSchemas}
+          resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
+        anyOfSchemas.push(itemSchema);
+      });
+      return { 'anyOf': anyOfSchemas };
     }
     if (schema.oneOf) {
-      let oneOfSchemas = []
+      let oneOfSchemas = [];
       _.forOwn(schema.oneOf, (item, itemKey) => {
         let itemSchema = this.resolveRefs(item, parameterSourceOption, components, schemaResolutionCache, resolveFor,
-          resolveTo, stack, _.cloneDeep(seenRef), stackLimit)
+          resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
         oneOfSchemas.push(itemSchema);
-      })
-      return {"oneOf": oneOfSchemas}
+      });
+      return { 'oneOf': oneOfSchemas };
     }
     if (schema.allOf) {
       return this.resolveAllOf(schema.allOf, parameterSourceOption, components, schemaResolutionCache, resolveFor,


### PR DESCRIPTION
A potential fix for https://github.com/postmanlabs/openapi-to-postman/issues/368

The OpenAPI spec results in this JSON schema 

```
// Response Validation
const schema = {"x-graphql-type-name":"ContactList","type":"object","required":["data"],"properties":{"data":{"type":"array","items":{"required":["name"],"x-pii":["name"],"type":"object","properties":{"custom_fields":{"type":"array","items":{"type":"object","required":["id"],"additionalProperties":false,"properties":{"id":{"type":"string","example":"custom_technologies"},"value":{"anyOf":[{"type":["string","null"],"example":"Uses Postman and OpenAPi"},{"type":["number","null"],"example":10},{"type":["boolean","null"],"example":true},{"type":"array","items":{"type":"string"}}]}}}}}}}}}

// Test whether the response matches the schema
pm.test("[GET] /crm/contacts - Schema is valid", function() {
   pm.response.to.have.jsonSchema(schema,{unknownFormats: ["int32", "int64"]});
});
```

See attachments
[OAspec_PostmanCollection.zip](https://github.com/postmanlabs/openapi-to-postman/files/6444497/OAspec_PostmanCollection.zip)

![image](https://user-images.githubusercontent.com/952446/117512581-2ec8e000-af90-11eb-8427-207c26f20cd4.png)




