### PR TITLE
Set param type in request to `file` if schema type is `string` and format is `binary`

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1832,11 +1832,21 @@ module.exports = {
           }
         }
 
-        param = new sdk.FormParam({
-          key: key,
-          value: value,
-          type: 'text'
-        });
+        // Set param type to 'file' for binary value
+        if (value === '<binary>') {
+          param = new sdk.FormParam({
+            key: key,
+            value: '',
+            type: 'file'
+          });
+        }
+        else {
+          param = new sdk.FormParam({
+            key: key,
+            value: value,
+            type: 'text'
+          });
+        }
         param.description = description;
         paramArray.push(param);
       });

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -1592,14 +1592,18 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
                 schema: {
                   type: 'object',
                   properties: {
-                    file: {
+                    array: {
                       type: 'array',
                       items: {
                         type: 'string'
                       }
+                    },
+                    file: {
+                      type: 'string',
+                      format: 'binary'
                     }
                   },
-                  required: ['file']
+                  required: ['array']
                 }
               }
             }
@@ -1607,7 +1611,9 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           result, resultBody;
         result = SchemaUtils.convertToPmBody(requestBody);
         resultBody = (result.body.formdata.toJSON());
-        expect(resultBody[0].key).to.equal('file');
+        expect(resultBody[0].key).to.equal('array');
+        expect(resultBody[1].key).to.equal('file');
+        expect(resultBody[1].type).to.equal('file');
         expect(result.contentHeader).to.deep.include(
           { key: 'Content-Type', value: 'multipart/form-data' });
         done();


### PR DESCRIPTION
Fixes #379 