### PR TITLE
Fixes the value format for apiKey security scheme.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1097,7 +1097,7 @@ module.exports = {
               key: 'key',
               value: _.isString(securityDef.name) ? securityDef.name : '<API Key Name>'
             },
-            { key: 'value', value: true },
+            { key: 'value', value: '<API Key>' },
             {
               key: 'in',
               value: _.includes(['query', 'header'], securityDef.in) ? securityDef.in : 'header'


### PR DESCRIPTION
The apiKey is applied either in query param or header, currently, the value is a boolean whereas the value in header or query should always be a string.

Related Issue: https://github.com/postmanlabs/openapi-to-postman/issues/392