### PR TITLE
Fixed issue where description was missing from suggested fix from mismatches.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -382,6 +382,9 @@ module.exports = {
    * @returns {string} description of the parameters
    */
   getParameterDescription: function(parameter) {
+    if (!_.isObject(parameter)) {
+      return '';
+    }
     return (parameter.required ? '(Required) ' : '') + (parameter.description || '') +
       (parameter.enum ? ' (This can only be one of ' + parameter.enum + ')' : '');
   },
@@ -2853,11 +2856,13 @@ module.exports = {
       }
       else {
         let required = _.get(metaInfo, 'required') || false,
+          description = _.get(metaInfo, 'description') || '',
           pathPrefix = _.get(metaInfo, 'pathPrefix');
 
         childParamSchemas.push({
           name: `${paramKey}[${key}]`,
           schema: value,
+          description,
           required,
           isResolvedParam: true,
           pathPrefix
@@ -3263,7 +3268,8 @@ module.exports = {
                 key: pathVar.name,
                 value: safeSchemaFaker(pathVar.schema || {}, 'example', PROCESSING_TYPE.VALIDATION,
                   PARAMETER_SOURCE.REQUEST, components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache,
-                  options.stackLimit)
+                  options.stackLimit),
+                description: this.getParameterDescription(pathVar)
               }
             };
           }
@@ -3453,7 +3459,7 @@ module.exports = {
         // resolve all child params of parent param with deepObject style
         if (style === 'deepObject') {
           resolvedSchemaParams = _.concat(resolvedSchemaParams, this.extractChildParamSchema(paramSchema,
-            param.name, { required: _.get(param, 'required'), pathPrefix }));
+            param.name, { required: _.get(param, 'required'), pathPrefix, description: _.get(param, 'description') }));
         }
         else {
           // add schema of all properties instead entire object
@@ -3462,6 +3468,7 @@ module.exports = {
               name: propName,
               schema: propSchema,
               required: _.get(param, 'required') || false,
+              description: _.get(param, 'description'),
               isResolvedParam: true,
               pathPrefix
             });
@@ -3547,7 +3554,8 @@ module.exports = {
                 key: qp.name,
                 value: safeSchemaFaker(qp.schema || {}, 'example', PROCESSING_TYPE.VALIDATION,
                   PARAMETER_SOURCE.REQUEST, components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache,
-                  options.stackLimit)
+                  options.stackLimit),
+                description: this.getParameterDescription(qp)
               }
             };
           }
@@ -3774,7 +3782,8 @@ module.exports = {
                 key: header.name,
                 value: safeSchemaFaker(header.schema || {}, 'example', PROCESSING_TYPE.VALIDATION,
                   PARAMETER_SOURCE.REQUEST, components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache,
-                  options.stackLimit)
+                  options.stackLimit),
+                description: this.getParameterDescription(header)
               }
             };
           }
@@ -3881,7 +3890,8 @@ module.exports = {
                 key: header.name,
                 value: safeSchemaFaker(header.schema || {}, 'example', PROCESSING_TYPE.VALIDATION,
                   PARAMETER_SOURCE.REQUEST, components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache,
-                  options.stackLimit)
+                  options.stackLimit),
+                description: this.getParameterDescription(header)
               }
             };
           }
@@ -3942,7 +3952,8 @@ module.exports = {
         let resolvedProp = {
             name: propName,
             schema: propSchema,
-            in: 'query' // serialization follows same behaviour as query params
+            in: 'query', // serialization follows same behaviour as query params
+            description: _.get(propSchema, 'description') || ''
           },
           encodingValue = _.get(schemaPath, ['requestBody', 'content', URLENCODED, 'encoding', propName]),
           pSerialisationInfo,
@@ -3978,7 +3989,7 @@ module.exports = {
           // resolve all child params of parent param with deepObject style
           if (pSerialisationInfo.style === 'deepObject') {
             resolvedSchemaParams = _.concat(resolvedSchemaParams, this.extractChildParamSchema(propSchema,
-              propName, { required: resolvedProp.required || false }));
+              propName, { required: resolvedProp.required || false, description: resolvedProp.description }));
           }
           else {
             // add schema of all properties instead entire object
@@ -3987,7 +3998,8 @@ module.exports = {
                 name: key,
                 schema: value,
                 isResolvedParam: true,
-                required: resolvedProp.required || false
+                required: resolvedProp.required || false,
+                description: resolvedProp.description
               });
             });
           }
@@ -4090,7 +4102,8 @@ module.exports = {
                   key: uParam.name,
                   value: safeSchemaFaker(uParam.schema || {}, 'example', PROCESSING_TYPE.VALIDATION,
                     PARAMETER_SOURCE.REQUEST, components, SCHEMA_FORMATS.DEFAULT, options.indentCharacter, schemaCache,
-                    options.stackLimit)
+                    options.stackLimit),
+                  description: this.getParameterDescription(uParam)
                 }
               };
             }

--- a/test/data/validationData/suggestAvailableFixesCollection.json
+++ b/test/data/validationData/suggestAvailableFixesCollection.json
@@ -40,11 +40,6 @@
             },
             "header": [
               {
-                "description": "(Required) ",
-                "key": "pet-quantity",
-                "value": "Not a Boolean"
-              },
-              {
                 "key": "Content-Type",
                 "value": "application/json"
               }

--- a/test/data/validationData/suggestAvailableFixesSpec.yaml
+++ b/test/data/validationData/suggestAvailableFixesSpec.yaml
@@ -29,6 +29,7 @@ paths:
             example: 'Not a Number'
         - name: pet-quantity
           in: header
+          description: Quantity of pets available
           required: true
           schema:
             type: boolean

--- a/test/data/validationData/urlencodedBodySpec.yaml
+++ b/test/data/validationData/urlencodedBodySpec.yaml
@@ -81,8 +81,12 @@ paths:
                         type: integer
                       prop2ArrayComp:
                         type: string
+                propMissingInReq:
+                  type: integer
+                  description: This property is not available in matched collection.
+                  example: 321
               required:
-              - status
+              - propMissingInReq
             encoding:
               propObjectExplodable:
                 style: form

--- a/test/unit/validator.test.js
+++ b/test/unit/validator.test.js
@@ -300,7 +300,9 @@ describe('The Validation option', function () {
       // check for all suggested value to be according to schema
       expect(_.isInteger(propertyMismatchMap.PATHVARIABLE.suggestedFix.suggestedValue)).to.eql(true);
       expect(propertyMismatchMap.QUERYPARAM.suggestedFix.suggestedValue).to.be.a('number');
-      expect(propertyMismatchMap.HEADER.suggestedFix.suggestedValue).to.be.a('boolean');
+      expect(propertyMismatchMap.HEADER.suggestedFix.suggestedValue.value).to.be.a('boolean');
+      expect(propertyMismatchMap.HEADER.suggestedFix.suggestedValue.description)
+        .to.eql('(Required) Quantity of pets available');
       expect(propertyMismatchMap.BODY.suggestedFix.suggestedValue.name).to.be.a('string');
       expect(propertyMismatchMap.BODY.suggestedFix.suggestedValue.name.length >= 30).to.eql(true);
       expect(propertyMismatchMap.BODY.suggestedFix.suggestedValue.tag).to.be.a('string');
@@ -680,7 +682,8 @@ describe('VALIDATE FUNCTION TESTS ', function () {
         expect(resultObj.mismatches[1].suggestedFix.actualValue).to.be.null;
         expect(resultObj.mismatches[1].suggestedFix.suggestedValue).to.eql({
           key: 'user[address][country]',
-          value: 'India'
+          value: 'India',
+          description: '(Required) info about user'
         });
         done();
       });
@@ -721,7 +724,7 @@ describe('VALIDATE FUNCTION TESTS ', function () {
       expect(err).to.be.null;
       expect(result).to.be.an('object');
       resultObj = result.requests[historyRequest[0].id].endpoints[0];
-      expect(resultObj.mismatches).to.have.lengthOf(4);
+      expect(resultObj.mismatches).to.have.lengthOf(5);
 
       /**
        * no mismatches should be found for complex array type params as validation is skipped for them,
@@ -751,6 +754,13 @@ describe('VALIDATE FUNCTION TESTS ', function () {
       expect(resultObj.mismatches[3].transactionJsonPath).to.eql('$.request.body.urlencoded[8].value');
       expect(resultObj.mismatches[3].suggestedFix.actualValue).to.eql('123');
       expect(resultObj.mismatches[3].suggestedFix.suggestedValue).to.eql('Delhi');
+
+      // property named "propMissingInReq" is missing in request
+      expect(resultObj.mismatches[4].reasonCode).to.eql('MISSING_IN_REQUEST');
+      expect(resultObj.mismatches[4].suggestedFix.actualValue).to.eql(null);
+      expect(resultObj.mismatches[4].suggestedFix.suggestedValue.key).to.eql('propMissingInReq');
+      expect(resultObj.mismatches[4].suggestedFix.suggestedValue.description)
+        .to.eql('(Required) This property is not available in matched collection.');
       done();
     });
   });


### PR DESCRIPTION
During validation against collection for OpenAPI spec, we suggest fixes given option `suggestionAvailableFixes` is `true`. And as such for key-value pair kinds of values like query params, headers, path variables, and url-encoded body we suggest the entire key-value object for `MISSING_IN_REQUEST` kind of mismatches.

For these scenarios, at moment we only provide key and value as suggestion and description is left out in suggestion. This PR adds support for it.