### PR TITLE
Add NPM badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 # OpenAPI 3.0 to Postman Collection v2.1.0 Converter
 
 [![Build Status](https://travis-ci.org/postmanlabs/openapi-to-postman.svg?branch=master)](https://travis-ci.org/postmanlabs/openapi-to-postman)
+<a href="https://www.npmjs.com/package/openapi-to-postmanv2" alt="Latest Stable Version">![npm](https://img.shields.io/npm/v/openapi-format.svg)</a> 
+<a href="https://www.npmjs.com/package/openapi-to-postmanv2" alt="Total Downloads">![npm](https://img.shields.io/npm/dw/openapi-format.svg)</a>
 
 #### Contents 
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 # OpenAPI 3.0 to Postman Collection v2.1.0 Converter
 
 [![Build Status](https://travis-ci.org/postmanlabs/openapi-to-postman.svg?branch=master)](https://travis-ci.org/postmanlabs/openapi-to-postman)
-<a href="https://www.npmjs.com/package/openapi-to-postmanv2" alt="Latest Stable Version">![npm](https://img.shields.io/npm/v/openapi-format.svg)</a> 
-<a href="https://www.npmjs.com/package/openapi-to-postmanv2" alt="Total Downloads">![npm](https://img.shields.io/npm/dw/openapi-format.svg)</a>
+<a href="https://www.npmjs.com/package/openapi-to-postmanv2" alt="Latest Stable Version">![npm](https://img.shields.io/npm/v/openapi-to-postmanv2.svg)</a> 
+<a href="https://www.npmjs.com/package/openapi-to-postmanv2" alt="Total Downloads">![npm](https://img.shields.io/npm/dw/openapi-to-postmanv2.svg)</a>
 
 #### Contents 
 


### PR DESCRIPTION
Added badges for NPM version & total downloads.

If you land on the Github page of openapi-to-postman, it is confusing to find out what is now the latest version at first glance.
Adding the NPM version badge will make it easier. The total downloads badge indicates how widely used the package is.