### PR TITLE
fix: use operationId for Item id if available

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2285,6 +2285,7 @@ module.exports = {
     // creating the request object
     item = new sdk.Item({
       name: reqName,
+      id: operation.operationId,
       request: {
         description: operation.description,
         url: displayUrl || baseUrl,


### PR DESCRIPTION
This allows linking into a particular request with the operation id instead of the uuid4 that is generated. Please advise on how you would like this tested.