### PR TITLE
Fixed issue where genberated collection contained response code as null.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1960,11 +1960,13 @@ module.exports = {
     else {
       responseHeaders.push({ key: 'Content-Type', value: TEXT_PLAIN });
     }
+    // replace 'X' char with '0'
     code = code.replace(/X/g, '0');
+    code = code === 'default' ? 500 : _.toSafeInteger(code);
 
     sdkResponse = new sdk.Response({
       name: response.description,
-      code: code === 'default' ? 500 : Number(code),
+      code: code || 500,
       header: responseHeaders,
       body: responseBodyWrapper.responseBody,
       originalRequest: originalRequest


### PR DESCRIPTION
Fixes issue https://github.com/postmanlabs/postman-app-support/issues/9936.

Root cause: 

Specification in question contained some response code in `x-400.E0101` format, as we transform swagger to openapi and then convert it, these codes were defined as null in the transformed definition. Which is what was causing the issue.