### PR TITLE
Added option to manage implicit headers

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -17,3 +17,4 @@ validateMetadata|boolean|-|false|Whether to show mismatches for incorrect name a
 ignoreUnresolvedVariables|boolean|-|false|Whether to ignore mismatches resulting from unresolved variables in the Postman request|VALIDATION
 strictRequestMatching|boolean|-|false|Whether requests should be strictly matched with schema operations. Setting to true will not include any matches where the URL path segments don't match exactly.|VALIDATION
 disableOptionalParameters|boolean|-|false|Whether to set optional parameters as disabled|CONVERSION
+keepImplicitHeaders|boolean|-|false|Whether to keep implicit headers|CONVERSION

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -17,4 +17,4 @@ validateMetadata|boolean|-|false|Whether to show mismatches for incorrect name a
 ignoreUnresolvedVariables|boolean|-|false|Whether to ignore mismatches resulting from unresolved variables in the Postman request|VALIDATION
 strictRequestMatching|boolean|-|false|Whether requests should be strictly matched with schema operations. Setting to true will not include any matches where the URL path segments don't match exactly.|VALIDATION
 disableOptionalParameters|boolean|-|false|Whether to set optional parameters as disabled|CONVERSION
-keepImplicitHeaders|boolean|-|false|Whether to keep implicit headers from the OpenAPI specification,which are removed by default.|CONVERSION
+keepImplicitHeaders|boolean|-|false|Whether to keep implicit headers from the OpenAPI specification, which are removed by default.|CONVERSION

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -17,4 +17,4 @@ validateMetadata|boolean|-|false|Whether to show mismatches for incorrect name a
 ignoreUnresolvedVariables|boolean|-|false|Whether to ignore mismatches resulting from unresolved variables in the Postman request|VALIDATION
 strictRequestMatching|boolean|-|false|Whether requests should be strictly matched with schema operations. Setting to true will not include any matches where the URL path segments don't match exactly.|VALIDATION
 disableOptionalParameters|boolean|-|false|Whether to set optional parameters as disabled|CONVERSION
-keepImplicitHeaders|boolean|-|false|Whether to keep implicit headers|CONVERSION
+keepImplicitHeaders|boolean|-|false|Whether to keep implicit headers from the OpenAPI specification,which are removed by default.|CONVERSION

--- a/lib/options.js
+++ b/lib/options.js
@@ -210,6 +210,15 @@ module.exports = {
         description: 'Whether to set optional parameters as disabled',
         external: true,
         usage: ['CONVERSION']
+      },
+      {
+        name: 'Keep implicit headers',
+        id: 'keepImplicitHeaders',
+        type: 'boolean',
+        default: false,
+        description: 'Whether to keep implicit headers',
+        external: true,
+        usage: ['CONVERSION']
       }
     ];
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -216,7 +216,7 @@ module.exports = {
         id: 'keepImplicitHeaders',
         type: 'boolean',
         default: false,
-        description: 'Whether to keep implicit headers',
+        description: 'Whether to keep implicit headers from the OpenAPI specification,which are removed by default.',
         external: true,
         usage: ['CONVERSION']
       }

--- a/lib/options.js
+++ b/lib/options.js
@@ -216,7 +216,7 @@ module.exports = {
         id: 'keepImplicitHeaders',
         type: 'boolean',
         default: false,
-        description: 'Whether to keep implicit headers from the OpenAPI specification,which are removed by default.',
+        description: 'Whether to keep implicit headers from the OpenAPI specification, which are removed by default.',
         external: true,
         usage: ['CONVERSION']
       }

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1878,12 +1878,10 @@ module.exports = {
         raw: JSON.stringify(bodyData, null, 4)
       };
 
-      if (!options.keepImplicitHeaders) {
-        contentHeader = new sdk.Header({
-          key: 'Content-Type',
-          value: bodyType
-        });
-      }
+      contentHeader = new sdk.Header({
+        key: 'Content-Type',
+        value: bodyType
+      });
 
       reqBody.update(updateOptions);
     }
@@ -2358,7 +2356,9 @@ module.exports = {
       }
       pmBody = this.convertToPmBody(reqBody, REQUEST_TYPE.ROOT, components, options, schemaCache);
       item.request.body = pmBody.body;
-      item.request.addHeader(pmBody.contentHeader);
+      if (!options.keepImplicitHeaders || (reqParams.header && reqParams.header.length === 0)) {
+        item.request.addHeader(pmBody.contentHeader);
+      }
       // extra form headers if encoding is present in request Body.
       // TODO: Show warning for incorrect schema if !pmBody.formHeaders
       pmBody.formHeaders && pmBody.formHeaders.forEach((element) => {

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2319,7 +2319,7 @@ module.exports = {
 
     // adding headers to request from reqParam
     _.forEach(reqParams.header, (header) => {
-      if (!options.keepImplicitHeaders && !_.includes(IMPLICIT_HEADERS, _.toLower(_.get(header, 'name')))) {
+      if (options.keepImplicitHeaders || !_.includes(IMPLICIT_HEADERS, _.toLower(_.get(header, 'name')))) {
         item.request.addHeader(this.convertToPmHeader(header, REQUEST_TYPE.ROOT, PARAMETER_SOURCE.REQUEST,
           components, options, schemaCache));
       }

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1878,10 +1878,12 @@ module.exports = {
         raw: JSON.stringify(bodyData, null, 4)
       };
 
-      contentHeader = new sdk.Header({
-        key: 'Content-Type',
-        value: bodyType
-      });
+      if (!options.keepImplicitHeaders) {
+        contentHeader = new sdk.Header({
+          key: 'Content-Type',
+          value: bodyType
+        });
+      }
 
       reqBody.update(updateOptions);
     }

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2319,7 +2319,7 @@ module.exports = {
 
     // adding headers to request from reqParam
     _.forEach(reqParams.header, (header) => {
-      if (!_.includes(IMPLICIT_HEADERS, _.toLower(_.get(header, 'name')))) {
+      if (!options.keepImplicitHeaders && !_.includes(IMPLICIT_HEADERS, _.toLower(_.get(header, 'name')))) {
         item.request.addHeader(this.convertToPmHeader(header, REQUEST_TYPE.ROOT, PARAMETER_SOURCE.REQUEST,
           components, options, schemaCache));
       }

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2356,7 +2356,10 @@ module.exports = {
       }
       pmBody = this.convertToPmBody(reqBody, REQUEST_TYPE.ROOT, components, options, schemaCache);
       item.request.body = pmBody.body;
-      if (!options.keepImplicitHeaders || (reqParams.header && reqParams.header.length === 0)) {
+      if (!options.keepImplicitHeaders || (!_.find(reqParams.header, (h) => {
+        return _.toLower(_.get(h, 'name')) === 'content-type';
+      }))) {
+        // Add detected content-type header
         item.request.addHeader(pmBody.contentHeader);
       }
       // extra form headers if encoding is present in request Body.

--- a/test/data/valid_openapi/implicit_headers.json
+++ b/test/data/valid_openapi/implicit_headers.json
@@ -1,0 +1,58 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "example",
+    "version": "1.0."
+  },
+  "paths": {
+    "/accounts": {
+      "parameters": [
+        {
+          "in": "header",
+          "name": "Authorization",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "example": "Bearer {{oauth_access_token}}",
+            "default": "Bearer {{oauth_access_token}}"
+          },
+          "description": "Oauth2 token to authorize requests."
+        },
+        {
+          "in": "header",
+          "name": "content-type",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "example": "application/json",
+            "default": "application/json"
+          },
+          "description": "Define the file type and format for the response object."
+        }
+      ],
+      "get": {
+        "operationId": "get-accounts",
+        "summary": "Get all accounts",
+        "description": "Returns a list of your accounts for a certain tenant.",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "The response of the list of accounts.",
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "description": "Result of the accounts for the portal."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/data/valid_openapi/implicit_headers.json
+++ b/test/data/valid_openapi/implicit_headers.json
@@ -20,7 +20,7 @@
         },
         {
           "in": "header",
-          "name": "content-type",
+          "name": "Content-Type",
           "required": true,
           "schema": {
             "type": "string",
@@ -33,10 +33,53 @@
       "get": {
         "operationId": "get-accounts",
         "summary": "Get all accounts",
-        "description": "Returns a list of your accounts for a certain tenant.",
+        "description": "Returns a list of your accounts.",
         "responses": {
           "200": {
             "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "The response of the list of accounts.",
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "description": "Result of the accounts"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "post-accounts",
+        "summary": "Create account",
+        "description": "Create a new account.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "Description of Pet ID"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Description of Pet name"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Success response",
             "content": {
               "application/json": {
                 "schema": {

--- a/test/system/structure.test.js
+++ b/test/system/structure.test.js
@@ -20,7 +20,8 @@ const optionIds = [
     'ignoreUnresolvedVariables',
     'optimizeConversion',
     'strictRequestMatching',
-    'disableOptionalParameters'
+    'disableOptionalParameters',
+    'keepImplicitHeaders'
   ],
   expectedOptions = {
     collapseFolders: {
@@ -146,6 +147,14 @@ const optionIds = [
       type: 'boolean',
       default: false,
       description: 'Whether to set optional parameters as disabled'
+    },
+    keepImplicitHeaders: {
+      name: 'Keep implicit headers',
+      type: 'boolean',
+      default: false,
+      description: 'Whether to keep implicit headers from the OpenAPI specification,which are removed by default.',
+      external: true,
+      usage: ['CONVERSION']
     }
   };
 

--- a/test/system/structure.test.js
+++ b/test/system/structure.test.js
@@ -152,7 +152,7 @@ const optionIds = [
       name: 'Keep implicit headers',
       type: 'boolean',
       default: false,
-      description: 'Whether to keep implicit headers from the OpenAPI specification,which are removed by default.',
+      description: 'Whether to keep implicit headers from the OpenAPI specification, which are removed by default.',
       external: true,
       usage: ['CONVERSION']
     }

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -61,7 +61,7 @@ describe('CONVERT FUNCTION TESTS ', function() {
         expect(conversionResult.output[0].data).to.have.property('info');
         expect(conversionResult.output[0].data).to.have.property('item');
         expect(conversionResult.output[0].data.auth).to.have.property('type');
-        expect(conversionResult.output[0].data.auth.type).to.equal('bearer');
+        expect(conversionResult.output[0].data.auth.type).to.equal('apikey');
         done();
       });
     });

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -20,6 +20,7 @@ describe('CONVERT FUNCTION TESTS ', function() {
       infoHavingContactOnlySpec = path.join(__dirname, VALID_OPENAPI_PATH + '/info_having_contact_only.json'),
       infoHavingDescriptionOnlySpec = path.join(__dirname, VALID_OPENAPI_PATH + '/info_having_description_only.json'),
       customHeadersSpec = path.join(__dirname, VALID_OPENAPI_PATH + '/custom_headers.json'),
+      implicitHeadersSpec = path.join(__dirname, VALID_OPENAPI_PATH + '/implicit_headers.json'),
       readOnlySpec = path.join(__dirname, VALID_OPENAPI_PATH + '/readOnly.json'),
       multipleFoldersSpec = path.join(__dirname, VALID_OPENAPI_PATH + '/multiple_folder_problem.json'),
       multipleFoldersSpec1 = path.join(__dirname, VALID_OPENAPI_PATH + '/multiple_folder_problem1.json'),
@@ -289,6 +290,37 @@ describe('CONVERT FUNCTION TESTS ', function() {
         expect(err).to.be.null;
         expect(conversionResult.output[0].data.item[0].response[0].header[0].value)
           .to.equal('application/vnd.retailer.v3+json');
+        done();
+      });
+    });
+    it('convertor should maintain implicit headers in the request' +
+    implicitHeadersSpec, function(done) {
+      var openapi = fs.readFileSync(implicitHeadersSpec, 'utf8');
+      Converter.convert({ type: 'string', data: openapi }, {
+        schemaFaker: true,
+        keepImplicitHeaders: true
+      }, (err, conversionResult) => {
+        expect(err).to.be.null;
+        expect(conversionResult.output[0].data.item[0].request.header[0].key)
+          .to.equal('Authorization');
+        expect(conversionResult.output[0].data.item[0].request.header[0].value)
+          .to.equal('Bearer {{oauth_access_token}}');
+        expect(conversionResult.output[0].data.item[0].request.header[1].key)
+          .to.equal('content-type');
+        expect(conversionResult.output[0].data.item[0].request.header[1].value)
+          .to.equal('application/json');
+        done();
+      });
+    });
+    it('convertor should remove implicit headers in the request' +
+    implicitHeadersSpec, function(done) {
+      var openapi = fs.readFileSync(implicitHeadersSpec, 'utf8');
+      Converter.convert({ type: 'string', data: openapi }, {
+        schemaFaker: true,
+        keepImplicitHeaders: false
+      }, (err, conversionResult) => {
+        expect(err).to.be.null;
+        expect(conversionResult.output[0].data.item[0].request.header).to.equal(undefined);
         done();
       });
     });

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -317,7 +317,7 @@ describe('CONVERT FUNCTION TESTS ', function() {
           .to.equal('Content-Type');
         expect(conversionResult.output[0].data.item[0].item[1].request.header[1].value)
           .to.equal('application/json');
-        expect(conversionResult.output[0].data.item[0].item[1].request.header[2]).to.equal(undefined);
+        expect(conversionResult.output[0].data.item[0].item[1].request.header).to.have.length(2);
         done();
       });
     });
@@ -329,7 +329,7 @@ describe('CONVERT FUNCTION TESTS ', function() {
         keepImplicitHeaders: false
       }, (err, conversionResult) => {
         expect(err).to.be.null;
-        expect(conversionResult.output[0].data.item[0].item[0].request.header).to.equal(undefined);
+        expect(conversionResult.output[0].data.item[0].item[1].request.header).to.have.length(1);
         expect(conversionResult.output[0].data.item[0].item[1].request.header[0].key)
           .to.equal('Content-Type');
         expect(conversionResult.output[0].data.item[0].item[1].request.header[0].value)

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -301,14 +301,23 @@ describe('CONVERT FUNCTION TESTS ', function() {
         keepImplicitHeaders: true
       }, (err, conversionResult) => {
         expect(err).to.be.null;
-        expect(conversionResult.output[0].data.item[0].request.header[0].key)
+        expect(conversionResult.output[0].data.item[0].item[0].request.header[0].key)
           .to.equal('Authorization');
-        expect(conversionResult.output[0].data.item[0].request.header[0].value)
+        expect(conversionResult.output[0].data.item[0].item[0].request.header[0].value)
           .to.equal('Bearer {{oauth_access_token}}');
-        expect(conversionResult.output[0].data.item[0].request.header[1].key)
-          .to.equal('content-type');
-        expect(conversionResult.output[0].data.item[0].request.header[1].value)
+        expect(conversionResult.output[0].data.item[0].item[0].request.header[1].key)
+          .to.equal('Content-Type');
+        expect(conversionResult.output[0].data.item[0].item[0].request.header[1].value)
           .to.equal('application/json');
+        expect(conversionResult.output[0].data.item[0].item[1].request.header[0].key)
+          .to.equal('Authorization');
+        expect(conversionResult.output[0].data.item[0].item[1].request.header[0].value)
+          .to.equal('Bearer {{oauth_access_token}}');
+        expect(conversionResult.output[0].data.item[0].item[1].request.header[1].key)
+          .to.equal('Content-Type');
+        expect(conversionResult.output[0].data.item[0].item[1].request.header[1].value)
+          .to.equal('application/json');
+        expect(conversionResult.output[0].data.item[0].item[1].request.header[2]).to.equal(undefined);
         done();
       });
     });
@@ -320,7 +329,11 @@ describe('CONVERT FUNCTION TESTS ', function() {
         keepImplicitHeaders: false
       }, (err, conversionResult) => {
         expect(err).to.be.null;
-        expect(conversionResult.output[0].data.item[0].request.header).to.equal(undefined);
+        expect(conversionResult.output[0].data.item[0].item[0].request.header).to.equal(undefined);
+        expect(conversionResult.output[0].data.item[0].item[1].request.header[0].key)
+          .to.equal('Content-Type');
+        expect(conversionResult.output[0].data.item[0].item[1].request.header[0].value)
+          .to.equal('application/json');
         done();
       });
     });


### PR DESCRIPTION
Option to manage implicit headers, to provide support for the implicit headers, which are now skipped.
See item https://github.com/postmanlabs/openapi-to-postman/issues/361 for the origin of the PR.