### PR TITLE
Fixed issue where invalid cached schemas were being used for resolution.

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -133,6 +133,14 @@ module.exports = {
       return { value: ERR_TOO_MANY_LEVELS };
     }
 
+    // Update max stack reached for all current refs that's being resolved
+    if (!_.isEmpty(this._currentRefStack)) {
+      _.forEach(this._currentRefStack, (refKey) => {
+        _.set(schemaResolutionCache, [refKey, 'maxStack'],
+          Math.max(_.get(schemaResolutionCache, [refKey, 'maxStack'], 0), stack));
+      });
+    }
+
     if (!schema) {
       return { value: '<Error: Schema not found>' };
     }
@@ -167,8 +175,15 @@ module.exports = {
         // not throwing an error. We didn't find the reference - generate a dummy value
         return { value: 'reference ' + schema.$ref + ' not found in the OpenAPI spec' };
       }
-      if (schemaResolutionCache[refKey]) {
-        return schemaResolutionCache[refKey];
+
+      /**
+       * use cached schema if it was resolved at level lower or equal then at current stack level or
+       * cached schema is resolved fully (it does not contain ERR_TOO_MANY_LEVELS value in sub schema)
+       */
+      if (_.get(schemaResolutionCache, [refKey, 'schema']) &&
+        (_.get(schemaResolutionCache, [refKey, 'maxStack'], 0) < stackLimit ||
+        _.get(schemaResolutionCache, [refKey, 'resLevel'], stackLimit) <= stack)) {
+        return schemaResolutionCache[refKey].schema;
       }
       // something like #/components/schemas/PaginationEnvelope/properties/page
       // will be resolved - we don't care about anything after the components part
@@ -188,11 +203,19 @@ module.exports = {
       resolvedSchema = this._getEscaped(components, splitRef);
 
       if (resolvedSchema) {
+        // add current ref that's being resolved in ref stack
+        !_.isArray(this._currentRefStack) && (this._currentRefStack = []);
+        this._currentRefStack.push(refKey);
+
         let refResolvedSchema = this.resolveRefs(resolvedSchema, parameterSourceOption,
           components, schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef));
 
+        // remove current ref that's being resolved from stack as soon as resolved
+        _.isArray(this._currentRefStack) && (this._currentRefStack.pop());
+
         if (refResolvedSchema && refResolvedSchema.value !== ERR_TOO_MANY_LEVELS) {
-          schemaResolutionCache[refKey] = refResolvedSchema;
+          _.set(schemaResolutionCache, [refKey, 'resLevel'], stack);
+          _.set(schemaResolutionCache, [refKey, 'schema'], refResolvedSchema);
         }
 
         return refResolvedSchema;

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -111,7 +111,12 @@ module.exports = {
    * @param {*} schema (openapi) to resolve references.
    * @param {string} parameterSourceOption tells that the schema object is of request or response
    * @param {*} components components in openapi spec.
-   * @param {object} schemaResolutionCache stores already resolved references
+   * @param {object} schemaResolutionCache stores already resolved references - more structure detail below
+   * {'schema reference key': {
+   *    maxStack {Integer} : Defined as how deep of nesting level we reached while resolving schema that's being cached
+   *    resLevel {Integer} : Defined as nesting level at which schema that's being cached was resolved
+   *    schema {Object} : resolved schema that will be cached
+   * }}
    * @param {*} resolveFor - resolve refs for validation/conversion (value to be one of VALIDATION/CONVERSION)
    * @param {string} resolveTo The desired JSON-generation mechanism (schema: prefer using the JSONschema to
     generate a fake object, example: use specified examples as-is). Default: schema
@@ -177,7 +182,9 @@ module.exports = {
       }
 
       if (_.get(schemaResolutionCache, [refKey, 'schema'])) {
+        // maxStack for cached schema is how deep of nesting level we reached while resolving that schema
         let maxStack = _.get(schemaResolutionCache, [refKey, 'maxStack'], 0),
+          // resLevel of perticuler cached schema is nesting level at which schema was resolved
           resLevel = _.get(schemaResolutionCache, [refKey, 'resLevel'], stackLimit);
 
         /**

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -176,14 +176,17 @@ module.exports = {
         return { value: 'reference ' + schema.$ref + ' not found in the OpenAPI spec' };
       }
 
-      /**
-       * use cached schema if it was resolved at level lower or equal then at current stack level or
-       * cached schema is resolved fully (it does not contain ERR_TOO_MANY_LEVELS value in sub schema)
-       */
-      if (_.get(schemaResolutionCache, [refKey, 'schema']) &&
-        (_.get(schemaResolutionCache, [refKey, 'maxStack'], 0) < stackLimit ||
-        _.get(schemaResolutionCache, [refKey, 'resLevel'], stackLimit) <= stack)) {
-        return schemaResolutionCache[refKey].schema;
+      if (_.get(schemaResolutionCache, [refKey, 'schema'])) {
+        let maxStack = _.get(schemaResolutionCache, [refKey, 'maxStack'], 0),
+          resLevel = _.get(schemaResolutionCache, [refKey, 'resLevel'], stackLimit);
+
+        /**
+         * use cached schema if it was resolved at level lower or equal then at current stack level or
+         * if cached schema is resolved fully (it does not contain ERR_TOO_MANY_LEVELS value in sub schema)
+         */
+        if (resLevel <= stack || maxStack < stackLimit) {
+          return schemaResolutionCache[refKey].schema;
+        }
       }
       // something like #/components/schemas/PaginationEnvelope/properties/page
       // will be resolved - we don't care about anything after the components part


### PR DESCRIPTION
This PR fixes issues where schemas that are cached were used incorrectly for resolution in other places. i.e. Schema are cached based on `$ref` key. Now if this referenced schema was used somewhere deeper that was past the allowed nesting limit (e.g. 10 levels) then resolved value is partial with `<Error: Too many levels of nesting to fake this schema>` error.

Now if we are using same `$ref` somewhere not too in (at lower nesting level) then the cached schema that was used contained only partially resolved schema even though we are not past nesting limit.