### PR TITLE
Fixed issue where example values with pm variable syntax were not picked up in conversion.

### DIFF
--- a/assets/json-schema-faker.js
+++ b/assets/json-schema-faker.js
@@ -24565,10 +24565,12 @@ function extend() {
           _.unset(clonedSchema, 'minItems');
           _.unset(clonedSchema, 'maxItems');
 
-          result = validateSchema(clonedSchema, schema.example);
+          // avoid validation of values that are in pm variable format (i.e. '{{userId}}')
+          result = validateSchema(clonedSchema, schema.example, { ignoreUnresolvedVariables: true });
         }
         else {
-          result = validateSchema(schema, schema.example);
+          // avoid validation of values that are in pm variable format (i.e. '{{userId}}')
+          result = validateSchema(schema, schema.example, { ignoreUnresolvedVariables: true });
         }
 
         // Use example only if valid 

--- a/test/unit/faker.test.js
+++ b/test/unit/faker.test.js
@@ -58,4 +58,22 @@ describe('JSON SCHEMA FAKER TESTS', function () {
       default: 'This is actual property and not JSON schema defined "default" keyword'
     });
   });
+
+  it('Should use example value with pm variable syntax even though it violates schema type.', function () {
+    const schema = {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'integer',
+          example: '{{orderId}}',
+          description: 'Above example value is not valid integer but is an pm variable'
+        }
+      }
+    };
+
+    var fakedData = schemaFaker(schema);
+    expect(fakedData).to.deep.equal({
+      id: '{{orderId}}'
+    });
+  });
 });


### PR DESCRIPTION
This PR fixes issue where converted collection contained random faked value even if example value was present in schema in PM variable schema. (i.e. `{{pmVar}}`)