### PR TITLE
Fixed issue where we threw TypeError for undefined parameters.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -500,13 +500,13 @@ module.exports = {
       pathParam = [];
     }
     pathParam.forEach((param, index, arr) => {
-      if (param.hasOwnProperty('$ref')) {
+      if (_.has(param, '$ref')) {
         arr[index] = this.getRefObject(param.$ref, components, options);
       }
     });
 
     operationParam.forEach((param, index, arr) => {
-      if (param.hasOwnProperty('$ref')) {
+      if (_.has(param, '$ref')) {
         arr[index] = this.getRefObject(param.$ref, components, options);
       }
     });


### PR DESCRIPTION
Updated usage of checking for `param` having `$ref` or not.