### PR TITLE
Fixed issue where validation against collection always provides mismatch if requestBody has $ref.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -3816,9 +3816,17 @@ module.exports = {
     }, (err, res) => {
       let mismatches = [],
         mismatchObj,
-        contentHeaderMismatches = this.checkContentTypeHeader(headers, transactionPathPrefix,
-          schemaPathPrefix + '.requestBody.content', _.get(schemaPath, 'requestBody.content'),
-          mismatchProperty, options);
+        reqBody = _.get(schemaPath, 'requestBody'),
+        contentHeaderMismatches;
+
+      // resolve $ref in request body if present
+      if (reqBody.$ref) {
+        reqBody = this.getRefObject(reqBody.$ref, components, options);
+      }
+
+      contentHeaderMismatches = this.checkContentTypeHeader(headers, transactionPathPrefix,
+        schemaPathPrefix + '.requestBody.content', _.get(reqBody, 'content'),
+        mismatchProperty, options);
 
       _.each(_.filter(schemaHeaders, (h) => {
         // exclude non-required and implicit header from further validation

--- a/test/data/validationData/internalRefsCollection.json
+++ b/test/data/validationData/internalRefsCollection.json
@@ -153,6 +153,91 @@
           }
         ],
         "event": []
+      },
+      {
+        "id": "9a089428-7a6c-4b30-ba0c-b036383af51e",
+        "name": "/inventory/:searchString",
+        "request": {
+          "name": "/inventory/:searchString",
+          "description": {},
+          "url": {
+            "path": [
+              "inventory",
+              ":searchString"
+            ],
+            "host": [
+              "{{baseUrl}}"
+            ],
+            "query": [],
+            "variable": [
+              {
+                "disabled": false,
+                "type": "any",
+                "value": "sed eu",
+                "key": "searchString",
+                "description": "pass an optional search string for looking up inventory"
+              }
+            ]
+          },
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "method": "PUT",
+          "auth": null,
+          "body": {
+            "mode": "raw",
+            "raw": "{\n    \"name\": \"dolore ex consequat\",\n    \"alternateName\": \"id consequat Ut\",\n    \"providerId\": \"Ut reprehenderit aute ea consectetur\"\n}",
+            "options": {
+              "raw": {
+                "language": "json"
+              }
+            }
+          }
+        },
+        "response": [
+          {
+            "id": "2b4dd71c-4664-4685-8c7c-8ef5bf8f6704",
+            "name": "successful operation",
+            "originalRequest": {
+              "url": {
+                "path": [
+                  "inventory",
+                  ":searchString"
+                ],
+                "host": [
+                  "{{baseUrl}}"
+                ],
+                "query": [],
+                "variable": [
+                  {
+                    "disabled": false,
+                    "type": "any",
+                    "value": "sed eu",
+                    "key": "searchString",
+                    "description": "pass an optional search string for looking up inventory"
+                  }
+                ]
+              },
+              "method": "PUT",
+              "body": {}
+            },
+            "status": "OK",
+            "code": 200,
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": "\"sed eu\"",
+            "cookie": [],
+            "_postman_previewlanguage": "json"
+          }
+        ],
+        "event": []
       }
     ],
     "event": [],

--- a/test/data/validationData/internalRefsSpec.yaml
+++ b/test/data/validationData/internalRefsSpec.yaml
@@ -38,6 +38,16 @@ paths:
               $ref: '#/components/headers/x-date'
         '401':
           $ref: '#/components/responses/Unauthorized'
+    put:
+      requestBody:
+        $ref: '#/components/requestBodies/ProviderConfig'
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: string
 components:
   headers:
     x-date:
@@ -77,6 +87,11 @@ components:
           schema:
             $ref: '#/components/schemas/InventoryItem'
       description: Inventory item to add
+    ProviderConfig:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ProviderConfig'
   responses:
     UnexpectedError:
       description: An unexpected error has occured
@@ -186,3 +201,12 @@ components:
         message:
           type: string
           example: "we have run out of storage; this is embarrassing, and someone have been paged"
+    ProviderConfig:
+      type: object
+      properties:
+        name:
+          type: string
+        alternateName:
+          type: string
+        providerId:
+          type: string

--- a/test/unit/validator.test.js
+++ b/test/unit/validator.test.js
@@ -510,14 +510,17 @@ describe('VALIDATE FUNCTION TESTS ', function () {
       schemaPack.validateTransaction(historyRequest, (err, result) => {
         expect(err).to.be.null;
         expect(result).to.be.an('object');
-        resultObj = result.requests[historyRequest[0].id].endpoints[0];
 
-        // no mismatches should be found when resolved correctly
-        expect(resultObj.matched).to.be.true;
-        expect(resultObj.mismatches).to.have.lengthOf(0);
-        _.forEach(resultObj.responses, (response) => {
-          expect(response.matched).to.be.true;
-          expect(response.mismatches).to.have.lengthOf(0);
+        _.forEach(historyRequest, (hr) => {
+          resultObj = result.requests[hr.id].endpoints[0];
+
+          // no mismatches should be found when resolved correctly
+          expect(resultObj.matched).to.be.true;
+          expect(resultObj.mismatches).to.have.lengthOf(0);
+          _.forEach(resultObj.responses, (response) => {
+            expect(response.matched).to.be.true;
+            expect(response.mismatches).to.have.lengthOf(0);
+          });
         });
         done();
       });


### PR DESCRIPTION
This PR fixes issue where we always provided mismatch in validation against collection flow if requestBody contained `$ref`.

For example:

```
paths:
  "/v1/organizations/{orgId}/users/{userId}":
    put:
      requestBody:
        $ref: "#/components/requestBodies/NotificationDTO"
components:
  requestBodies:
    NotificationDTO:
      content:
        application/json:
          schema:
            $ref: "#/components/schemas/NotificationDTO"
```