### PR TITLE
Fix/get options and validation tests

### DIFF
--- a/lib/common/versionUtils.js
+++ b/lib/common/versionUtils.js
@@ -4,7 +4,8 @@ const VERSION_30 = { key: 'openapi', version: '3.0' },
   GENERIC_VERSION2 = { key: 'swagger', version: '2.' },
   GENERIC_VERSION3 = { key: 'openapi', version: '3.' },
   DEFAULT_SPEC_VERSION = VERSION_30.version,
-  fs = require('fs');
+  fs = require('fs'),
+  _ = require('lodash');
 
 /**
  * gets the version key and the version and generates a regular expression that
@@ -129,7 +130,32 @@ function getConcreteSchemaUtils({ type, data }) {
   return concreteUtils;
 }
 
+/**
+   * Filter the options by the version provided by the user
+   * @param {array} optsArray The options to be filtered
+   * @param {string} version The version that will be used
+   * @returns {array} the filtered options related to the version used
+   */
+function filterOptionsByVersion(optsArray, version) {
+  let defOptions = {};
+  optsArray = optsArray.filter((option) => {
+    return option.supportedIn.includes(version);
+  });
+  _.each(optsArray, (opt) => {
+    // special handling for indent character as in documentation it states `Tab` and `Space`
+    // but for the generation mode, we need actual values
+    if (opt.id === 'indentCharacter') {
+      defOptions[opt.id] = opt.default === 'tab' ? '\t' : ' ';
+    }
+    else {
+      defOptions[opt.id] = opt.default;
+    }
+  });
+  return defOptions;
+}
+
 module.exports = {
   getSpecVersion,
-  getConcreteSchemaUtils
+  getConcreteSchemaUtils,
+  filterOptionsByVersion
 };

--- a/lib/common/versionUtils.js
+++ b/lib/common/versionUtils.js
@@ -4,8 +4,7 @@ const VERSION_30 = { key: 'openapi', version: '3.0' },
   GENERIC_VERSION2 = { key: 'swagger', version: '2.' },
   GENERIC_VERSION3 = { key: 'openapi', version: '3.' },
   DEFAULT_SPEC_VERSION = VERSION_30.version,
-  fs = require('fs'),
-  _ = require('lodash');
+  fs = require('fs');
 
 /**
  * gets the version key and the version and generates a regular expression that
@@ -132,26 +131,15 @@ function getConcreteSchemaUtils({ type, data }) {
 
 /**
    * Filter the options by the version provided by the user
-   * @param {array} optsArray The options to be filtered
+   * @param {array} options The options to be filtered
    * @param {string} version The version that will be used
    * @returns {array} the filtered options related to the version used
    */
-function filterOptionsByVersion(optsArray, version) {
-  let defOptions = {};
-  optsArray = optsArray.filter((option) => {
+function filterOptionsByVersion(options, version) {
+  options = options.filter((option) => {
     return option.supportedIn.includes(version);
   });
-  _.each(optsArray, (opt) => {
-    // special handling for indent character as in documentation it states `Tab` and `Space`
-    // but for the generation mode, we need actual values
-    if (opt.id === 'indentCharacter') {
-      defOptions[opt.id] = opt.default === 'tab' ? '\t' : ' ';
-    }
-    else {
-      defOptions[opt.id] = opt.default;
-    }
-  });
-  return defOptions;
+  return options;
 }
 
 module.exports = {

--- a/lib/options.js
+++ b/lib/options.js
@@ -69,7 +69,7 @@ module.exports = {
         ' values: `description`, `operationid`, `url`.',
         external: true,
         usage: ['CONVERSION', 'VALIDATION'],
-        supportedIn: [VERSION31]
+        supportedIn: [VERSION30, VERSION31]
       },
       {
         name: 'Set indent character',
@@ -299,7 +299,19 @@ module.exports = {
 
     if (mode === 'use') {
       // options to be used as default kv-pairs
-      return filterOptionsByVersion(optsArray, version);
+      let defOptions = {};
+      optsArray = filterOptionsByVersion(optsArray, version);
+      _.each(optsArray, (opt) => {
+        // special handling for indent character as in documentation it states `Tab` and `Space`
+        // but for the generation mode, we need actual values
+        if (opt.id === 'indentCharacter') {
+          defOptions[opt.id] = opt.default === 'tab' ? '\t' : ' ';
+        }
+        else {
+          defOptions[opt.id] = opt.default;
+        }
+      });
+      return defOptions;
     }
 
     // options to be used as documentation

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,3 +1,5 @@
+const { filterOptionsByVersion } = require('./common/versionUtils');
+
 const _ = require('lodash'),
   VALID_MODES = ['document', 'use'],
   VERSION30 = '3.0',
@@ -67,7 +69,7 @@ module.exports = {
         ' values: `description`, `operationid`, `url`.',
         external: true,
         usage: ['CONVERSION', 'VALIDATION'],
-        supportedIn: [VERSION30, VERSION31]
+        supportedIn: [VERSION31]
       },
       {
         name: 'Set indent character',
@@ -297,25 +299,13 @@ module.exports = {
 
     if (mode === 'use') {
       // options to be used as default kv-pairs
-      let defOptions = {};
-      _.each(optsArray, (opt) => {
-        // special handling for indent character as in documentation it states `Tab` and `Space`
-        // but for the generation mode, we need actual values
-        if (opt.id === 'indentCharacter') {
-          defOptions[opt.id] = opt.default === 'tab' ? '\t' : ' ';
-        }
-        else {
-          defOptions[opt.id] = opt.default;
-        }
-      });
-      return defOptions;
+      return filterOptionsByVersion(optsArray, version);
     }
 
     // options to be used as documentation
     return _.filter(optsArray, (opt) => {
       // only return options that are not disabled
-      return opt.disabled !== true &&
-        opt.supportedIn.includes(version);
+      return opt.disabled !== true;
     });
   }
 };

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,9 +1,35 @@
-const _ = require('lodash');
+const _ = require('lodash'),
+  VALID_MODES = ['document', 'use'],
+  VERSION30 = '3.0',
+  VERSION31 = '3.1',
+  VALID_VERSIONS = [VERSION30, VERSION31];
+
+/**
+ * Takes a list of arguments and resolve them acording its content
+ * @param {array} args The arguments that will be resolved
+ * @returns {array} The list of arguments after have been resolved
+ */
+function handleArguments(args) {
+  let mode = 'document',
+    criteria = {},
+    version = VERSION30;
+  args.forEach((argument) => {
+    if (typeof argument === 'object' && Object.keys(argument).length > 0) {
+      criteria = argument;
+    }
+    else if (VALID_MODES.includes(argument)) {
+      mode = argument;
+    }
+    else if (VALID_VERSIONS.includes(argument)) {
+      version = argument;
+    }
+  });
+  return { mode, criteria, version };
+}
 
 module.exports = {
   // default options
   // if mode=document, returns an array of name/id/default etc.
-
   /**
    * name - human-readable name for the option
    * id - key to pass the option with
@@ -19,14 +45,15 @@ module.exports = {
    * @param {Object} criteria Decribes required criteria for options to be returned. can have properties
    *   external: <boolean>
    *   usage: <array> (Array of supported usage type - CONVERSION, VALIDATION)
+   * @param {string} version The specification version provided
    * @returns {mixed} An array or object (depending on mode) that describes available options
    */
-  getOptions: function(mode = 'document', criteria = {}) {
+  getOptions: function(mode = 'document', criteria = {}, version = '3.0') {
     // Override mode & criteria if first arg is criteria (objects)
-    if (typeof mode === 'object') {
-      criteria = mode;
-      mode = 'document';
-    }
+    const resolvedArguments = handleArguments([mode, criteria, version]);
+    mode = resolvedArguments.mode;
+    criteria = resolvedArguments.criteria;
+    version = resolvedArguments.version;
 
     let optsArray = [
       {
@@ -39,7 +66,8 @@ module.exports = {
         ' If “Fallback” is selected, the request will be named after one of the following schema' +
         ' values: `description`, `operationid`, `url`.',
         external: true,
-        usage: ['CONVERSION', 'VALIDATION']
+        usage: ['CONVERSION', 'VALIDATION'],
+        supportedIn: [VERSION30, VERSION31]
       },
       {
         name: 'Set indent character',
@@ -49,7 +77,8 @@ module.exports = {
         availableOptions: ['Space', 'Tab'],
         description: 'Option for setting indentation character',
         external: true,
-        usage: ['CONVERSION']
+        usage: ['CONVERSION'],
+        supportedIn: [VERSION30, VERSION31]
       },
       {
         name: 'Collapse redundant folders',
@@ -59,7 +88,8 @@ module.exports = {
         description: 'Importing will collapse all folders that have only one child element and lack ' +
         'persistent folder-level data.',
         external: true,
-        usage: ['CONVERSION']
+        usage: ['CONVERSION'],
+        supportedIn: [VERSION30, VERSION31]
       },
       {
         name: 'Optimize conversion',
@@ -69,7 +99,8 @@ module.exports = {
         description: 'Optimizes conversion for large specification, disabling this option might affect' +
           ' the performance of conversion.',
         external: true,
-        usage: ['CONVERSION']
+        usage: ['CONVERSION'],
+        supportedIn: [VERSION30, VERSION31]
       },
       {
         name: 'Request parameter generation',
@@ -82,7 +113,8 @@ module.exports = {
         ' [example](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#exampleObject)' +
         ' in the schema.',
         external: true,
-        usage: ['CONVERSION']
+        usage: ['CONVERSION'],
+        supportedIn: [VERSION30, VERSION31]
       },
       {
         name: 'Response parameter generation',
@@ -95,7 +127,8 @@ module.exports = {
         ' [example](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#exampleObject)' +
         ' in the schema.',
         external: true,
-        usage: ['CONVERSION']
+        usage: ['CONVERSION'],
+        supportedIn: [VERSION30, VERSION31]
       },
       {
         name: 'Folder organization',
@@ -105,7 +138,8 @@ module.exports = {
         availableOptions: ['Paths', 'Tags'],
         description: 'Select whether to create folders according to the spec’s paths or tags.',
         external: true,
-        usage: ['CONVERSION']
+        usage: ['CONVERSION'],
+        supportedIn: [VERSION30, VERSION31]
       },
       {
         name: 'Enable Schema Faking',
@@ -114,7 +148,8 @@ module.exports = {
         default: true,
         description: 'Whether or not schemas should be faked.',
         external: false,
-        usage: ['CONVERSION']
+        usage: ['CONVERSION'],
+        supportedIn: [VERSION30, VERSION31]
       },
       {
         name: 'Schema resolution nesting limit',
@@ -125,7 +160,8 @@ module.exports = {
           ' result in more time to convert collection depending on complexity of specification. (To make sure this' +
           ' option works correctly "optimizeConversion" option needs to be disabled)',
         external: false,
-        usage: ['CONVERSION']
+        usage: ['CONVERSION'],
+        supportedIn: [VERSION30, VERSION31]
       },
       {
         name: 'Include auth info in example requests',
@@ -134,7 +170,8 @@ module.exports = {
         default: true,
         description: 'Select whether to include authentication parameters in the example request',
         external: true,
-        usage: ['CONVERSION']
+        usage: ['CONVERSION'],
+        supportedIn: [VERSION30, VERSION31]
       },
       {
         name: 'Short error messages during request <> schema validation',
@@ -143,7 +180,8 @@ module.exports = {
         default: false,
         description: 'Whether detailed error messages are required for request <> schema validation operations.',
         external: true,
-        usage: ['VALIDATION']
+        usage: ['VALIDATION'],
+        supportedIn: [VERSION30, VERSION31]
       },
       {
         name: 'Properties to ignore during validation',
@@ -154,7 +192,8 @@ module.exports = {
           ' Must be sent as an array of strings. Valid inputs in the array: PATHVARIABLE, QUERYPARAM,' +
           ' HEADER, BODY, RESPONSE_HEADER, RESPONSE_BODY',
         external: true,
-        usage: ['VALIDATION']
+        usage: ['VALIDATION'],
+        supportedIn: [VERSION30, VERSION31]
       },
       {
         name: 'Whether MISSING_IN_SCHEMA mismatches should be returned',
@@ -164,7 +203,8 @@ module.exports = {
         description: 'MISSING_IN_SCHEMA indicates that an extra parameter was included in the request. For most ' +
           'use cases, this need not be considered an error.',
         external: true,
-        usage: ['VALIDATION']
+        usage: ['VALIDATION'],
+        supportedIn: [VERSION30, VERSION31]
       },
       {
         name: 'Show detailed body validation messages',
@@ -174,7 +214,8 @@ module.exports = {
         description: 'Determines whether to show detailed mismatch information for application/json content ' +
           'in the request/response body.',
         external: true,
-        usage: ['VALIDATION']
+        usage: ['VALIDATION'],
+        supportedIn: [VERSION30, VERSION31]
       },
       {
         name: 'Suggest fixes if available',
@@ -183,7 +224,8 @@ module.exports = {
         default: false,
         description: 'Whether to provide fixes for patching corresponding mismatches.',
         external: true,
-        usage: ['VALIDATION']
+        usage: ['VALIDATION'],
+        supportedIn: [VERSION30, VERSION31]
       },
       {
         name: 'Show Metadata validation messages',
@@ -192,7 +234,8 @@ module.exports = {
         default: false,
         description: 'Whether to show mismatches for incorrect name and description of request',
         external: true,
-        usage: ['VALIDATION']
+        usage: ['VALIDATION'],
+        supportedIn: [VERSION30, VERSION31]
       },
       {
         name: 'Ignore mismatch for unresolved postman variables',
@@ -201,7 +244,8 @@ module.exports = {
         default: false,
         description: 'Whether to ignore mismatches resulting from unresolved variables in the Postman request',
         external: true,
-        usage: ['VALIDATION']
+        usage: ['VALIDATION'],
+        supportedIn: [VERSION30, VERSION31]
       },
       {
         name: 'Enable strict request matching',
@@ -211,7 +255,8 @@ module.exports = {
         description: 'Whether requests should be strictly matched with schema operations. Setting to true will not ' +
           'include any matches where the URL path segments don\'t match exactly.',
         external: true,
-        usage: ['VALIDATION']
+        usage: ['VALIDATION'],
+        supportedIn: [VERSION30, VERSION31]
       },
       {
         name: 'Disable optional parameters',
@@ -220,7 +265,8 @@ module.exports = {
         default: false,
         description: 'Whether to set optional parameters as disabled',
         external: true,
-        usage: ['CONVERSION']
+        usage: ['CONVERSION'],
+        supportedIn: [VERSION30, VERSION31]
       },
       {
         name: 'Keep implicit headers',
@@ -229,7 +275,8 @@ module.exports = {
         default: false,
         description: 'Whether to keep implicit headers from the OpenAPI specification, which are removed by default.',
         external: true,
-        usage: ['CONVERSION']
+        usage: ['CONVERSION'],
+        supportedIn: [VERSION30, VERSION31]
       }
     ];
 
@@ -267,7 +314,8 @@ module.exports = {
     // options to be used as documentation
     return _.filter(optsArray, (opt) => {
       // only return options that are not disabled
-      return opt.disabled !== true;
+      return opt.disabled !== true &&
+        opt.supportedIn.includes(version);
     });
   }
 };

--- a/test/data/31CollectionTransactions/issues/issue#133.json
+++ b/test/data/31CollectionTransactions/issues/issue#133.json
@@ -1,0 +1,219 @@
+{
+	"openapi": "3.0.0",
+	"info": {
+		"version": "1.0.0",
+		"title": "Path Variable issues",
+		"license": {
+			"name": "MIT"
+		}
+	},
+	"servers": [
+		{
+			"url": "http://petstore.swagger.io/v1"
+		}
+	],
+	"paths": {
+		"/send-sms.{format}": {
+			"get": {
+				"summary": "List all pets",
+				"operationId": "listPets",
+				"tags": [
+					"pets"
+				],
+				"parameters": [
+					{
+						"name": "format",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+					}
+				]
+			}
+    },
+    "/some/{path}": {
+			"get": {
+				"summary": "List all pets",
+				"operationId": "listPets",
+				"tags": [
+					"pets"
+				],
+				"parameters": [
+					{
+						"name": "path",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+					}
+				]
+			}
+    },
+    "/new/{path}.{new-path-variable-1}": {
+			"get": {
+				"summary": "List all pets",
+				"operationId": "listPets",
+				"tags": [
+					"pets"
+				],
+				"parameters": [
+					{
+						"name": "path",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "example": "send-email"
+						}
+          },
+          {
+						"name": "new-path-variable-1",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "object",
+              "properties": {
+								"R": { "type": "integer", "example": 100 },
+								"G": { "type": "integer", "example": 200 },
+								"B": { "type": "integer", "example": 150 }
+							}
+						}
+					}
+				]
+			}
+		},
+		"/next/{path}/{new-path-variable}": {
+			"get": {
+				"summary": "List all pets",
+				"operationId": "listPets",
+				"tags": [
+					"pets"
+				],
+				"parameters": [
+					{
+						"name": "path",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+          },
+          {
+						"name": "new-path-variable",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+					}
+				]
+			}
+		},
+		"/anotherpath/{path}/{new-path-variable-2}.{onemore}": {
+			"get": {
+				"summary": "List all pets",
+				"operationId": "listPets",
+				"tags": [
+					"pets"
+				],
+				"parameters": [
+					{
+						"name": "path",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+          },
+          {
+						"name": "new-path-variable-2",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "array",
+              "items": {
+								"type": "string",
+								"example": "exampleString"
+							}
+						}
+					},
+					{
+						"name": "onemore",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+					}
+				]
+			}
+		},
+		"/{path}({new-path-variable}={onemore})": {
+			"get": {
+				"summary": "List all pets",
+				"operationId": "listPets",
+				"tags": [
+					"pets"
+				],
+				"parameters": [
+					{
+						"name": "path",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+          },
+          {
+						"name": "new-path-variable",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+					},
+					{
+						"name": "onemore",
+						"in": "path",
+						"description": "description",
+						"required": true,
+						"schema": {
+							"type": "string",
+              "pattern": "json|xml",
+              "example": "json"
+						}
+					}
+				]
+			}
+		}
+	}
+}

--- a/test/data/31CollectionTransactions/issues/issue#133.json
+++ b/test/data/31CollectionTransactions/issues/issue#133.json
@@ -1,5 +1,5 @@
 {
-	"openapi": "3.0.0",
+	"openapi": "3.1.0",
 	"info": {
 		"version": "1.0.0",
 		"title": "Path Variable issues",
@@ -27,9 +27,9 @@
 						"description": "description",
 						"required": true,
 						"schema": {
-							"type": "string",
+							"type": ["string"],
               "pattern": "json|xml",
-              "example": "json"
+              "examples": ["json"]
 						}
 					}
 				]
@@ -49,9 +49,9 @@
 						"description": "description",
 						"required": true,
 						"schema": {
-							"type": "string",
+							"type": ["string"],
               "pattern": "json|xml",
-              "example": "json"
+              "examples": ["json"]
 						}
 					}
 				]
@@ -71,8 +71,8 @@
 						"description": "description",
 						"required": true,
 						"schema": {
-							"type": "string",
-              "example": "send-email"
+							"type": ["string"],
+              "examples": ["send-email"]
 						}
           },
           {
@@ -81,11 +81,11 @@
 						"description": "description",
 						"required": true,
 						"schema": {
-							"type": "object",
+							"type": ["object"],
               "properties": {
-								"R": { "type": "integer", "example": 100 },
-								"G": { "type": "integer", "example": 200 },
-								"B": { "type": "integer", "example": 150 }
+								"R": { "type": ["integer"], "examples": [100] },
+								"G": { "type": ["integer"], "examples": [200] },
+								"B": { "type": ["integer"], "examples": [150] }
 							}
 						}
 					}
@@ -106,9 +106,9 @@
 						"description": "description",
 						"required": true,
 						"schema": {
-							"type": "string",
+							"type": ["string"],
               "pattern": "json|xml",
-              "example": "json"
+              "examples": ["json"]
 						}
           },
           {
@@ -117,9 +117,9 @@
 						"description": "description",
 						"required": true,
 						"schema": {
-							"type": "string",
+							"type": ["string"],
               "pattern": "json|xml",
-              "example": "json"
+              "examples": ["json"]
 						}
 					}
 				]
@@ -139,9 +139,9 @@
 						"description": "description",
 						"required": true,
 						"schema": {
-							"type": "string",
+							"type": ["string"],
               "pattern": "json|xml",
-              "example": "json"
+              "examples": ["json"]
 						}
           },
           {
@@ -150,10 +150,10 @@
 						"description": "description",
 						"required": true,
 						"schema": {
-							"type": "array",
+							"type": ["array"],
               "items": {
-								"type": "string",
-								"example": "exampleString"
+								"type": ["string"],
+								"examples": ["exampleString"]
 							}
 						}
 					},
@@ -163,9 +163,9 @@
 						"description": "description",
 						"required": true,
 						"schema": {
-							"type": "string",
+							"type": ["string"],
               "pattern": "json|xml",
-              "example": "json"
+              "examples": ["json"]
 						}
 					}
 				]
@@ -185,9 +185,9 @@
 						"description": "description",
 						"required": true,
 						"schema": {
-							"type": "string",
+							"type": ["string"],
               "pattern": "json|xml",
-              "example": "json"
+              "examples": ["json"]
 						}
           },
           {
@@ -196,9 +196,9 @@
 						"description": "description",
 						"required": true,
 						"schema": {
-							"type": "string",
+							"type": ["string"],
               "pattern": "json|xml",
-              "example": "json"
+              "examples": ["json"]
 						}
 					},
 					{
@@ -207,9 +207,9 @@
 						"description": "description",
 						"required": true,
 						"schema": {
-							"type": "string",
+							"type": ["string"],
               "pattern": "json|xml",
-              "example": "json"
+              "examples": ["json"]
 						}
 					}
 				]

--- a/test/data/31CollectionTransactions/issues/issue#150.yml
+++ b/test/data/31CollectionTransactions/issues/issue#150.yml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.1.0
 info:
   title: Swagger Petstore
   description: des
@@ -13,7 +13,9 @@ paths:
                     content:
                         application/json:
                             schema:
-                                type: array
+                                type: 
+                                    - array
                                 items:
-                                    type: string
+                                    type: 
+                                        - string
                             examples: {}

--- a/test/data/31CollectionTransactions/issues/issue#150.yml
+++ b/test/data/31CollectionTransactions/issues/issue#150.yml
@@ -1,0 +1,19 @@
+openapi: 3.0.0
+info:
+  title: Swagger Petstore
+  description: des
+  version: 1.0.0
+paths:
+    /get:
+        get:
+            summary: Some API
+            responses:
+                '200':
+                    description: Some description
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    type: string
+                            examples: {}

--- a/test/data/31CollectionTransactions/issues/issue#160.json
+++ b/test/data/31CollectionTransactions/issues/issue#160.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.0",
+  "openapi": "3.1.0",
   "info": {
     "version": "1.0.0",
     "title": "#160",
@@ -44,7 +44,7 @@
             "description": "How many items to return at one time (max 100)",
             "required": false,
             "schema": {
-              "type": "integer",
+              "type": ["integer"],
               "format": "int32"
             }
           }
@@ -56,7 +56,7 @@
               "x-next": {
                 "description": "A link to the next page of responses",
                 "schema": {
-                  "type": "string"
+                  "type": ["string"]
                 }
               }
             },
@@ -107,43 +107,43 @@
   "components": {
     "schemas": {
       "Pet": {
-        "type": "object",
+        "type": ["object"],
         "required": [
           "id",
           "name"
         ],
         "properties": {
           "id": {
-            "type": "integer",
+            "type": ["integer"],
             "format": "int64"
           },
           "name": {
-            "type": "string"
+            "type": ["string"]
           },
           "tag": {
-            "type": "string"
+            "type": ["string"]
           }
         }
       },
       "Pets": {
-        "type": "array",
+        "type": ["array"],
         "items": {
           "$ref": "#/components/schemas/Pet"
         }
       },
       "Error": {
-        "type": "object",
+        "type": ["object"],
         "required": [
           "code",
           "message"
         ],
         "properties": {
           "code": {
-            "type": "integer",
+            "type": ["integer"],
             "format": "int32"
           },
           "message": {
-            "type": "string"
+            "type": ["string"]
           }
         }
       }

--- a/test/data/31CollectionTransactions/issues/issue#160.json
+++ b/test/data/31CollectionTransactions/issues/issue#160.json
@@ -1,0 +1,152 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "#160",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "paths": {
+    "/pets": {
+     "servers": [
+        {
+          "url": "http://petstore.swagger.io:{port}/{basePath}",
+         "variables": {
+            "port": {
+              "enum": [
+                "8443",
+                "443"
+              ],
+              "default": "8443"
+            },
+            "basePath": {
+              "default": "v2"
+            }
+         }
+        }
+     ],
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paged array of pets",
+            "headers": {
+              "x-next": {
+                "description": "A link to the next page of responses",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pets"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      },
+      "Pets": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Pet"
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/data/31CollectionTransactions/issues/issue#173.yml
+++ b/test/data/31CollectionTransactions/issues/issue#173.yml
@@ -1,0 +1,30 @@
+openapi: "3.0.0"
+
+info:
+  version: "1.0.0"
+  title: "Sample API"
+
+paths:
+  /path1:
+    post:
+      parameters:
+        - in: header
+          name: access_token
+          description: Access token
+          schema:
+            type: string
+            example: X-access-token
+
+      responses:
+        200:
+          description: 200 Success
+        400:
+          description: 400 Bad Request
+        401:
+          description: 401 Unauthorized
+        403:
+         description: 403 Forbidden
+        404:
+          description: 404 Not Found
+        500:
+          description: 500 Internal Server Error

--- a/test/data/31CollectionTransactions/issues/issue#173.yml
+++ b/test/data/31CollectionTransactions/issues/issue#173.yml
@@ -1,4 +1,4 @@
-openapi: "3.0.0"
+openapi: "3.1.0"
 
 info:
   version: "1.0.0"
@@ -12,8 +12,10 @@ paths:
           name: access_token
           description: Access token
           schema:
-            type: string
-            example: X-access-token
+            type: 
+              - string
+            examples: 
+              - X-access-token
 
       responses:
         200:

--- a/test/data/31CollectionTransactions/issues/issue#193.yml
+++ b/test/data/31CollectionTransactions/issues/issue#193.yml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.1.0
 info:
   version: 1.0
   title: Demo API dodo
@@ -12,42 +12,61 @@ paths:
           content:
             application/json:
                 schema:
-                  type: object
+                  type: 
+                    - object
                   properties:
                     nominmax:
-                      type: array
+                      type: 
+                        - array
                       items:
-                        type: string
-                      exmaple: hello
+                        type: 
+                          - string
+                      exmaples: 
+                        - hello
                     nomin:
-                      type: array
+                      type: 
+                        - array
                       maxItems: 5
                       items:
-                        type: string
-                      exmaple: hello
+                        type: 
+                          - string
+                      exmaples: 
+                        - hello
                     nomax:
-                      type: array
+                      type: 
+                        - array
                       minItems: 4
                       items:
-                        type: string
-                      exmaple: hello
+                        type: 
+                          - string
+                      exmaples: 
+                        - hello
                     minmax:
-                      type: array
+                      type: 
+                        - array
                       minItems: 3
                       maxItems: 5
                       items:
-                        type: string
-                      exmaple: hello
+                        type: 
+                          - string
+                      exmaples: 
+                        - hello
                     max:
-                      type: array
+                      type: 
+                        - array
                       minItems: 30
                       maxItems: 40
                       items:
-                        type: string
-                      exmaple: hello
+                        type: 
+                          - string
+                      exmaples: 
+                        - hello
                     min:
-                      type: array
+                      type: 
+                        - array
                       minItems: 1
                       items:
-                        type: string
-                      exmaple: hello
+                        type: 
+                          - string
+                      exmaples: 
+                        - hello

--- a/test/data/31CollectionTransactions/issues/issue#193.yml
+++ b/test/data/31CollectionTransactions/issues/issue#193.yml
@@ -1,0 +1,53 @@
+openapi: 3.0.0
+info:
+  version: 1.0
+  title: Demo API dodo
+paths:
+  /api:
+    get:
+      summary: 'Demo invalid type'
+      responses:
+        '200':
+          description: 'Cannot use type boolean'
+          content:
+            application/json:
+                schema:
+                  type: object
+                  properties:
+                    nominmax:
+                      type: array
+                      items:
+                        type: string
+                      exmaple: hello
+                    nomin:
+                      type: array
+                      maxItems: 5
+                      items:
+                        type: string
+                      exmaple: hello
+                    nomax:
+                      type: array
+                      minItems: 4
+                      items:
+                        type: string
+                      exmaple: hello
+                    minmax:
+                      type: array
+                      minItems: 3
+                      maxItems: 5
+                      items:
+                        type: string
+                      exmaple: hello
+                    max:
+                      type: array
+                      minItems: 30
+                      maxItems: 40
+                      items:
+                        type: string
+                      exmaple: hello
+                    min:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: string
+                      exmaple: hello

--- a/test/data/31CollectionTransactions/issues/path-refs-error.yaml
+++ b/test/data/31CollectionTransactions/issues/path-refs-error.yaml
@@ -1,0 +1,128 @@
+openapi: 3.1.0
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: 
+              - integer
+            format: int32
+      responses:
+        "200":
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: 
+                  - string
+          content:
+            application/json:
+              schema:
+                properties:
+                  newprop:
+                    type: 
+                      - array
+                    items:
+                      required:
+                        - id
+                        - name
+                      properties:
+                        id:
+                          type: 
+                            - integer
+                          format: int64
+                        name:
+                          type: 
+                            - string
+                        tag:
+                          type: 
+                            - string
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                required:
+                  - code
+                  - message
+                properties:
+                  code:
+                    type: 
+                      - integer
+                    format: int32
+                  message:
+                    type: 
+                      - string
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: 
+                      - array
+                    items:
+                      oneOf:
+                        - $ref: "#/paths/~1pets/get/responses/200/content/applicati\
+                            on~1json/schema/properties/newprop"
+                        - $ref: "#/paths/~1pets/get/responses/default/content/appli\
+                            cation~1json/schema"
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: 
+            - integer
+          format: int64
+        name:
+          type: 
+            - string
+        tag:
+          type: 
+            - string
+    Pets:
+      type: 
+        - array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: 
+            - integer
+          format: int32
+        message:
+          type: 
+            - string

--- a/test/data/31CollectionTransactions/validate30Scenarios/compositeSchemaCollection.json
+++ b/test/data/31CollectionTransactions/validate30Scenarios/compositeSchemaCollection.json
@@ -1,0 +1,252 @@
+{
+  "item": [
+    {
+      "id": "e3a46ab9-3e5d-4209-8a1c-3c2d9b51d488",
+      "name": "composite schema with anyOf keyword",
+      "request": {
+        "name": "composite schema with anyOf keyword",
+        "description": {},
+        "url": {
+          "path": [
+            "pets",
+            "anyOf"
+          ],
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "query": [],
+          "variable": []
+        },
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "method": "POST",
+        "auth": null,
+        "body": {
+          "mode": "raw",
+          "raw": "{\n \"objectType\": \"a string\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        }
+      },
+      "response": [
+        {
+          "id": "586bc4d3-3e99-4996-ae41-492b9528a09c",
+          "name": "ok",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "pets",
+                "anyOf"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n \"objectType\": \"a string\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "status": "Internal Server Error",
+          "code": 500,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "text/plain"
+            }
+          ],
+          "body": "",
+          "cookie": [],
+          "_postman_previewlanguage": "text"
+        }
+      ],
+      "event": []
+    },
+    {
+      "id": "07e822eb-3b75-44ca-8f95-47a5d529e64d",
+      "name": "composite schema with oneOf keyword",
+      "request": {
+        "name": "composite schema with oneOf keyword",
+        "description": {},
+        "url": {
+          "path": [
+            "pets",
+            "oneOf"
+          ],
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "query": [],
+          "variable": []
+        },
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "method": "POST",
+        "auth": null,
+        "body": {
+          "mode": "raw",
+          "raw":"{\n \"objectType2\": \"a string\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        }
+      },
+      "response": [
+        {
+          "id": "8e4bffe2-c6b9-490a-9d65-3d16997d54fa",
+          "name": "ok",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "pets",
+                "oneOf"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "body": {
+              "mode": "raw",
+              "raw":"{\n \"objectType2\": \"a string\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "status": "Internal Server Error",
+          "code": 500,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "text/plain"
+            }
+          ],
+          "body": "",
+          "cookie": [],
+          "_postman_previewlanguage": "text"
+        }
+      ],
+      "event": []
+    },
+    {
+      "id": "b7c13480-5b84-4acc-9749-1b9949f99a7d",
+      "name": "composite schema with allOf keyword",
+      "request": {
+        "name": "composite schema with allOf keyword",
+        "description": {},
+        "url": {
+          "path": [
+            "pets",
+            "allOf"
+          ],
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "query": [],
+          "variable": []
+        },
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "method": "POST",
+        "auth": null,
+        "body": {
+          "mode": "raw",
+          "raw": "{\n \"objectType\": \"not an integer\",\n \"objectType2\": \"prop named objectType2\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        }
+      },
+      "response": [
+        {
+          "id": "292a946f-874a-4274-a6a2-66715f3b37f3",
+          "name": "ok",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "pets",
+                "allOf"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n \"objectType\": \"not an integer\",\n \"objectType2\": \"prop named objectType2\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "status": "Internal Server Error",
+          "code": 500,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "text/plain"
+            }
+          ],
+          "body": "",
+          "cookie": [],
+          "_postman_previewlanguage": "text"
+        }
+      ],
+      "event": []
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "type": "string",
+      "value": "http://petstore.swagger.io/v1",
+      "key": "baseUrl"
+    }
+  ],
+  "info": {
+    "_postman_id": "2cccac2f-9007-4df9-ae5e-a6630ad8fc3f",
+    "name": "Swagger Petstore",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "",
+      "type": "text/plain"
+    }
+  }
+}

--- a/test/data/31CollectionTransactions/validate30Scenarios/compositeSchemaSpec.yaml
+++ b/test/data/31CollectionTransactions/validate30Scenarios/compositeSchemaSpec.yaml
@@ -1,0 +1,86 @@
+openapi: "3.1.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets/anyOf:
+    post:
+      summary: composite schema with anyOf keyword
+      requestBody:
+        content:
+          application/json:    
+            schema:
+              $ref: "#/components/schemas/anyOfExample"
+      responses:
+        default:
+          description: ok
+  /pets/oneOf:
+    post:
+      summary: composite schema with oneOf keyword
+      requestBody:
+        content:
+          application/json:    
+            schema:
+              $ref: "#/components/schemas/oneOfExample"
+      responses:
+        default:
+          description: ok
+  /pets/allOf:
+    post:
+      summary: composite schema with allOf keyword
+      requestBody:
+        content:
+          application/json:    
+            schema:
+              $ref: "#/components/schemas/allOfExample"
+      responses:
+        default:
+          description: ok
+components:
+  schemas:
+    anyOfExample:
+      anyOf:
+        - $ref: "#/components/schemas/schema1"
+        - $ref: "#/components/schemas/schema2"
+    oneOfExample:
+      oneOf:
+        - $ref: "#/components/schemas/schema1"
+        - $ref: "#/components/schemas/schema3"
+    allOfExample:
+      allOf:
+        - $ref: "#/components/schemas/schema1"
+        - $ref: "#/components/schemas/schema3"
+    schema1:
+      type: 
+        - object
+      required:
+        - objectType
+      properties:
+        objectType:
+          type: 
+            - integer
+          example: 4321
+    schema2:
+      type: 
+        - object
+      required:
+        - objectType
+      properties:
+        objectType:
+          type: 
+            - string
+          example: prop named objectType
+    schema3:
+      type: 
+        - object
+      required:
+        - objectType2
+      properties:
+        objectType2:
+          type: 
+            - string
+          example: prop named objectType2

--- a/test/data/31CollectionTransactions/validate30Scenarios/differentContentTypesCollection.json
+++ b/test/data/31CollectionTransactions/validate30Scenarios/differentContentTypesCollection.json
@@ -1,0 +1,102 @@
+{
+  "item": [
+    {
+      "id": "01cf6ca9-c708-433b-9713-eb11be11f4d8",
+      "name": "pets",
+      "description": {
+        "content": "",
+        "type": "text/plain"
+      },
+      "item": [
+        {
+          "id": "2359399f-6127-457f-afdf-ac74c1c35717",
+          "name": "List all pets",
+          "request": {
+            "name": "List all pets",
+            "description": {},
+            "url": {
+              "path": [
+                "pets"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/vnd.github+json"
+              }
+            ],
+            "method": "POST",
+            "auth": null,
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"id\": true,\n    \"name\": \"ea adip\",\n    \"tag\": \"proident Duis aliquip quis\"\n}"
+            }
+          },
+          "response": [
+            {
+              "id": "41dec372-09c2-44b9-958b-6d0897038947",
+              "name": "content with optional params media type",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "pets"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "limit",
+                      "value": "<integer>"
+                    }
+                  ],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"id\": -74679749,\n    \"name\": \"ea adip\",\n    \"tag\": \"proident Duis aliquip quis\"\n}"
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json; charset=utf-8"
+                }
+              ],
+              "body": "{\n \"id\": 1234,\n \"name\": 1234,\n \"tag\": \"proident Duis aliquip quis\"\n}",
+              "cookie": [],
+              "_postman_previewlanguage": "json"
+            }
+          ],
+          "event": []
+        }
+      ],
+      "event": []
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "id": "baseUrl",
+      "type": "string",
+      "value": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "info": {
+    "_postman_id": "8e92c978-8d41-4a4e-8d63-98d3bc0572d2",
+    "name": "Swagger Petstore",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "",
+      "type": "text/plain"
+    }
+  }
+}

--- a/test/data/31CollectionTransactions/validate30Scenarios/differentContentTypesSpec.yaml
+++ b/test/data/31CollectionTransactions/validate30Scenarios/differentContentTypesSpec.yaml
@@ -1,0 +1,44 @@
+openapi: "3.1.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    post:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      requestBody:
+        content:
+          application/vnd.github+json:    
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        '200':
+          description: content with optional params media type
+          content:
+            'application/json; charset=utf-8':
+              schema:
+                $ref: "#/components/schemas/Pet"
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: 
+            - integer
+          format: int64
+        name:
+          type: 
+            - string
+        tag:
+          type: 
+            - string

--- a/test/data/31CollectionTransactions/validate30Scenarios/doubleValidationFixSpec.yaml
+++ b/test/data/31CollectionTransactions/validate30Scenarios/doubleValidationFixSpec.yaml
@@ -1,0 +1,118 @@
+openapi: 3.1.0
+info:
+  title: Products
+  description: This is the OpenAPI for the Union Fashion product catalog.
+  version: '1.0'
+servers:
+  - url: '{{baseUrl}}'
+paths:
+  /products:
+    post:
+      summary: Add Productz
+      description: Creates a new productz.
+      operationId: addProduct
+      tags:
+        - Products
+      requestBody:
+        description: A product schema.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Product'
+            example:
+              category: Jeans
+              brand: Union
+              color: black
+              gender: m
+              unitPrice: 49.99
+              unitSalePrice: 29.99
+      security:
+        - api_key: []
+      responses:
+        default:
+          description: 'Sample desc.'
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: x-api-key
+      in: header
+  schemas:
+    Products:
+      type: 
+        - array
+      items:
+        $ref: '#/components/schemas/Product'
+    Product:
+      title: Product
+      required:
+        - identifier
+        - name
+      type: 
+        - object
+      properties:
+        identifier:
+          type: 
+            - string
+        name:
+          type: 
+            - string
+        description:
+          type: 
+            - string
+        image:
+          type: 
+            - string
+        url:
+          type: 
+            - string
+        brand:
+          type: 
+            - string
+        category:
+          type: 
+            - string
+        color:
+          type: 
+            - string
+        logo:
+          type: 
+            - string
+        manufacturer:
+          type: 
+            - string
+        material:
+          type: 
+            - string
+        model:
+          type: 
+            - string
+        releaseDate:
+          type: 
+            - string
+        sku:
+          type: 
+            - string
+        width:
+          type: 
+            - string
+        weight:
+          type: 
+            - string
+        depth:
+          type: 
+            - string
+        height:
+          type: 
+            - string
+      example:
+        id: XYZ-JEAN-123
+        category: Jeans
+        brand: Union
+        color: black
+        gender: m
+        unitPrice: 49.99
+        unitSalePrice: 29.99
+tags:
+  - name: Products
+    description: A product object.

--- a/test/data/31CollectionTransactions/validate30Scenarios/emptyParameterCollection.json
+++ b/test/data/31CollectionTransactions/validate30Scenarios/emptyParameterCollection.json
@@ -1,0 +1,134 @@
+{
+  "item": [
+    {
+      "id": "448f9fe2-0057-4d55-a369-80d41162b8a6",
+      "name": "pets",
+      "description": {
+        "content": "",
+        "type": "text/plain"
+      },
+      "item": [
+        {
+          "id": "6ee42234-271d-490c-a23a-50b70a57142c",
+          "name": "List all pets",
+          "request": {
+            "name": "List all pets",
+            "description": {},
+            "url": {
+              "path": [
+                "pets"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [
+                {
+                  "description": "How many items to return at one time (max 100)",
+                  "key": "limit",
+                  "value": "89178631"
+                }
+              ],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "d491ab71-8cde-4fd8-9538-7896929c2309",
+              "name": "A paged array of pets",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "pets"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "limit",
+                      "value": "<integer>"
+                    }
+                  ],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "description": "A link to the next page of responses",
+                  "key": "x-next",
+                  "value": "velit ea si"
+                },
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "[\n {\n  \"id\": -14143765,\n  \"name\": \"deserunt in\",\n  \"tag\": \"consectetur cupidatat\"\n },\n {\n  \"id\": -65226018,\n  \"name\": \"ex consectetur eu in\",\n  \"tag\": \"laborum mollit officia Ut\"\n }\n]",
+              "cookie": [],
+              "_postman_previewlanguage": "json"
+            },
+            {
+              "id": "23ad8e8e-a752-4a5d-905e-2b63f04fb7ea",
+              "name": "unexpected error",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "pets"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "limit",
+                      "value": "<integer>"
+                    }
+                  ],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Internal Server Error",
+              "code": 500,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n \"code\": 41499321,\n \"message\": \"dolore\"\n}",
+              "cookie": [],
+              "_postman_previewlanguage": "json"
+            }
+          ],
+          "event": []
+        }
+      ],
+      "event": []
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "id": "baseUrl",
+      "type": "string",
+      "value": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "info": {
+    "_postman_id": "a60fcbcc-ec53-4cd7-a4df-7abe60ebeb84",
+    "name": "Swagger Petstore",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "",
+      "type": "text/plain"
+    }
+  }
+}

--- a/test/data/31CollectionTransactions/validate30Scenarios/emptyParameterSpec.yaml
+++ b/test/data/31CollectionTransactions/validate30Scenarios/emptyParameterSpec.yaml
@@ -1,0 +1,83 @@
+openapi: "3.1.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        # below param is empty for testing
+        - 
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: 
+              - integer
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: 
+                  - string
+          content:
+            application/json:    
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: 
+        - object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: 
+            - integer
+          format: int64
+        name:
+          type: 
+            - string
+        tag:
+          type: 
+            - string
+    Pets:
+      type: 
+        - array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      type: 
+        - object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: 
+            - integer
+          format: int32
+        message:
+          type: 
+            - string

--- a/test/data/31CollectionTransactions/validate30Scenarios/implicitHeaderCollection.json
+++ b/test/data/31CollectionTransactions/validate30Scenarios/implicitHeaderCollection.json
@@ -1,0 +1,163 @@
+{
+  "item": [
+    {
+      "id": "6e1e8783-7fae-4902-b764-b8a5c2632139",
+      "name": "pets",
+      "description": {
+        "content": "",
+        "type": "text/plain"
+      },
+      "item": [
+        {
+          "id": "46d9bd4b-c82c-454b-93e5-dcdf64798497",
+          "name": "Create a pet",
+          "request": {
+            "name": "Create a pet",
+            "description": {},
+            "url": {
+              "path": [
+                "pets"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "header": [
+              {
+                "description": "",
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "description": "",
+                "key": "header-1",
+                "value": "not a number"
+              }
+            ],
+            "method": "POST",
+            "auth": null,
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"id\": 11265533,\n    \"name\": \"tempor adipisicin\",\n    \"tag\": \"sint culpa veniam\"\n}"
+            }
+          },
+          "response": [
+            {
+              "id": "34840c21-65c2-42f6-8a6d-280a4f800849",
+              "name": "Null response",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "pets"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "description": "",
+                    "key": "Accept",
+                    "value": "<string>"
+                  },
+                  {
+                    "description": "",
+                    "key": "header-1",
+                    "value": "<integer>"
+                  }
+                ],
+                "method": "POST",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"id\": 11265533,\n    \"name\": \"tempor adipisicin\",\n    \"tag\": \"sint culpa veniam\"\n}"
+                }
+              },
+              "status": "Created",
+              "code": 201,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            },
+            {
+              "id": "7aaf6fcb-2af9-4c4f-a650-b004101b6cf5",
+              "name": "unexpected error",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "pets"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "description": "",
+                    "key": "Accept",
+                    "value": "<string>"
+                  },
+                  {
+                    "description": "",
+                    "key": "header-1",
+                    "value": "<integer>"
+                  }
+                ],
+                "method": "POST",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"id\": 11265533,\n    \"name\": \"tempor adipisicin\",\n    \"tag\": \"sint culpa veniam\"\n}"
+                }
+              },
+              "status": "Internal Server Error",
+              "code": 500,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n \"code\": 22640796,\n \"message\": \"aute\"\n}",
+              "cookie": [],
+              "_postman_previewlanguage": "json"
+            }
+          ],
+          "event": []
+        }
+      ],
+      "event": []
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "id": "baseUrl",
+      "type": "string",
+      "value": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "info": {
+    "_postman_id": "2d5ffaea-40bd-4f22-8bc7-e951deeacdf6",
+    "name": "Swagger Petstore",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "",
+      "type": "text/plain"
+    }
+  }
+}

--- a/test/data/31CollectionTransactions/validate30Scenarios/implicitHeaderSpec.yaml
+++ b/test/data/31CollectionTransactions/validate30Scenarios/implicitHeaderSpec.yaml
@@ -1,0 +1,88 @@
+openapi: "3.1.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      parameters:
+        - name: Accept
+          in: header
+          required: false
+          schema:
+            type: 
+              - string
+        - name: header-1
+          in: header
+          required: false
+          schema:
+            type: 
+              - integer
+            format: int32
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          headers:
+            content-type:
+              description: content-type of response body
+              required: true
+              schema:
+                type: 
+                  - string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: 
+        - object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: 
+            - integer
+          format: int64
+        name:
+          type: 
+            - string
+        tag:
+          type: 
+            - string
+    Pets:
+      type: 
+        - array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      type: 
+        - object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: 
+            - integer
+          format: int32
+        message:
+          type: 
+            - string

--- a/test/data/31CollectionTransactions/validate30Scenarios/internalRefsCollection.json
+++ b/test/data/31CollectionTransactions/validate30Scenarios/internalRefsCollection.json
@@ -1,0 +1,260 @@
+{
+    "item": [
+      {
+        "id": "9b8ff406-3176-49ca-b91a-e99277130d40",
+        "name": "searches inventory",
+        "request": {
+          "name": "searches inventory",
+          "description": {
+            "content": "By passing in the appropriate options, you can search for\navailable inventory in the system\n",
+            "type": "text/plain"
+          },
+          "url": {
+            "path": [
+              "inventory",
+              ":searchString"
+            ],
+            "host": [
+              "{{baseUrl}}"
+            ],
+            "query": [
+              {
+                "description": "number of records to skip for pagination",
+                "key": "skip",
+                "value": "71616628"
+              }
+            ],
+            "variable": [
+              {
+                "description": "pass an optional search string for looking up inventory",
+                "type": "any",
+                "value": "magna",
+                "key": "searchString"
+              }
+            ]
+          },
+          "header": [
+            {
+              "description": "maximum number of records to return",
+              "key": "limit",
+              "value": "25"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "method": "POST",
+          "auth": null,
+          "body": {
+            "mode": "raw",
+            "raw": "{\n    \"id\": \"d290f1ee-6c54-4b01-90e6-d701748f0851\",\n    \"name\": \"Widget Adapter\",\n    \"manufacturer\": {\n        \"name\": \"ACME Corporation\",\n        \"homePage\": \"https://www.acme-corp.com\",\n        \"phone\": \"408-867-5309\"\n    },\n    \"releaseDate\": \"2016-08-29T09:12:33.001Z\"\n}"
+          }
+        },
+        "response": [
+          {
+            "id": "103e959b-3d59-4a3b-9a0f-eef9206733e9",
+            "name": "An array of profiles",
+            "originalRequest": {
+              "url": {
+                "path": [
+                  "inventory",
+                  ":searchString"
+                ],
+                "host": [
+                  "{{baseUrl}}"
+                ],
+                "query": [
+                  {
+                    "key": "skip",
+                    "value": "<integer>"
+                  }
+                ],
+                "variable": [
+                  {
+                    "type": "any",
+                    "key": "searchString"
+                  }
+                ]
+              },
+              "header": [
+                {
+                  "description": "maximum number of records to return",
+                  "key": "limit",
+                  "value": "<integer>"
+                }
+              ],
+              "method": "POST",
+              "body": {}
+            },
+            "status": "OK",
+            "code": 200,
+            "header": [
+              {
+                "description": "The date.",
+                "key": "x-date",
+                "value": "2012-06-15"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": "{\n \"id\": \"urn:uuid:986f1de0-b002-2c4e-63a7-724ac665365b\",\n \"name\": \"ioneyed\",\n \"given_name\": \"Robert\",\n \"family_name\": \"Buchanan\"\n}",
+            "cookie": [],
+            "_postman_previewlanguage": "json"
+          },
+          {
+            "id": "7e2062e0-d928-4ae5-924b-858d3bcce494",
+            "name": "The user is unauthorized for this action",
+            "originalRequest": {
+              "url": {
+                "path": [
+                  "inventory",
+                  ":searchString"
+                ],
+                "host": [
+                  "{{baseUrl}}"
+                ],
+                "query": [
+                  {
+                    "key": "skip",
+                    "value": "<integer>"
+                  }
+                ],
+                "variable": [
+                  {
+                    "type": "any",
+                    "key": "searchString"
+                  }
+                ]
+              },
+              "header": [
+                {
+                  "description": "maximum number of records to return",
+                  "key": "limit",
+                  "value": "<integer>"
+                }
+              ],
+              "method": "POST",
+              "body": {}
+            },
+            "status": "Unauthorized",
+            "code": 401,
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": "{\n \"code\": \"PROFILE-108-401\",\n \"message\": \"you do not have appropriate credentials\"\n}",
+            "cookie": [],
+            "_postman_previewlanguage": "json"
+          }
+        ],
+        "event": []
+      },
+      {
+        "id": "9a089428-7a6c-4b30-ba0c-b036383af51e",
+        "name": "/inventory/:searchString",
+        "request": {
+          "name": "/inventory/:searchString",
+          "description": {},
+          "url": {
+            "path": [
+              "inventory",
+              ":searchString"
+            ],
+            "host": [
+              "{{baseUrl}}"
+            ],
+            "query": [],
+            "variable": [
+              {
+                "disabled": false,
+                "type": "any",
+                "value": "sed eu",
+                "key": "searchString",
+                "description": "pass an optional search string for looking up inventory"
+              }
+            ]
+          },
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "method": "PUT",
+          "auth": null,
+          "body": {
+            "mode": "raw",
+            "raw": "{\n    \"name\": \"dolore ex consequat\",\n    \"alternateName\": \"id consequat Ut\",\n    \"providerId\": \"Ut reprehenderit aute ea consectetur\"\n}",
+            "options": {
+              "raw": {
+                "language": "json"
+              }
+            }
+          }
+        },
+        "response": [
+          {
+            "id": "2b4dd71c-4664-4685-8c7c-8ef5bf8f6704",
+            "name": "successful operation",
+            "originalRequest": {
+              "url": {
+                "path": [
+                  "inventory",
+                  ":searchString"
+                ],
+                "host": [
+                  "{{baseUrl}}"
+                ],
+                "query": [],
+                "variable": [
+                  {
+                    "disabled": false,
+                    "type": "any",
+                    "value": "sed eu",
+                    "key": "searchString",
+                    "description": "pass an optional search string for looking up inventory"
+                  }
+                ]
+              },
+              "method": "PUT",
+              "body": {}
+            },
+            "status": "OK",
+            "code": 200,
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": "\"sed eu\"",
+            "cookie": [],
+            "_postman_previewlanguage": "json"
+          }
+        ],
+        "event": []
+      }
+    ],
+    "event": [],
+    "variable": [
+      {
+        "id": "baseUrl",
+        "type": "string",
+        "value": "https://example.com"
+      }
+    ],
+    "info": {
+      "_postman_id": "758b4b2c-df93-4250-a287-6e526f194a75",
+      "name": "Simple Inventory API",
+      "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+      "description": {
+        "content": "This is a simple API\n\nContact Support:\n Email: you@your-company.com",
+        "type": "text/plain"
+      }
+    }
+  }

--- a/test/data/31CollectionTransactions/validate30Scenarios/internalRefsSpec.yaml
+++ b/test/data/31CollectionTransactions/validate30Scenarios/internalRefsSpec.yaml
@@ -1,0 +1,248 @@
+openapi: 3.1.0
+servers:
+  - description: Internal $refs
+    url: https://example.com
+info:
+  description: This is a simple API
+  version: "1.0.0"
+  title: Simple Inventory API
+  contact:
+    email: you@your-company.com
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+paths:
+  /inventory/{searchString}:
+    parameters:
+      - $ref: '#/components/parameters/searchString'
+    post:
+      summary: searches inventory
+      operationId: searchInventory
+      description: |
+        By passing in the appropriate options, you can search for
+        available inventory in the system
+      parameters:
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/limit'
+      requestBody:
+        $ref: '#/components/requestBodies/inventoryBody'
+      responses:
+        '200':
+          description: 'An array of profiles'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Profile'
+          headers:
+            x-date:
+              $ref: '#/components/headers/x-date'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+    put:
+      requestBody:
+        $ref: '#/components/requestBodies/ProviderConfig'
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: 
+                  - string
+components:
+  headers:
+    x-date:
+      description: The date.
+      schema:
+        type: 
+          - string
+        format: date
+  parameters:
+    limit:
+      in: header
+      name: limit
+      description: maximum number of records to return
+      schema:
+        type: 
+          - integer
+        format: int32
+        minimum: 0
+        maximum: 50
+    searchString:
+      in: path
+      name: searchString
+      description: pass an optional search string for looking up inventory
+      required: false
+      schema:
+        $ref: '#/components/schemas/SearchString'
+    skip:
+      in: query
+      name: skip
+      description: number of records to skip for pagination
+      schema:
+        type: 
+          - integer
+        format: int32
+        minimum: 0
+  requestBodies:
+    inventoryBody:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/InventoryItem'
+      description: Inventory item to add
+    ProviderConfig:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ProviderConfig'
+  responses:
+    UnexpectedError:
+      description: An unexpected error has occured
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            code: 'PROFILE-107-500'
+            message: 'fixing problems'
+    Unauthorized:
+      description: The user is unauthorized for this action
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            code: 'PROFILE-108-401'
+            message: 'you do not have appropriate credentials'
+    Forbidden:
+      description: The user in forbidden from completing that action
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            code: 'PROFILE-109-403'
+            message: 'thou shall not pass for you are forbidden'
+    NotFound:
+      description: The resource was not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            code: 'PROFILE-110-404'
+            message: 'resource was not found'
+  schemas:
+    SearchString:
+      type: 
+        - string
+    InventoryItem:
+      type: 
+        - object
+      required:
+        - id
+        - name
+        - manufacturer
+        - releaseDate
+      properties:
+        id:
+          type: 
+            - string
+          format: uuid
+          examples: 
+            - d290f1ee-6c54-4b01-90e6-d701748f0851
+        name:
+          type: 
+            - string
+          examples: 
+            - Widget Adapter
+        releaseDate:
+          type: 
+            - string
+          format: date-time
+          examples: 
+            - '2016-08-29T09:12:33.001Z'
+        manufacturer:
+          $ref: '#/components/schemas/Manufacturer'
+    Manufacturer:
+      required:
+        - name
+      properties:
+        name:
+          type: 
+            - string
+          examples: 
+            - ACME Corporation
+        homePage:
+          type: 
+            - string
+          format: url
+          examples: 
+            - 'https://www.acme-corp.com'
+        phone:
+          type: 
+            - string
+          examples: 
+            - 408-867-5309
+      type: 
+        - object
+    Profile:
+      type: 
+        - object
+      required:
+        - id
+        - name
+        - given_name
+        - family_name
+      properties:
+        id:
+          type: 
+            - string
+          format: uuid
+        name:
+          type: 
+            - string
+          examples: 
+            - "ioneyed"
+        given_name:
+          type: 
+            - string
+          examples: 
+            - "Robert"
+        family_name:
+          type: 
+            - string
+          examples: 
+            - "Buchanan"
+    Error:
+      type: 
+        - object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: 
+            - string
+          pattern: 'PROFILE-\d{3}-\d{3}'
+          examples: 
+            - "PROFILE-100-507"
+        message:
+          type: 
+            - string
+          examples: 
+            - "we have run out of storage; this is embarrassing, and someone have been paged"
+    ProviderConfig:
+      type: 
+        - object
+      properties:
+        name:
+          type: 
+            - string
+        alternateName:
+          type: 
+            - string
+        providerId:
+          type: 
+            - string

--- a/test/data/31CollectionTransactions/validate30Scenarios/multiplePathVarCollection.json
+++ b/test/data/31CollectionTransactions/validate30Scenarios/multiplePathVarCollection.json
@@ -1,0 +1,165 @@
+{
+  "item": [
+    {
+      "id": "98f1665c-b4ee-43d1-8454-51e4b1bc0c1f",
+      "name": "/api/path_with_multiple_pathvars/:pathvar1/:pathvar2/:pathvar3",
+      "request": {
+        "name": "/api/path_with_multiple_pathvars/:pathvar1/:pathvar2/:pathvar3",
+        "description": {},
+        "url": {
+          "path": [
+            "api",
+            "path_with_multiple_pathvars",
+            ":pathvar1",
+            ":pathvar2",
+            ":pathvar3"
+          ],
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "query": [],
+          "variable": [
+            {
+              "description": "(Required) ",
+              "type": "any",
+              "value": "66.42473585353362",
+              "key": "pathvar1"
+            },
+            {
+              "description": "(Required) ",
+              "type": "any",
+              "value": "10.018941650763242",
+              "key": "pathvar2"
+            },
+            {
+              "description": "(Required) ",
+              "type": "any",
+              "value": "false",
+              "key": "pathvar3"
+            }
+          ]
+        },
+        "method": "GET",
+        "auth": null
+      },
+      "response": [
+        {
+          "id": "659f472d-f227-4122-a8da-64079749fea4",
+          "name": "Success",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "api",
+                "path_with_multiple_pathvars",
+                ":pathvar1",
+                ":pathvar2",
+                ":pathvar3"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "type": "any",
+                  "key": "pathvar1"
+                },
+                {
+                  "type": "any",
+                  "key": "pathvar2"
+                },
+                {
+                  "type": "any",
+                  "key": "pathvar3"
+                }
+              ]
+            },
+            "method": "GET",
+            "body": {}
+          },
+          "status": "OK",
+          "code": 200,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "text/plain"
+            }
+          ],
+          "body": "",
+          "cookie": [],
+          "_postman_previewlanguage": "text"
+        }
+      ],
+      "event": []
+    },
+    {
+      "id": "82704c56-aadb-4925-a6bf-db07b4a8f538",
+      "name": "/pets",
+      "request": {
+        "name": "/pets",
+        "description": {},
+        "url": {
+          "path": [
+            "pets"
+          ],
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "query": [],
+          "variable": []
+        },
+        "method": "GET",
+        "auth": null
+      },
+      "response": [
+        {
+          "id": "9a9c0108-1ec7-4ba3-82f2-0c335e650c49",
+          "name": "Success",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "pets"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "body": {}
+          },
+          "status": "OK",
+          "code": 200,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "text/plain"
+            }
+          ],
+          "body": "",
+          "cookie": [],
+          "_postman_previewlanguage": "text"
+        }
+      ],
+      "event": []
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "id": "baseUrl",
+      "type": "string",
+      "value": "/"
+    }
+  ],
+  "info": {
+    "_postman_id": "1df2ca7f-6b37-48ce-b340-8367b28a59ee",
+    "name": "Incorrect validation of Path var",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "",
+      "type": "text/plain"
+    }
+  }
+}

--- a/test/data/31CollectionTransactions/validate30Scenarios/multiplePathVarSpec.json
+++ b/test/data/31CollectionTransactions/validate30Scenarios/multiplePathVarSpec.json
@@ -1,0 +1,71 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Incorrect validation of Path var",
+    "version": "v1"
+  },
+  "paths": {
+    "/api/path_with_multiple_pathvars/{pathvar1}/{pathvar2}/{pathvar3}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "pathvar1",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "maximum": 70,
+              "minimum": 10,
+              "type": ["number"],
+              "format": "double"
+            }
+          },
+          {
+            "name": "pathvar2",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "maximum": 20,
+              "minimum": 0,
+              "type": ["number"],
+              "format": "double"
+            }
+          },
+          {
+            "name": "pathvar3",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": ["boolean"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/{petId}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": ["number"],
+              "format": "double"
+            },
+            "example": 99.99
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/data/31CollectionTransactions/validate30Scenarios/nestedObjectParamsCollection.json
+++ b/test/data/31CollectionTransactions/validate30Scenarios/nestedObjectParamsCollection.json
@@ -1,0 +1,136 @@
+{
+  "item": [
+    {
+      "id": "a2b99009-5e11-43ac-b411-fa7fd1425262",
+      "name": "pets",
+      "description": {
+        "content": "",
+        "type": "text/plain"
+      },
+      "item": [
+        {
+          "id": "099ccc06-611e-4e31-8462-7e66ba7783e7",
+          "name": "List all pets",
+          "request": {
+            "name": "List all pets",
+            "description": {},
+            "url": {
+              "path": [
+                "pets"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [
+                {
+                  "disabled": false,
+                  "key": "limit",
+                  "value": "prop2,32,prop1,[object Object]",
+                  "description": "(Required) How many items to return at one time (max 100)"
+                }
+              ],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "24e8f452-28f2-44a2-839e-081e2d54c287",
+              "name": "An paged array of pets",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "pets"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "limit",
+                      "value": "prop2,32,prop1,[object Object]"
+                    }
+                  ],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "disabled": false,
+                  "description": "A link to the next page of responses",
+                  "key": "x-next",
+                  "value": "nostrud do"
+                },
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "[\n {\n  \"id\": 17889649,\n  \"name\": \"enim tempor minim\",\n  \"tag\": \"incididunt esse nostrud culpa sit\"\n },\n {\n  \"id\": 54275385,\n  \"name\": \"et labore veniam\",\n  \"tag\": \"elit ut si\"\n }\n]",
+              "cookie": [],
+              "_postman_previewlanguage": "json"
+            },
+            {
+              "id": "5b174b95-db8c-4a53-9a89-a817b47e9d1b",
+              "name": "unexpected error",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "pets"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "limit",
+                      "value": "prop2,32,prop1,[object Object]"
+                    }
+                  ],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Internal Server Error",
+              "code": 500,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n \"code\": -28330006,\n \"message\": \"qui occaecat magna\"\n}",
+              "cookie": [],
+              "_postman_previewlanguage": "json"
+            }
+          ],
+          "event": []
+        }
+      ],
+      "event": []
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "type": "string",
+      "value": "http://petstore.swagger.io/v1",
+      "key": "baseUrl"
+    }
+  ],
+  "info": {
+    "_postman_id": "0861b241-23ad-435c-a80e-af77f30b2acd",
+    "name": "Swagger Petstore",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "",
+      "type": "text/plain"
+    }
+  }
+}

--- a/test/data/31CollectionTransactions/validate30Scenarios/nestedObjectParamsSpec.yaml
+++ b/test/data/31CollectionTransactions/validate30Scenarios/nestedObjectParamsSpec.yaml
@@ -1,0 +1,92 @@
+openapi: "3.1.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: true
+          explode: false
+          schema:
+            type: 
+              - object
+            required:
+              - prop2
+            properties:
+              prop1:
+                type: 
+                  - object
+                properties:
+                  prop1_1:
+                    type: 
+                      - string
+              prop2:
+                type: 
+                  - integer
+                example: 
+                  - 32
+      responses:
+        '200':
+          description: An paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: 
+                  - string
+          content:
+            application/json:    
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: 
+            - integer
+          format: int64
+        name:
+          type: 
+            - string
+        tag:
+          type: 
+            - string
+    Pets:
+      type: 
+        - array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: 
+            - integer
+          format: int32
+        message:
+          type: 
+            - string

--- a/test/data/31CollectionTransactions/validate30Scenarios/primitiveDataTypeBodyCollection.json
+++ b/test/data/31CollectionTransactions/validate30Scenarios/primitiveDataTypeBodyCollection.json
@@ -1,0 +1,90 @@
+{
+  "item": [
+    {
+      "id": "69d7005c-6a60-4a30-b71f-7d88f9341898",
+      "name": "Demo invalid type",
+      "request": {
+        "name": "Demo invalid type",
+        "description": {},
+        "url": {
+          "path": [
+            "api"
+          ],
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "query": [],
+          "variable": []
+        },
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "method": "POST",
+        "auth": null,
+        "body": {
+          "mode": "raw",
+          "raw": "false"
+        }
+      },
+      "response": [
+        {
+          "id": "c457a34e-3b7d-4052-a034-3a2fe1cf7e24",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "api"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [
+                {
+                  "key": "",
+                  "value": null
+                }
+              ],
+              "variable": []
+            },
+            "method": "POST",
+            "body": {
+              "mode": "raw",
+              "raw": "true"
+            }
+          },
+          "status": "OK",
+          "code": 200,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "body": "123",
+          "cookie": [],
+          "_postman_previewlanguage": "json"
+        }
+      ],
+      "event": []
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "id": "baseUrl",
+      "type": "string",
+      "value": "/"
+    }
+  ],
+  "info": {
+    "_postman_id": "f12b0220-20c0-4619-bfae-7b8d7c7574cf",
+    "name": "Demo API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "",
+      "type": "text/plain"
+    }
+  }
+}

--- a/test/data/31CollectionTransactions/validate30Scenarios/primitiveDataTypeBodySpec.yaml
+++ b/test/data/31CollectionTransactions/validate30Scenarios/primitiveDataTypeBodySpec.yaml
@@ -1,0 +1,24 @@
+openapi: 3.1.0
+info:
+  version: 1.0
+  title: Demo API
+paths:
+  /api:
+    post:
+      summary: 'Demo invalid type'
+      requestBody:
+        description: 'Cannot use type boolean'
+        content:
+          application/json:
+              schema:
+                type: 
+                  - boolean
+      responses:
+        '200':
+          content:
+            application/json:
+                schema:
+                  type: 
+                    - integer
+                  minimum: 5
+                  maximum: 10

--- a/test/data/31CollectionTransactions/validate30Scenarios/queryParamDeepObjectCollection.json
+++ b/test/data/31CollectionTransactions/validate30Scenarios/queryParamDeepObjectCollection.json
@@ -1,0 +1,160 @@
+{
+  "item": [
+    {
+      "id": "9861bc73-aafe-4c44-8c91-f42e4d820ae6",
+      "name": "pet",
+      "description": {
+        "content": "",
+        "type": "text/plain"
+      },
+      "item": [
+        {
+          "id": "23d37c51-7a63-412e-b15a-10c336d49615",
+          "name": "Updates a pet in the store with form data",
+          "request": {
+            "name": "Updates a pet in the store with form data",
+            "description": {},
+            "url": {
+              "path": [
+                "pets"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [
+                {
+                  "disabled": false,
+                  "key": "user[id]",
+                  "value": "notAnInteger",
+                  "description": "(Required) info about user"
+                },
+                {
+                  "disabled": false,
+                  "key": "user[name]",
+                  "value": "John Johanson",
+                  "description": "(Required) info about user"
+                },
+                {
+                  "disabled": false,
+                  "key": "user[address][city]",
+                  "value": "Delhi",
+                  "description": "(Required) info about user"
+                },
+                {
+                  "disabled": false,
+                  "key": "propArrayComplex[0][prop1ArrayComp]",
+                  "value": "notAnInteger",
+                  "description": "(Required) deepObject with complex array structure"
+                },
+                {
+                  "disabled": false,
+                  "key": "propArrayComplex[0][prop2ArrayComp]",
+                  "value": "qui anim",
+                  "description": "(Required) deepObject with complex array structure"
+                },
+                {
+                  "disabled": false,
+                  "key": "propArrayComplex[1][prop1ArrayComp]",
+                  "value": "87313126",
+                  "description": "(Required) deepObject with complex array structure"
+                },
+                {
+                  "disabled": false,
+                  "key": "propArrayComplex[1][prop2ArrayComp]",
+                  "value": "reprehenderit",
+                  "description": "(Required) deepObject with complex array structure"
+                }
+              ],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "76137f7a-7d78-4f8b-837f-d678124c0b8e",
+              "name": "Pet updated.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "pets"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "user[id]",
+                      "value": "123"
+                    },
+                    {
+                      "key": "user[name]",
+                      "value": "John Johanson"
+                    },
+                    {
+                      "key": "user[address][city]",
+                      "value": "Delhi"
+                    },
+                    {
+                      "key": "user[address][country]",
+                      "value": "India"
+                    },
+                    {
+                      "key": "propArrayComplex[0][prop1ArrayComp]",
+                      "value": "70013937"
+                    },
+                    {
+                      "key": "propArrayComplex[0][prop2ArrayComp]",
+                      "value": "pariatur sit consectetur minim"
+                    },
+                    {
+                      "key": "propArrayComplex[1][prop1ArrayComp]",
+                      "value": "-77852940"
+                    },
+                    {
+                      "key": "propArrayComplex[1][prop2ArrayComp]",
+                      "value": "amet"
+                    }
+                  ],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        }
+      ],
+      "event": []
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "type": "string",
+      "value": "http://petstore.swagger.io/v1",
+      "key": "baseUrl"
+    }
+  ],
+  "info": {
+    "_postman_id": "c3eff23a-fbd9-40b7-9029-7e9699d9bb1b",
+    "name": "Swagger Petstore",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "",
+      "type": "text/plain"
+    }
+  }
+}

--- a/test/data/31CollectionTransactions/validate30Scenarios/queryParamDeepObjectSpec.yaml
+++ b/test/data/31CollectionTransactions/validate30Scenarios/queryParamDeepObjectSpec.yaml
@@ -1,0 +1,70 @@
+openapi: "3.1.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      tags:
+      - pet
+      summary: Updates a pet in the store with form data
+      operationId: updatePetWithForm
+      parameters:
+      - name: user
+        in: query
+        description: info about user
+        required: true
+        style: deepObject
+        schema:
+          type: 
+            - object
+          properties:
+            id:
+              type: 
+                - integer
+              examples: 
+                - 123
+            name:
+              type: 
+                - string
+              examples: 
+                - John Johanson
+            address:
+              type: 
+                - object
+              properties:
+                city:
+                  type: 
+                    - string
+                  examples: 
+                    - Delhi
+                country:
+                  type: 
+                    - string
+                  examples: 
+                    - India
+      - name: propArrayComplex
+        in: query
+        description: deepObject with complex array structure
+        required: true
+        style: deepObject
+        schema:
+          type: 
+            - array
+          items:
+            type: 
+              - object
+            properties:
+              prop1ArrayComp:
+                type: 
+                  - integer
+              prop2ArrayComp:
+                type: 
+                  - string
+      responses:
+        '200':
+          description: Pet updated.

--- a/test/data/31CollectionTransactions/validate30Scenarios/rootKeywordViolationCollection.json
+++ b/test/data/31CollectionTransactions/validate30Scenarios/rootKeywordViolationCollection.json
@@ -1,0 +1,145 @@
+{
+  "item": [
+    {
+      "id": "6a23e0c5-f874-4d64-917f-436e8b6630b7",
+      "name": "pets",
+      "description": {
+        "content": "",
+        "type": "text/plain"
+      },
+      "item": [
+        {
+          "id": "58a1eaab-6150-4bd8-9606-aae2a519d1dc",
+          "name": "Create a pet",
+          "request": {
+            "name": "Create a pet",
+            "description": {},
+            "url": {
+              "path": [
+                "pets"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [
+                {
+                  "description": "",
+                  "key": "limit",
+                  "value": "-74270672"
+                }
+              ],
+              "variable": []
+            },
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "auth": null,
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"id\": -97299140,\n    \"name\": \"dolore\",\n    \"tag\": \"nostrud et in\"\n}"
+            }
+          },
+          "response": [
+            {
+              "id": "497bb8cc-bf09-4712-b3c2-38a7f7772e00",
+              "name": "Null response",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "pets"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "limit",
+                      "value": "<integer>"
+                    }
+                  ],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"id\": -97299140,\n    \"name\": \"dolore\",\n    \"tag\": \"nostrud et in\"\n}"
+                }
+              },
+              "status": "Created",
+              "code": 201,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            },
+            {
+              "id": "51d2030f-e874-4b29-b8b7-a92de6566ec0",
+              "name": "unexpected error",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "pets"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "limit",
+                      "value": "<integer>"
+                    }
+                  ],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"id\": -97299140,\n    \"name\": \"dolore\",\n    \"tag\": \"nostrud et in\"\n}"
+                }
+              },
+              "status": "Internal Server Error",
+              "code": 500,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n \"code\": 94595733,\n \"message\": \"Duis sit qui\"\n}",
+              "cookie": [],
+              "_postman_previewlanguage": "json"
+            }
+          ],
+          "event": []
+        }
+      ],
+      "event": []
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "id": "baseUrl",
+      "type": "string",
+      "value": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "info": {
+    "_postman_id": "9836d256-0ada-42d6-a825-a103d0bb3695",
+    "name": "Swagger Petstore",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "",
+      "type": "text/plain"
+    }
+  }
+}

--- a/test/data/31CollectionTransactions/validate30Scenarios/rootKeywordViolationSpec.yaml
+++ b/test/data/31CollectionTransactions/validate30Scenarios/rootKeywordViolationSpec.yaml
@@ -1,0 +1,71 @@
+openapi: "3.1.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: 
+              - integer
+            format: int32
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: 
+        - object
+      minProperties: 4
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: 
+            - integer
+          format: int64
+        name:
+          type: 
+            - string
+        tag:
+          type: 
+            - string
+    Error:
+      type: 
+        - object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: 
+            - integer
+          format: int32
+        message:
+          type: 
+            - string

--- a/test/data/31CollectionTransactions/validate30Scenarios/urlencodedBodyCollection.json
+++ b/test/data/31CollectionTransactions/validate30Scenarios/urlencodedBodyCollection.json
@@ -1,0 +1,201 @@
+{
+  "item": [
+    {
+      "id": "f5983708-1a61-43a4-919b-ca40a34fe2a3",
+      "name": "pet",
+      "description": {
+        "content": "",
+        "type": "text/plain"
+      },
+      "item": [
+        {
+          "id": "9c4d4bf3-c8f6-47f5-83d6-6e25f89c1314",
+          "name": "Updates a pet in the store with form data",
+          "request": {
+            "name": "Updates a pet in the store with form data",
+            "description": {},
+            "url": {
+              "path": [
+                "pets",
+                ":petId"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "description": "(Required) ID of pet that needs to be updated",
+                  "type": "any",
+                  "value": "elit nulla",
+                  "key": "petId"
+                }
+              ]
+            },
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "method": "POST",
+            "auth": null,
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "prop1",
+                  "value": "hello"
+                },
+                {
+                  "key": "prop2",
+                  "value": "false"
+                },
+                {
+                  "key": "propObjectNonExplodable",
+                  "value": "prop3,hello,prop4,true"
+                },
+                {
+                  "key": "propArray",
+                  "value": "str1"
+                },
+                {
+                  "key": "propArray",
+                  "value": "999"
+                },
+                {
+                  "key": "propSimple",
+                  "value": "123"
+                },
+                {
+                  "disabled": false,
+                  "key": "propDeepObject[id]",
+                  "value": "123"
+                },
+                {
+                  "disabled": false,
+                  "key": "propDeepObject[name]",
+                  "value": "John Johanson"
+                },
+                {
+                  "disabled": false,
+                  "key": "propDeepObject[address][city]",
+                  "value": "123"
+                },
+                {
+                  "disabled": false,
+                  "key": "propDeepObject[address][country]",
+                  "value": "India"
+                },
+                {
+                  "disabled": false,
+                  "key": "propArrayComplex[0][prop1ArrayComp]",
+                  "value": "notAnInteger"
+                },
+                {
+                  "disabled": false,
+                  "key": "propArrayComplex[0][prop2ArrayComp]",
+                  "value": "irure labore Lorem consequat l"
+                },
+                {
+                  "disabled": false,
+                  "key": "propArrayComplex[1][prop1ArrayComp]",
+                  "value": "-14216671"
+                },
+                {
+                  "disabled": false,
+                  "key": "propArrayComplex[1][prop2ArrayComp]",
+                  "value": "officia"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "id": "613fc0d2-9836-48a6-9518-8f239ba9427f",
+              "name": "Pet updated.",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "pets",
+                    ":petId"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "type": "any",
+                      "key": "petId"
+                    }
+                  ]
+                },
+                "method": "POST",
+                "body": {
+                  "mode": "urlencoded",
+                  "urlencoded": [
+                    {
+                      "key": "prop1",
+                      "value": "hello"
+                    },
+                    {
+                      "key": "prop2",
+                      "value": "world"
+                    },
+                    {
+                      "key": "propObjectNonExplodable",
+                      "value": "prop1,hello,prop2,world"
+                    },
+                    {
+                      "key": "propArray",
+                      "value": "str1"
+                    },
+                    {
+                      "key": "propArray",
+                      "value": "str2"
+                    },
+                    {
+                      "key": "propSimple",
+                      "value": "123"
+                    }
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        }
+      ],
+      "event": []
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "id": "baseUrl",
+      "type": "string",
+      "value": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "info": {
+    "_postman_id": "acd16ff0-eda5-48b4-b0de-4d35138da21d",
+    "name": "Swagger Petstore",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "",
+      "type": "text/plain"
+    }
+  }
+}

--- a/test/data/31CollectionTransactions/validate30Scenarios/urlencodedBodySpec.yaml
+++ b/test/data/31CollectionTransactions/validate30Scenarios/urlencodedBodySpec.yaml
@@ -1,0 +1,137 @@
+openapi: "3.1.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets/{petId}:
+    post:
+      tags:
+      - pet
+      summary: Updates a pet in the store with form data
+      operationId: updatePetWithForm
+      parameters:
+      - name: petId
+        in: path
+        description: ID of pet that needs to be updated
+        required: true
+        schema:
+          type: 
+            - string
+      requestBody:
+        content:
+          'application/x-www-form-urlencoded':
+            schema:
+              properties:
+                propObjectExplodable:
+                  type: 
+                    - object
+                  properties:
+                    prop1:
+                      type: 
+                        - string
+                      examples: 
+                        - hello
+                    prop2:
+                      type: 
+                        - string
+                      examples: 
+                        - world
+                propObjectNonExplodable:
+                  type: 
+                    - object
+                  properties:
+                    prop3:
+                      type: 
+                        - string
+                      examples: 
+                        - hello
+                    prop4:
+                      type: 
+                        - string
+                      examples: 
+                        - world
+                propArray:
+                  type: 
+                    - array
+                  items:
+                    type: 
+                      - string
+                    examples: 
+                      - exampleString
+                  examples:
+                    - - str1
+                      - str2
+                propSimple:
+                  type: 
+                    - integer
+                  examples: 
+                    - 123
+                propDeepObject:
+                  type: 
+                    - object
+                  properties:
+                    id:
+                      type: 
+                        - integer
+                      examples: 
+                        - 123
+                    name:
+                      type: 
+                        - string
+                      examples: 
+                        - John Johanson
+                    address:
+                      type: 
+                        - object
+                      properties:
+                        city:
+                          type: 
+                            - string
+                          examples: 
+                            - Delhi
+                        country:
+                          type: 
+                            - string
+                          examples: 
+                            - India
+                propArrayComplex:
+                  type: 
+                    - array
+                  items:
+                    type: 
+                      - object
+                    properties:
+                      prop1ArrayComp:
+                        type: 
+                          - integer
+                      prop2ArrayComp:
+                        type: 
+                          - string
+                propMissingInReq:
+                  type: 
+                    - integer
+                  description: This property is not available in matched collection.
+                  examples: 
+                    - 321
+              required:
+              - propMissingInReq
+            encoding:
+              propObjectExplodable:
+                style: form
+                explode: true
+              propObjectNonExplodable:
+                style: form
+                explode: false
+              propDeepObject:
+                style: deepObject
+                explode: true
+              propArrayComplex:
+                style: deepObject
+                explode: true
+      responses:
+        '200':
+          description: Pet updated.

--- a/test/data/31CollectionTransactions/validateOptions/detailedBlobValidationCollection.json
+++ b/test/data/31CollectionTransactions/validateOptions/detailedBlobValidationCollection.json
@@ -1,0 +1,85 @@
+{
+	"info": {
+		"_postman_id": "7a1d1b7f-f6c3-4ce1-8c1f-1e93fc4a470d",
+		"name": "lets see",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"id": "req",
+			"name": "Sample endpoint: Returns details about a particular user",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl}}/user?id=1",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"user"
+					],
+					"query": [
+						{
+							"key": "id",
+							"value": "1",
+							"description": "(Required) ID of the user"
+						}
+					]
+				},
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"data\": [\n        {\n            \"entityId\": \"5e5792b234d88e12b8511b92\",\n            \"accountNumber\": \"1YNykgIi3T2NDeElON0IqcPOpPI\",\n            \"entityName\": \"Farmer Freddy's Veg\",\n            \"entityPhone\": \"+4420832132132\",\n            \"incType\": \"sole\",\n            \"companyNumber\": 10000,\n            \"needThisNot\": \"hello\",\n            \"website\": \"https://farmer-freddy.null\",\n            \"turnover\": 10000,\n            \"description\": \"def\",\n            \"status\": \"tradingAccepted\",\n           \"wants\": [\n                \"carpentry\",\n                \"beer\",\n            \"beer\"\n            ],\n            \"isFavorite\": true\n        }\n    ],\n    \"meta\": {\n        \"notNeeded\": 1,\n        \"numberOfResults\": 1,\n        \"totalPages\": 1\n    }\n}"
+				}
+			},
+			"response": [
+				{
+					"id": "res",
+					"name": "OK",
+					"originalRequest": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/user?id=1",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"user"
+							],
+							"query": [
+								{
+									"key": "id",
+									"value": "1"
+								}
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [],
+					"cookie": [],
+					"body": "{\n    \"data\": [\n        {\n            \"entityId\": \"5e5792b234d88e12b8511b92\",\n            \"accountNumber\": \"1YNykgIi3T2NDeElON0IqcPOpPI\",\n            \"entityName\": \"Farmer Freddy's Veg\",\n            \"entityPhone\": \"+4420832132132\",\n            \"incType\": \"sole\",\n            \"companyNumber\": \"none\",\n            \"website\": \"https://farmer-freddy.null\",\n            \"turnover\": 10000,\n            \"description\": \"High quality carpentry at a reasonable price.\",\n            \"status\": \"wrongEnum\",\n            \"offers\": [\n                \"organic-vegetables\",\n                \"organic-fruits\"\n            ],\n            \"wants\": [\n                \"carpentry\",\n                \"beer\"\n            ],\n            \"isFavorite\": true\n        }\n    ],\n    \"meta\": {\n        \"numberOfResults\": 1,\n        \"totalPages\": 1\n    }\n}"
+				}
+			]
+		}
+	],
+	"variable": [
+		{
+			"id": "baseUrl",
+			"key": "baseUrl",
+			"value": "http://localhost:3000",
+			"type": "string"
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/test/data/31CollectionTransactions/validateOptions/detailedBlobValidationSpec.yaml
+++ b/test/data/31CollectionTransactions/validateOptions/detailedBlobValidationSpec.yaml
@@ -1,0 +1,121 @@
+openapi: 3.1.0
+info:
+  version: 1
+  title: IMPORT-202
+servers:
+  - url: 'http://localhost:3000'
+paths:
+  /user:
+    post:
+      summary: 'Sample endpoint: Returns details about a particular user'
+      operationId: listUser
+      tags:
+        - user
+      parameters:
+        - name: id
+          in: query
+          description: ID of the user
+          required: true
+          schema:
+            type: 
+              - integer
+            format: int32
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: 
+                - object
+              properties:
+                data:
+                  type: 
+                    - array
+                  items:
+                    $ref: '#/components/schemas/Entity'
+                meta:
+                  type: 
+                    - object
+                  maxProperties: 1
+                  additionalProperties: false
+                  properties:
+                    numberOfResults:
+                      type: 
+                        - number
+                      format: int32
+                    totalPages:
+                      type: 
+                        - number
+                      format: int32
+      responses:
+        200:
+          description: OK
+components:
+  schemas:
+    Entity:
+      type: 
+        - object
+      title: Entity
+      description: A single and unique entity linked to a user
+      minProperties: 50
+      required: [entityId, needThis]
+      dependencies:
+        id: [needThis, accountNumber]
+      properties:
+        entityId:
+          type: 
+            - string
+          maxLength: 5
+        accountNumber:
+          type: 
+            - string
+          minLength: 50
+        entityName:
+          type: 
+            - string
+          format: ipv4
+        entityPhone:
+          type: 
+            - string
+        incType:
+          type: 
+            - string
+          enum: ['Postman']
+        companyNumber:
+          type: 
+            - number
+          exclusiveMinimum: 10000
+        website:
+          type: 
+            - number
+        turnover:
+          type: 
+            - integer
+          format: int32
+          multipleOf: 7
+        description:
+          type: 
+            - string
+          pattern: '[abc]+'
+        status:
+          type: 
+            - string
+          enum:
+            - pending
+            - accepted
+            - rejected
+            - tradingPending
+            - tradingAccepted
+            - tradingRejected
+        wants:
+          type: 
+            - array
+          uniqueItems: true
+          items:
+            type: 
+              - string
+        isFavorite:
+          type: 
+            - boolean
+        needThis:
+          type: 
+            - string

--- a/test/data/31CollectionTransactions/validateOptions/ignoreUnresolvedVariablesCollection.json
+++ b/test/data/31CollectionTransactions/validateOptions/ignoreUnresolvedVariablesCollection.json
@@ -1,0 +1,134 @@
+{
+  "item": [
+    {
+      "id": "e3b75312-ce49-45b5-987f-03af612be2eb",
+      "name": "pets",
+      "description": {
+        "content": "",
+        "type": "text/plain"
+      },
+      "item": [
+        {
+          "id": "8145304c-1a14-4332-97c6-02f5b536c79b",
+          "name": "Info for a specific pet",
+          "request": {
+            "name": "Info for a specific pet",
+            "description": {},
+            "url": {
+              "path": [
+                "pets",
+                ":samplePathVar"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [
+                {
+                  "description": "(Required) The id of the pet to retrieve",
+                  "key": "sampleQueryParam",
+                  "value": "{{sampleQueryParamCollectionVar}}"
+                }
+              ],
+              "variable": [
+                {
+                  "description": "(Required) The id of the pet to retrieve",
+                  "type": "any",
+                  "value": "{{petIdCollectionVar}}",
+                  "key": "samplePathVar"
+                }
+              ]
+            },
+            "header": [
+              {
+                "description": "(Required) The id of the pet to retrieve",
+                "key": "sampleHeader",
+                "value": "{{sampleHeaderCollectionVar}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "auth": null,
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"petId\": \"{{petIdVar}}\",\n    \"name\": \"{{nameVar}}\",\n    \"tag\": \"{{tagVar}}\"\n}"
+            }
+          },
+          "response": [
+            {
+              "id": "483c6f74-c8aa-41d3-986f-407195d9ea5d",
+              "name": "unexpected error",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "pets",
+                    ":samplePathVar"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "sampleQueryParam",
+                      "value": "{{sampleQueryParamCollectionVar}}"
+                    }
+                  ],
+                  "variable": [
+                    {
+                      "type": "any",
+                      "key": "samplePathVar"
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": "(Required) The id of the pet to retrieve",
+                    "key": "sampleHeader",
+                    "value": "{{sampleHeaderCollectionVar}}"
+                  }
+                ],
+                "method": "POST",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"petId\": \"{{petIdVar}}\",\n    \"name\": \"{{nameVar}}\",\n    \"tag\": \"{{tagVar}}\"\n}"
+                }
+              },
+              "status": "Internal Server Error",
+              "code": 500,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n \"code\": \"{{codeVar}}\",\n \"message\": \"{{messageVar}}\"\n}",
+              "cookie": [],
+              "_postman_previewlanguage": "json"
+            }
+          ],
+          "event": []
+        }
+      ],
+      "event": []
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "id": "baseUrl",
+      "type": "string",
+      "value": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "info": {
+    "_postman_id": "2bba452f-eac2-43bf-b5b5-b813cfa76e43",
+    "name": "Ignore unresolved pm variables",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "",
+      "type": "text/plain"
+    }
+  }
+}

--- a/test/data/31CollectionTransactions/validateOptions/ignoreUnresolvedVariablesSpec.yaml
+++ b/test/data/31CollectionTransactions/validateOptions/ignoreUnresolvedVariablesSpec.yaml
@@ -1,0 +1,86 @@
+openapi: "3.1.0"
+info:
+  version: 1.0.0
+  title: 
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets/{samplePathVar}:
+    post:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: samplePathVar
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: 
+              - integer
+          example: '{{petIdCollectionVar}}'
+        - name: sampleQueryParam
+          in: query
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: 
+              - number
+          example: '{{sampleQueryParamCollectionVar}}'
+        - name: sampleHeader
+          in: header
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: 
+              - boolean
+          example: '{{sampleHeaderCollectionVar}}'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: 
+        - object
+      properties:
+        petId:
+          type: 
+            - integer
+          format: int64
+        name:
+          type: 
+            - string
+        tag:
+          type: 
+            - string
+      examples:
+        - petId: '{{petIdVar}}'
+          name: '{{nameVar}}'
+          tag: '{{tagVar}}'
+    Error:
+      type: 
+        - object
+      properties:
+        code:
+          type: 
+            - integer
+          format: int32
+        message:
+          type: 
+            - string
+      examples:
+        - code: '{{codeVar}}'
+          message: '{{messageVar}}'

--- a/test/data/31CollectionTransactions/validateOptions/strictRequestMatchingCollection.json
+++ b/test/data/31CollectionTransactions/validateOptions/strictRequestMatchingCollection.json
@@ -1,0 +1,145 @@
+{
+  "item": [
+    {
+      "id": "1e465050-08f3-47a0-8a7e-6fb35546a212",
+      "name": "/users/admin/:userId",
+      "request": {
+        "name": "/users/admin/:userId",
+        "description": "/users/admin/{userId}",
+        "url": {
+          "path": [
+            "users",
+            "admin",
+            ":userId"
+          ],
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "query": [],
+          "variable": [
+            {
+              "description": "(Required) ",
+              "type": "any",
+              "value": "12345",
+              "key": "userId"
+            }
+          ]
+        },
+        "method": "GET",
+        "auth": null
+      },
+      "response": [
+        {
+          "id": "097e701a-e964-43d9-bb37-ccbe747d3a7b",
+          "name": "/users/admin/{userId}",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "users",
+                "admin",
+                ":userId"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "type": "any",
+                  "key": "userId"
+                }
+              ]
+            },
+            "method": "GET",
+            "body": {}
+          },
+          "status": "OK",
+          "code": 200,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "body": "{\n \"id\": 2678975,\n \"name\": \"cillum minim aliqua\"\n}",
+          "cookie": [],
+          "_postman_previewlanguage": "json"
+        }
+      ],
+      "event": []
+    },
+    {
+      "id": "a7645f69-07a1-4d8b-97b4-575fd09c686c",
+      "name": "/users/admin/profile",
+      "request": {
+        "name": "/users/admin/profile",
+        "description": "/users/admin/profile",
+        "url": {
+          "path": [
+            "users",
+            "admin",
+            "profile"
+          ],
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "query": [],
+          "variable": []
+        },
+        "method": "GET",
+        "auth": null
+      },
+      "response": [
+        {
+          "id": "e485cfd8-b63d-46cd-b305-606d7b900ce1",
+          "name": "/users/admin/profile",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "users",
+                "admin",
+                "profile"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "body": {}
+          },
+          "status": "OK",
+          "code": 200,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "body": "{\n \"id\": 2678975,\n \"name\": \"cillum minim aliqua\"\n}",
+          "cookie": [],
+          "_postman_previewlanguage": "json"
+        }
+      ],
+      "event": []
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "id": "baseUrl",
+      "type": "string",
+      "value": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "info": {
+    "_postman_id": "81a0590b-0dfb-4ab8-8b6c-ea8e23b554bc",
+    "name": "Validation Option tests",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "",
+      "type": "text/plain"
+    }
+  }
+}

--- a/test/data/31CollectionTransactions/validateOptions/strictRequestMatchingSpec.yaml
+++ b/test/data/31CollectionTransactions/validateOptions/strictRequestMatchingSpec.yaml
@@ -1,0 +1,80 @@
+openapi: "3.1.0"
+info:
+  version: 1.0.0
+  title: Validation Option tests
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /users/admin/{userId}:
+    get:
+      description: /users/admin/{userId}
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: 
+              - string
+      responses:
+        '200':
+          description: /users/admin/{userId}
+          content:
+            application/json:
+              schema:
+                type: 
+                  - object
+                properties:
+                  id:
+                    type: 
+                      - integer
+                    format: int64
+                  name:
+                    type: 
+                      - string
+  /users/admin/profile:
+    get:
+      description: /users/admin/{userId}
+      responses:
+        '200':
+          description: /users/admin/profile
+          content:
+            application/json:
+              schema:
+                type: 
+                  - object
+                properties:
+                  id:
+                    type: 
+                      - integer
+                    format: int64
+                  name:
+                    type: 
+                      - string
+  /admin/{adminId}:
+    get:
+      description: /admin/{adminId}
+      parameters:
+        - name: adminId
+          in: path
+          required: true
+          schema:
+            type: 
+              - string
+      responses:
+        '200':
+          description: /admin/{adminId}
+          content:
+            application/json:
+              schema:
+                type: 
+                  - object
+                properties:
+                  id:
+                    type: 
+                      - integer
+                    format: int64
+                  name:
+                    type: 
+                      - string

--- a/test/data/31CollectionTransactions/validateOptions/suggestAvailableFixesCollection.json
+++ b/test/data/31CollectionTransactions/validateOptions/suggestAvailableFixesCollection.json
@@ -1,0 +1,133 @@
+{
+  "item": [
+    {
+      "id": "24c0a942-d439-45ca-84f7-7728b449169c",
+      "name": "pets",
+      "description": {
+        "content": "",
+        "type": "text/plain"
+      },
+      "item": [
+        {
+          "id": "e96f3f5b-f8d3-4548-b514-8fa1e937bbd3",
+          "name": "Info for a specific pet",
+          "request": {
+            "name": "Info for a specific pet",
+            "description": {},
+            "url": {
+              "path": [
+                "pets",
+                ":petId"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [
+                {
+                  "description": "(Required) ",
+                  "key": "limit",
+                  "value": "Not a Number"
+                }
+              ],
+              "variable": [
+                {
+                  "description": "(Required) The id of the pet to retrieve",
+                  "type": "any",
+                  "value": "Not an Integer",
+                  "key": "petId"
+                }
+              ]
+            },
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "auth": null,
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"petId\": 8,\n    \"name\": \"My name is less than 30 chars\",\n    \"tag\": true,\n    \"breeds\": [\"Bulldog\", \"Timberwolf\", \"GrizzlyBear\"]\n}"
+            }
+          },
+          "response": [
+            {
+              "id": "eeeb3cf9-e830-4514-a1a0-4af90feda7b1",
+              "name": "unexpected error",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "pets",
+                    ":petId"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "limit",
+                      "value": "Not a Number"
+                    }
+                  ],
+                  "variable": [
+                    {
+                      "type": "any",
+                      "key": "petId"
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "description": "(Required) ",
+                    "key": "pet-quantity",
+                    "value": "Not a Boolean"
+                  }
+                ],
+                "method": "POST",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"petId\": 8,\n    \"name\": \"My name is less than 30 chars\",\n    \"tag\": true,\n    \"breeds\": [\"Bulldog\", \"Timberwolf\", \"GrizzlyBear\"]\n}"
+                }
+              },
+              "status": "Internal Server Error",
+              "code": 500,
+              "header": [
+                {
+                  "description": "The number of allowed requests in the current period",
+                  "key": "X-Rate-Limit-Limit",
+                  "value": "<string>"
+                },
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n \"code\": \"{{codeVar}}\",\n \"message\": 123.456\n}",
+              "cookie": [],
+              "_postman_previewlanguage": "json"
+            }
+          ],
+          "event": []
+        }
+      ],
+      "event": []
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "id": "baseUrl",
+      "type": "string",
+      "value": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "info": {
+    "_postman_id": "648dcfad-2423-4619-a3ad-48ec88de11a9",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "",
+      "type": "text/plain"
+    }
+  }
+}

--- a/test/data/31CollectionTransactions/validateOptions/suggestAvailableFixesSpec.yaml
+++ b/test/data/31CollectionTransactions/validateOptions/suggestAvailableFixesSpec.yaml
@@ -1,0 +1,108 @@
+openapi: "3.1.0"
+info:
+  version: 1.0.0
+  title: 
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets/{petId}:
+    post:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: 
+              - integer
+            examples: 
+              - 'Not an Integer'
+        - name: limit
+          in: query
+          required: true
+          schema:
+            type: 
+              - number
+            examples: 
+              - 'Not a Number'
+        - name: pet-quantity
+          in: header
+          description: Quantity of pets available
+          required: true
+          schema:
+            type: 
+              - boolean
+            examples: 
+              - 'Not a Boolean'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        default:
+          description: unexpected error
+          headers:
+            X-Rate-Limit-Limit:
+              description: The number of allowed requests in the current period
+              schema:
+                type: 
+                  - integer
+                examples: 
+                  - '<string>'
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: 
+        - object
+      required:
+      - petId
+      - name
+      - tag
+      - breeds
+      properties:
+        petId:
+          type: 
+            - integer
+          format: int64
+        name:
+          type: 
+            - string
+          minLength: 30
+        tag:
+          type: 
+            - string
+        breeds:
+          type: 
+            - array
+          minItems: 3
+          maxItems: 3
+          items:
+            type: 
+              - string
+            enum: ["Bulldog", "Retriever", "Timberwolf", "Grizzly", "Husky"]
+    Error:
+      type: 
+        - object
+      properties:
+        code:
+          type: 
+            - integer
+          format: int32
+          multipleOf: 7
+        message:
+          type: 
+            - string
+      examples:
+        - code: '{{codeVar}}'
+          message: 123.456

--- a/test/data/31CollectionTransactions/validateOptions/validateMetadataCollection.json
+++ b/test/data/31CollectionTransactions/validateOptions/validateMetadataCollection.json
@@ -1,0 +1,149 @@
+{
+  "item": [
+    {
+      "id": "4e91e114-35be-4165-b6a2-760921ad7a59",
+      "name": "pets",
+      "description": {
+        "content": "",
+        "type": "text/plain"
+      },
+      "item": [
+        {
+          "id": "73046eed-2976-4767-8c58-c7890370d7d7",
+          "name": "List all pets",
+          "request": {
+            "name": "List all pets",
+            "description": "Wrong description",
+            "url": {
+              "path": [
+                "pets"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [
+                {
+                  "description": "How many items to return at one time (max 100)",
+                  "key": "limit",
+                  "value": "-99451457"
+                }
+              ],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "46e62ee6-8603-419f-938e-d111db7dc8be",
+              "name": "unexpected error",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "pets"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "limit",
+                      "value": "<integer>"
+                    }
+                  ],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "Internal Server Error",
+              "code": 500,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "de9fd791-43d2-4251-8e00-8349ee2e2c79",
+          "name": "Create a pet",
+          "request": {
+            "description": {
+              "content": null,
+              "type": "text/plain"
+            },
+            "url": {
+              "path": [
+                "pets"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "1cf53180-3534-4ab2-9f73-34a3176941df",
+              "name": "Null response",
+              "originalRequest": {
+                "url": {
+                  "path": [
+                    "pets"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {}
+              },
+              "status": "Created",
+              "code": 201,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        }
+      ],
+      "event": []
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "id": "baseUrl",
+      "type": "string",
+      "value": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "info": {
+    "_postman_id": "25a51c10-79ed-45fa-a82d-11b4fa79b9b1",
+    "name": "Swagger Petstore",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "",
+      "type": "text/plain"
+    }
+  }
+}

--- a/test/data/31CollectionTransactions/validateOptions/validateMetadataSpec.yaml
+++ b/test/data/31CollectionTransactions/validateOptions/validateMetadataSpec.yaml
@@ -1,0 +1,37 @@
+openapi: "3.1.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets Updated
+      description: Description for GET /pets - List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: 
+              - integer
+            format: int32
+      responses:
+        default:
+          description: unexpected error
+    post:
+      summary: Create a pet
+      description: Description for POST /pets - Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response

--- a/test/unit/validator.test.js
+++ b/test/unit/validator.test.js
@@ -6,6 +6,8 @@ var expect = require('chai').expect,
   _ = require('lodash'),
   schemaUtils = require('../../lib/schemaUtils'),
   VALIDATION_DATA_FOLDER_PATH = '../data/validationData',
+  VALIDATION_DATA_OPTIONS_FOLDER_31_PATH = '../data/31CollectionTransactions/validateOptions',
+  VALIDATION_DATA_SCENARIOS_FOLDER_31_PATH = '../data/31CollectionTransactions/validate30Scenarios',
   VALID_OPENAPI_FOLDER_PATH = '../data/valid_openapi';
 
 /**
@@ -27,6 +29,38 @@ function getAllTransactions (collection, allRequests) {
       getAllTransactions(item, allRequests);
     }
   });
+}
+
+/**
+ * Gets an array of objects with the specification file path and the version
+ * @param {array} foldersByVersion An array with the path of the folders that contain the validation test files
+ * @param {*} fileName the name of the file (all scenarios must be in both folders)
+ * @returns {array} An array with objects that contains the version and the specification file path
+ */
+function getSpecsPathByVersion(foldersByVersion, fileName) {
+  return foldersByVersion.map((folderData) => {
+    return {
+      path: path.join(__dirname, folderData.path + fileName),
+      version: folderData.version
+    };
+  });
+}
+
+/**
+ * Returns an array with objects with the version and the folder where the files are
+ * @param {string} folder30Path the path of the 3.0 spec validation files folder
+ * @param {*} folder31Path the path of the 3.1 spec validation files folder
+ * @returns {array} An array with objects that contain the version and the corresponding files folder
+ */
+function getFoldersByVersion(folder30Path, folder31Path) {
+  return [{
+    version: '3.0',
+    path: folder30Path
+  },
+  {
+    version: '3.1',
+    path: folder31Path
+  }];
 }
 
 describe('The validator must validate generated collection from schema against schema itself', function () {
@@ -123,72 +157,83 @@ describe('The validator must validate generated collection from schema against s
 });
 
 describe('The Validation option', function () {
-  var strictRequestMatchingSpec = path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-      '/strictRequestMatchingSpec.yaml'),
+  const strictRequestMatchingSpecs = getSpecsPathByVersion(
+      getFoldersByVersion(VALIDATION_DATA_FOLDER_PATH, VALIDATION_DATA_OPTIONS_FOLDER_31_PATH),
+      '/strictRequestMatchingSpec.yaml'
+    ),
     strictRequestMatchingCollection = path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
       '/strictRequestMatchingCollection.json'),
-    ignoreUnresolvedVariablesSpec = path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
+    ignoreUnresolvedVariablesSpecs = getSpecsPathByVersion(
+      getFoldersByVersion(VALIDATION_DATA_FOLDER_PATH, VALIDATION_DATA_OPTIONS_FOLDER_31_PATH),
       '/ignoreUnresolvedVariablesSpec.yaml'),
     ignoreUnresolvedVariablesCollection = path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
       '/ignoreUnresolvedVariablesCollection.json'),
-    validateMetadataSpec = path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
+    validateMetadataSpecs = getSpecsPathByVersion(
+      getFoldersByVersion(VALIDATION_DATA_FOLDER_PATH, VALIDATION_DATA_OPTIONS_FOLDER_31_PATH),
       '/validateMetadataSpec.yaml'),
     validateMetadataCollection = path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
       '/validateMetadataCollection.json'),
-    suggestAvailableFixesSpec = path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
+    suggestAvailableFixesSpecs = getSpecsPathByVersion(
+      getFoldersByVersion(VALIDATION_DATA_FOLDER_PATH, VALIDATION_DATA_OPTIONS_FOLDER_31_PATH),
       '/suggestAvailableFixesSpec.yaml'),
     suggestAvailableFixesCollection = path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
       '/suggestAvailableFixesCollection.json'),
-    detailedBlobValidationSpec = path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
+    detailedBlobValidationSpecs = getSpecsPathByVersion(
+      getFoldersByVersion(VALIDATION_DATA_FOLDER_PATH, VALIDATION_DATA_OPTIONS_FOLDER_31_PATH),
       '/detailedBlobValidationSpec.yaml'),
     detailedBlobValidationCollection = path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
       '/detailedBlobValidationCollection.json');
 
   describe('strictRequestMatching ', function () {
-    it('should strictly match collection request with corresponding schema endpoint/s', function (done) {
-      var schema = fs.readFileSync(strictRequestMatchingSpec, 'utf8'),
-        collection = fs.readFileSync(strictRequestMatchingCollection, 'utf8'),
-        schemaPack = new Converter.SchemaPack({ type: 'string', data: schema },
-          { strictRequestMatching: true }),
-        historyRequest = [];
 
-      getAllTransactions(JSON.parse(collection), historyRequest);
-      schemaPack.validateTransaction(historyRequest, (err, result) => {
-        expect(err).to.be.null;
+    strictRequestMatchingSpecs.forEach((specData) => {
+      it('should strictly match collection request with corresponding schema endpoint/s - version: ' +
+        specData.version, function (done) {
+        const schema = fs.readFileSync(specData.path, 'utf8'),
+          collection = fs.readFileSync(strictRequestMatchingCollection, 'utf8'),
+          schemaPack = new Converter.SchemaPack({ type: 'string', data: schema },
+            { strictRequestMatching: true }),
+          historyRequest = [];
 
-        /**
-         Collection request contains
-          - GET /users/admin/:userId (userId = 12345)
-          - GET /users/admin/profile
+        getAllTransactions(JSON.parse(collection), historyRequest);
+        schemaPack.validateTransaction(historyRequest, (err, result) => {
+          expect(err).to.be.null;
 
-         Schema Endpoints contains
-          - GET /users/admin/profile
-          - GET /users/admin/{userId}
-          - GET /admin/{adminId}
+          /**
+           Collection request contains
+            - GET /users/admin/:userId (userId = 12345)
+            - GET /users/admin/profile
 
-        For strictRequestMatching = false, both collection request matches with all 3 endpoints from schema,
-          and no endpoint will be present in missingEndpoints
-        For strictRequestMatching = true, we have matches as following
-        */
-        // for endpoint "/users/admin/:userId" we should only one match with "/users/admin/{userId}"
-        expect(result.requests[historyRequest[0].id].endpoints).to.have.lengthOf(1);
+          Schema Endpoints contains
+            - GET /users/admin/profile
+            - GET /users/admin/{userId}
+            - GET /admin/{adminId}
 
-        // for endpoint "/users/admin/profile" we should have two matches first match with "/users/admin/profile"
-        // and second with "/users/admin/{userId}" as first match has more fixed matched segments
-        expect(result.requests[historyRequest[1].id].endpoints).to.have.lengthOf(2);
+          For strictRequestMatching = false, both collection request matches with all 3 endpoints from schema,
+            and no endpoint will be present in missingEndpoints
+          For strictRequestMatching = true, we have matches as following
+          */
+          // for endpoint "/users/admin/:userId" we should only one match with "/users/admin/{userId}"
+          expect(result.requests[historyRequest[0].id].endpoints).to.have.lengthOf(1);
 
-        // endpoint "/admin/{adminId}"" should be present as missing endpoint
-        expect(result.missingEndpoints).to.have.lengthOf(1);
-        expect(result.missingEndpoints[0].endpoint).to.eql('GET /admin/{adminId}');
-        done();
+          // for endpoint "/users/admin/profile" we should have two matches first match with "/users/admin/profile"
+          // and second with "/users/admin/{userId}" as first match has more fixed matched segments
+          expect(result.requests[historyRequest[1].id].endpoints).to.have.lengthOf(2);
+
+          // endpoint "/admin/{adminId}"" should be present as missing endpoint
+          expect(result.missingEndpoints).to.have.lengthOf(1);
+          expect(result.missingEndpoints[0].endpoint).to.eql('GET /admin/{adminId}');
+          done();
+        });
       });
     });
   });
 
   describe('ignoreUnresolvedVariables ', function () {
-    it('should ignore all mismatches happening due to collection/environment variables present in request',
-      function (done) {
-        var schema = fs.readFileSync(ignoreUnresolvedVariablesSpec, 'utf8'),
+    ignoreUnresolvedVariablesSpecs.forEach((specData) => {
+      it('should ignore all mismatches happening due to collection/environment variables present in request ' +
+        '- version: ' + specData.version, function (done) {
+        var schema = fs.readFileSync(specData.path, 'utf8'),
           collection = fs.readFileSync(ignoreUnresolvedVariablesCollection, 'utf8'),
           schemaPack = new Converter.SchemaPack({ type: 'string', data: schema },
             { ignoreUnresolvedVariables: true }),
@@ -215,157 +260,169 @@ describe('The Validation option', function () {
           done();
         });
       });
+    });
   });
 
   describe('validateMetadata ', function () {
-    var schema = fs.readFileSync(validateMetadataSpec, 'utf8'),
-      collection = fs.readFileSync(validateMetadataCollection, 'utf8'),
-      schemaPack = new Converter.SchemaPack({ type: 'string', data: schema },
-        { validateMetadata: true, suggestAvailableFixes: true }),
-      historyRequest = [],
-      resultObj1,
-      resultObj2;
+    validateMetadataSpecs.forEach((specData) => {
+      let schema = fs.readFileSync(specData.path, 'utf8'),
+        collection = fs.readFileSync(validateMetadataCollection, 'utf8'),
+        schemaPack = new Converter.SchemaPack({ type: 'string', data: schema },
+          { validateMetadata: true, suggestAvailableFixes: true }),
+        historyRequest = [],
+        resultObj1,
+        resultObj2;
 
-    before(function (done) {
-      getAllTransactions(JSON.parse(collection), historyRequest);
-      schemaPack.validateTransaction(historyRequest, (err, result) => {
-        expect(err).to.be.null;
-        resultObj1 = result.requests[historyRequest[0].id].endpoints[0];
-        resultObj2 = result.requests[historyRequest[1].id].endpoints[0];
-        done();
+      before(function (done) {
+        getAllTransactions(JSON.parse(collection), historyRequest);
+        schemaPack.validateTransaction(historyRequest, (err, result) => {
+          expect(err).to.be.null;
+          resultObj1 = result.requests[historyRequest[0].id].endpoints[0];
+          resultObj2 = result.requests[historyRequest[1].id].endpoints[0];
+          done();
+        });
       });
-    });
 
-    it('should validate request name and description according to schema', function () {
-      expect(resultObj1.mismatches).to.have.lengthOf(2);
-      _.forEach(resultObj1.mismatches, (mismatch) => {
-        // check for suggested value to be one in schema
-        if (mismatch.property === 'REQUEST_NAME') {
-          expect(mismatch.reasonCode).to.eql('INVALID_VALUE');
-          expect(mismatch.reason).to.eql('The request name didn\'t match with specified schema');
-          expect(mismatch.suggestedFix.suggestedValue).to.eql('List all pets Updated');
-        }
-        else if (mismatch.property === 'REQUEST_DESCRIPTION') {
-          expect(mismatch.reasonCode).to.eql('INVALID_VALUE');
-          expect(mismatch.reason).to.eql('The request description didn\'t match with specified schema');
-          expect(mismatch.suggestedFix.suggestedValue).to.eql('Description for GET /pets - List all pets');
-        }
-        else {
-          throw Error('Unhandled mismatch property in test');
-        }
+      it('should validate request name and description according to schema - version: ' +
+        specData.version, function () {
+        expect(resultObj1.mismatches).to.have.lengthOf(2);
+        _.forEach(resultObj1.mismatches, (mismatch) => {
+          // check for suggested value to be one in schema
+          if (mismatch.property === 'REQUEST_NAME') {
+            expect(mismatch.reasonCode).to.eql('INVALID_VALUE');
+            expect(mismatch.reason).to.eql('The request name didn\'t match with specified schema');
+            expect(mismatch.suggestedFix.suggestedValue).to.eql('List all pets Updated');
+          }
+          else if (mismatch.property === 'REQUEST_DESCRIPTION') {
+            expect(mismatch.reasonCode).to.eql('INVALID_VALUE');
+            expect(mismatch.reason).to.eql('The request description didn\'t match with specified schema');
+            expect(mismatch.suggestedFix.suggestedValue).to.eql('Description for GET /pets - List all pets');
+          }
+          else {
+            throw Error('Unhandled mismatch property in test');
+          }
+        });
       });
-    });
 
-    it('should handle empty and null request name and description in request', function () {
-      expect(resultObj2.mismatches).to.have.lengthOf(1);
-      expect(resultObj2.mismatches[0].property).to.eql('REQUEST_DESCRIPTION');
-      expect(resultObj2.mismatches[0].reasonCode).to.eql('INVALID_VALUE');
-      expect(resultObj2.mismatches[0].reason).to.eql('The request description didn\'t match with specified schema');
-      expect(resultObj2.mismatches[0].suggestedFix.actualValue).to.be.null;
-      expect(resultObj2.mismatches[0].suggestedFix.suggestedValue)
-        .to.eql('Description for POST /pets - Create a pet');
+      it('should handle empty and null request name and description in request - version: ' +
+        specData.version, function () {
+        expect(resultObj2.mismatches).to.have.lengthOf(1);
+        expect(resultObj2.mismatches[0].property).to.eql('REQUEST_DESCRIPTION');
+        expect(resultObj2.mismatches[0].reasonCode).to.eql('INVALID_VALUE');
+        expect(resultObj2.mismatches[0].reason).to.eql('The request description didn\'t match with specified schema');
+        expect(resultObj2.mismatches[0].suggestedFix.actualValue).to.be.null;
+        expect(resultObj2.mismatches[0].suggestedFix.suggestedValue)
+          .to.eql('Description for POST /pets - Create a pet');
+      });
     });
   });
 
   describe('suggestAvailableFixes ', function () {
-    var schema = fs.readFileSync(suggestAvailableFixesSpec, 'utf8'),
-      collection = fs.readFileSync(suggestAvailableFixesCollection, 'utf8'),
-      schemaPack = new Converter.SchemaPack({ type: 'string', data: schema },
-        { suggestAvailableFixes: true }),
-      historyRequest = [],
-      resultObj,
-      responseResult,
-      propertyMismatchMap = {};
+    suggestAvailableFixesSpecs.forEach((specData) => {
+      let schema = fs.readFileSync(specData.path, 'utf8'),
+        collection = fs.readFileSync(suggestAvailableFixesCollection, 'utf8'),
+        schemaPack = new Converter.SchemaPack({ type: 'string', data: schema },
+          { suggestAvailableFixes: true }),
+        historyRequest = [],
+        resultObj,
+        responseResult,
+        propertyMismatchMap = {};
 
-    before(function (done) {
-      getAllTransactions(JSON.parse(collection), historyRequest);
-      schemaPack.validateTransaction(historyRequest, (err, result) => {
-        expect(err).to.be.null;
-        resultObj = result.requests[historyRequest[0].id].endpoints[0];
-        responseResult = resultObj.responses[historyRequest[0].response[0].id];
+      before(function (done) {
+        getAllTransactions(JSON.parse(collection), historyRequest);
+        schemaPack.validateTransaction(historyRequest, (err, result) => {
+          expect(err).to.be.null;
+          resultObj = result.requests[historyRequest[0].id].endpoints[0];
+          responseResult = resultObj.responses[historyRequest[0].response[0].id];
 
-        // check for expected mismatches length
-        expect(resultObj.mismatches).to.have.lengthOf(4);
-        expect(responseResult.mismatches).to.have.lengthOf(2);
+          // check for expected mismatches length
+          expect(resultObj.mismatches).to.have.lengthOf(4);
+          expect(responseResult.mismatches).to.have.lengthOf(2);
 
-        // map all mismatch objects with it's property
-        _.forEach(_.concat(resultObj.mismatches, responseResult.mismatches), (mismatch) => {
-          propertyMismatchMap[mismatch.property] = mismatch;
+          // map all mismatch objects with it's property
+          _.forEach(_.concat(resultObj.mismatches, responseResult.mismatches), (mismatch) => {
+            propertyMismatchMap[mismatch.property] = mismatch;
+          });
+          done();
         });
-        done();
       });
-    });
 
-    it('should suggest valid available fix for all kind of violated properties', function () {
-      // check for all suggested value to be according to schema
-      expect(_.isInteger(propertyMismatchMap.PATHVARIABLE.suggestedFix.suggestedValue)).to.eql(true);
-      expect(propertyMismatchMap.QUERYPARAM.suggestedFix.suggestedValue).to.be.a('number');
-      expect(propertyMismatchMap.HEADER.suggestedFix.suggestedValue.value).to.be.a('boolean');
-      expect(propertyMismatchMap.HEADER.suggestedFix.suggestedValue.description)
-        .to.eql('(Required) Quantity of pets available');
-      expect(propertyMismatchMap.BODY.suggestedFix.suggestedValue.name).to.be.a('string');
-      expect(propertyMismatchMap.BODY.suggestedFix.suggestedValue.name.length >= 30).to.eql(true);
-      expect(propertyMismatchMap.BODY.suggestedFix.suggestedValue.tag).to.be.a('string');
-      expect(_.includes(['Bulldog', 'Retriever', 'Timberwolf', 'Grizzly', 'Husky'],
-        propertyMismatchMap.BODY.suggestedFix.suggestedValue.breeds[2])).to.eql(true);
-      expect(_.isInteger(propertyMismatchMap.RESPONSE_HEADER.suggestedFix.suggestedValue)).to.eql(true);
-      expect(_.isInteger(propertyMismatchMap.RESPONSE_BODY.suggestedFix.suggestedValue.code)).to.eql(true);
-      expect(propertyMismatchMap.RESPONSE_BODY.suggestedFix.suggestedValue.code % 7).to.equal(0);
-      expect(propertyMismatchMap.RESPONSE_BODY.suggestedFix.suggestedValue.message).to.be.a('string');
-    });
+      it('should suggest valid available fix for all kind of violated properties - version: ' +
+        specData.version, function () {
+        // check for all suggested value to be according to schema
+        expect(_.isInteger(propertyMismatchMap.PATHVARIABLE.suggestedFix.suggestedValue)).to.eql(true);
+        expect(propertyMismatchMap.QUERYPARAM.suggestedFix.suggestedValue).to.be.a('number');
+        expect(propertyMismatchMap.HEADER.suggestedFix.suggestedValue.value).to.be.a('boolean');
+        expect(propertyMismatchMap.HEADER.suggestedFix.suggestedValue.description)
+          .to.eql('(Required) Quantity of pets available');
+        expect(propertyMismatchMap.BODY.suggestedFix.suggestedValue.name).to.be.a('string');
+        expect(propertyMismatchMap.BODY.suggestedFix.suggestedValue.name.length >= 30).to.eql(true);
+        expect(propertyMismatchMap.BODY.suggestedFix.suggestedValue.tag).to.be.a('string');
+        expect(_.includes(['Bulldog', 'Retriever', 'Timberwolf', 'Grizzly', 'Husky'],
+          propertyMismatchMap.BODY.suggestedFix.suggestedValue.breeds[2])).to.eql(true);
+        expect(_.isInteger(propertyMismatchMap.RESPONSE_HEADER.suggestedFix.suggestedValue)).to.eql(true);
+        expect(_.isInteger(propertyMismatchMap.RESPONSE_BODY.suggestedFix.suggestedValue.code)).to.eql(true);
+        expect(propertyMismatchMap.RESPONSE_BODY.suggestedFix.suggestedValue.code % 7).to.equal(0);
+        expect(propertyMismatchMap.RESPONSE_BODY.suggestedFix.suggestedValue.message).to.be.a('string');
+      });
 
-    it('should maintain valid properties/items in suggested value', function () {
-      expect(propertyMismatchMap.BODY.suggestedFix.suggestedValue.petId).to.eql(
-        propertyMismatchMap.BODY.suggestedFix.actualValue.petId
-      );
-      expect(propertyMismatchMap.BODY.suggestedFix.suggestedValue.breeds[0]).to.eql(
-        propertyMismatchMap.BODY.suggestedFix.actualValue.breeds[0]
-      );
-      expect(propertyMismatchMap.BODY.suggestedFix.suggestedValue.breeds[1]).to.eql(
-        propertyMismatchMap.BODY.suggestedFix.actualValue.breeds[1]
-      );
+      it('should maintain valid properties/items in suggested value - version:' +
+        specData.version, function () {
+        expect(propertyMismatchMap.BODY.suggestedFix.suggestedValue.petId).to.eql(
+          propertyMismatchMap.BODY.suggestedFix.actualValue.petId
+        );
+        expect(propertyMismatchMap.BODY.suggestedFix.suggestedValue.breeds[0]).to.eql(
+          propertyMismatchMap.BODY.suggestedFix.actualValue.breeds[0]
+        );
+        expect(propertyMismatchMap.BODY.suggestedFix.suggestedValue.breeds[1]).to.eql(
+          propertyMismatchMap.BODY.suggestedFix.actualValue.breeds[1]
+        );
+      });
     });
   });
 
   describe('detailedBlobValidation ', function () {
-    it('should provide detailed mismatches for each schema keyword violation', function (done) {
-      var schema = fs.readFileSync(detailedBlobValidationSpec, 'utf8'),
-        collection = fs.readFileSync(detailedBlobValidationCollection, 'utf8'),
-        schemaPack = new Converter.SchemaPack({ type: 'string', data: schema },
-          { detailedBlobValidation: true }),
-        historyRequest = [],
-        resultObj,
-        violatedKeywords = [
-          'data.items.minProperties',
-          'data.items.required',
-          'data.items.properties.entityId.maxLength',
-          'data.items.properties.accountNumber.minLength',
-          'data.items.properties.entityName.format',
-          'data.items.properties.incType.enum',
-          'data.items.properties.companyNumber.exclusiveMinimum',
-          'data.items.properties.website.type',
-          'data.items.properties.turnover.multipleOf',
-          'data.items.properties.description.pattern',
-          'data.items.properties.wants.uniqueItems',
-          'meta.maxProperties',
-          'meta.additionalProperties'
-        ];
+    detailedBlobValidationSpecs.forEach((specData) => {
+      it('should provide detailed mismatches for each schema keyword violation - version:' +
+        specData.version, function (done) {
+        var schema = fs.readFileSync(specData.path, 'utf8'),
+          collection = fs.readFileSync(detailedBlobValidationCollection, 'utf8'),
+          schemaPack = new Converter.SchemaPack({ type: 'string', data: schema },
+            { detailedBlobValidation: true }),
+          historyRequest = [],
+          resultObj,
+          violatedKeywords = [
+            'data.items.minProperties',
+            'data.items.required',
+            'data.items.properties.entityId.maxLength',
+            'data.items.properties.accountNumber.minLength',
+            'data.items.properties.entityName.format',
+            'data.items.properties.incType.enum',
+            'data.items.properties.companyNumber.exclusiveMinimum',
+            'data.items.properties.website.type',
+            'data.items.properties.turnover.multipleOf',
+            'data.items.properties.description.pattern',
+            'data.items.properties.wants.uniqueItems',
+            'meta.maxProperties',
+            'meta.additionalProperties'
+          ];
 
-      getAllTransactions(JSON.parse(collection), historyRequest);
-      schemaPack.validateTransaction(historyRequest, (err, result) => {
-        expect(err).to.be.null;
-        resultObj = result.requests[historyRequest[0].id].endpoints[0];
+        getAllTransactions(JSON.parse(collection), historyRequest);
+        schemaPack.validateTransaction(historyRequest, (err, result) => {
+          expect(err).to.be.null;
+          resultObj = result.requests[historyRequest[0].id].endpoints[0];
 
-        // map all mismatch objects with it's property
-        _.forEach(resultObj.mismatches, (mismatch) => {
-          // remove starting string '$.paths[/user].post.requestBody.content[application/json].schema.properties.'
-          let localJsonPath = mismatch.schemaJsonPath.slice(76);
-          expect(_.includes(violatedKeywords, localJsonPath)).to.eql(true);
+          // map all mismatch objects with it's property
+          _.forEach(resultObj.mismatches, (mismatch) => {
+            // remove starting string '$.paths[/user].post.requestBody.content[application/json].schema.properties.'
+            let localJsonPath = mismatch.schemaJsonPath.slice(76);
+            expect(_.includes(violatedKeywords, localJsonPath)).to.eql(true);
 
-          // mark matched path as empty to ensure repetition does'n occur
-          violatedKeywords[_.indexOf(violatedKeywords, localJsonPath)] = '';
+            // mark matched path as empty to ensure repetition does'n occur
+            violatedKeywords[_.indexOf(violatedKeywords, localJsonPath)] = '';
+          });
+          done();
         });
-        done();
       });
     });
   });
@@ -373,101 +430,118 @@ describe('The Validation option', function () {
 
 describe('VALIDATE FUNCTION TESTS ', function () {
   describe('validateTransaction function', function () {
-    it('Should not fail if spec to validate contains empty parameters', function (done) {
-      let emptyParameterSpec = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-          '/emptyParameterSpec.yaml'), 'utf-8'),
-        emptyParameterCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-          '/emptyParameterCollection.json'), 'utf-8'),
-        resultObj,
-        historyRequest = [],
-        schemaPack = new Converter.SchemaPack({ type: 'string', data: emptyParameterSpec }, {});
+    const emptyParameterSpecs = getSpecsPathByVersion(
+        getFoldersByVersion(
+          VALIDATION_DATA_FOLDER_PATH,
+          VALIDATION_DATA_SCENARIOS_FOLDER_31_PATH
+        ),
+        '/emptyParameterSpec.yaml'
+      ),
+      implicitHeadersSpecs = getSpecsPathByVersion(
+        getFoldersByVersion(
+          VALIDATION_DATA_FOLDER_PATH,
+          VALIDATION_DATA_SCENARIOS_FOLDER_31_PATH
+        ),
+        '/implicitHeaderSpec.yaml'
+      ),
+      rootKeywordViolationSpecs = getSpecsPathByVersion(
+        getFoldersByVersion(
+          VALIDATION_DATA_FOLDER_PATH,
+          VALIDATION_DATA_SCENARIOS_FOLDER_31_PATH
+        ),
+        '/rootKeywordViolationSpec.yaml'
+      ),
+      doubleValidationFixSpecs = getSpecsPathByVersion(
+        getFoldersByVersion(
+          VALIDATION_DATA_FOLDER_PATH,
+          VALIDATION_DATA_SCENARIOS_FOLDER_31_PATH
+        ),
+        '/doubleValidationFixSpec.yaml'
+      ),
+      internalRefsSpecs = getSpecsPathByVersion(
+        getFoldersByVersion(
+          VALIDATION_DATA_FOLDER_PATH,
+          VALIDATION_DATA_SCENARIOS_FOLDER_31_PATH
+        ),
+        '/internalRefsSpec.yaml'
+      ),
+      differentContentTypesSpecs = getSpecsPathByVersion(
+        getFoldersByVersion(
+          VALIDATION_DATA_FOLDER_PATH,
+          VALIDATION_DATA_SCENARIOS_FOLDER_31_PATH
+        ),
+        '/differentContentTypesSpec.yaml'
+      ),
+      primitiveDataTypeBodySpecs = getSpecsPathByVersion(
+        getFoldersByVersion(
+          VALIDATION_DATA_FOLDER_PATH,
+          VALIDATION_DATA_SCENARIOS_FOLDER_31_PATH
+        ),
+        '/primitiveDataTypeBodySpec.yaml'
+      ),
+      multiplePathVarSpecs = getSpecsPathByVersion(
+        getFoldersByVersion(
+          VALIDATION_DATA_FOLDER_PATH,
+          VALIDATION_DATA_SCENARIOS_FOLDER_31_PATH
+        ),
+        '/multiplePathVarSpec.json'
+      ),
+      nestedObjectParamsSpecs = getSpecsPathByVersion(
+        getFoldersByVersion(
+          VALIDATION_DATA_FOLDER_PATH,
+          VALIDATION_DATA_SCENARIOS_FOLDER_31_PATH
+        ),
+        '/nestedObjectParamsSpec.yaml'
+      ),
+      queryParamDeepObjectSpecs = getSpecsPathByVersion(
+        getFoldersByVersion(
+          VALIDATION_DATA_FOLDER_PATH,
+          VALIDATION_DATA_SCENARIOS_FOLDER_31_PATH
+        ),
+        '/queryParamDeepObjectSpec.yaml'
+      ),
+      compositeSchemaSpecs = getSpecsPathByVersion(
+        getFoldersByVersion(
+          VALIDATION_DATA_FOLDER_PATH,
+          VALIDATION_DATA_SCENARIOS_FOLDER_31_PATH
+        ),
+        '/compositeSchemaSpec.yaml'
+      );
 
-      getAllTransactions(JSON.parse(emptyParameterCollection), historyRequest);
+    emptyParameterSpecs.forEach((specData) => {
+      it('Should not fail if spec to validate contains empty parameters - version:' +
+        specData.version, function (done) {
+        let emptyParameterSpec = fs.readFileSync(specData.path, 'utf-8'),
+          emptyParameterCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
+            '/emptyParameterCollection.json'), 'utf-8'),
+          resultObj,
+          historyRequest = [],
+          schemaPack = new Converter.SchemaPack({ type: 'string', data: emptyParameterSpec }, {});
 
-      schemaPack.validateTransaction(historyRequest, (err, result) => {
-        // Schema is sample petsore with one of parameter as empty, expect no mismatch / error
-        expect(err).to.be.null;
-        expect(result).to.be.an('object');
-        resultObj = result.requests[historyRequest[0].id].endpoints[0];
-        expect(resultObj.mismatches).to.have.lengthOf(0);
-        done();
-      });
-    });
+        getAllTransactions(JSON.parse(emptyParameterCollection), historyRequest);
 
-    it('Should correctly handle transactionPath property when Implicit headers are present', function (done) {
-      let implicitHeaderSpec = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-          '/implicitHeaderSpec.yaml'), 'utf-8'),
-        implicitHeaderCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-          '/implicitHeaderCollection.json'), 'utf-8'),
-        resultObj,
-        historyRequest = [],
-        schemaPack = new Converter.SchemaPack({ type: 'string', data: implicitHeaderSpec }, {});
-
-      getAllTransactions(JSON.parse(implicitHeaderCollection), historyRequest);
-
-      schemaPack.validateTransaction(historyRequest, (err, result) => {
-        expect(err).to.be.null;
-        expect(result).to.be.an('object');
-        resultObj = result.requests[historyRequest[0].id].endpoints[0];
-
-        expect(resultObj.mismatches).to.have.lengthOf(1);
-
-        /**
-          header-1 is invalid according to schema, as request contains other 2 implicit headers(Content-Type and Accept)
-          the mismatch for header-1 should contain correct index as in request.
-        */
-        expect(_.endsWith(resultObj.mismatches[0].transactionJsonPath, '[2].value')).to.eql(true);
-        _.forEach(resultObj.responses, (response) => {
-          expect(response.matched).to.be.true;
-          expect(response.mismatches).to.have.lengthOf(0);
+        schemaPack.validateTransaction(historyRequest, (err, result) => {
+          // Schema is sample petsore with one of parameter as empty, expect no mismatch / error
+          expect(err).to.be.null;
+          expect(result).to.be.an('object');
+          resultObj = result.requests[historyRequest[0].id].endpoints[0];
+          expect(resultObj.mismatches).to.have.lengthOf(0);
+          done();
         });
-        done();
       });
     });
 
-    it('Should correctly suggest value when violated keyword is at root level', function (done) {
-      let rootKeywordViolationSpec = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-          '/rootKeywordViolationSpec.yaml'), 'utf-8'),
-        rootKeywordViolationCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-          '/rootKeywordViolationCollection.json'), 'utf-8'),
-        options = { suggestAvailableFixes: true },
-        resultObj,
-        historyRequest = [],
-        schemaPack = new Converter.SchemaPack({ type: 'string', data: rootKeywordViolationSpec }, options);
+    implicitHeadersSpecs.forEach((specData) => {
+      it('Should correctly handle transactionPath property when Implicit headers are present - version:' +
+        specData.version, function (done) {
+        let implicitHeaderSpec = fs.readFileSync(specData.path, 'utf-8'),
+          implicitHeaderCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
+            '/implicitHeaderCollection.json'), 'utf-8'),
+          resultObj,
+          historyRequest = [],
+          schemaPack = new Converter.SchemaPack({ type: 'string', data: implicitHeaderSpec }, {});
 
-      getAllTransactions(JSON.parse(rootKeywordViolationCollection), historyRequest);
-
-      schemaPack.validateTransaction(historyRequest, (err, result) => {
-        expect(err).to.be.null;
-        expect(result).to.be.an('object');
-        resultObj = result.requests[historyRequest[0].id].endpoints[0];
-
-        expect(resultObj.mismatches).to.have.lengthOf(1);
-
-        /**
-          The spec contains "POST /pet" endpoint with request body as Pet object which requires minimum property of 4
-          as this property is root (Json path to prop is ''(empty), we expect suggested value to be according to spec)
-        */
-        expect(_.keys(resultObj.mismatches[0].suggestedFix.actualValue)).to.have.lengthOf(3);
-        expect(_.keys(resultObj.mismatches[0].suggestedFix.suggestedValue)).to.have.lengthOf(4);
-        done();
-      });
-    });
-
-    it('Should correctly suggest value when property is vioalting multiple keywords', function (done) {
-      let doubleValidationFixSpec = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-          '/doubleValidationFixSpec.yaml'), 'utf-8'),
-        options = { requestParametersResolution: 'Example', suggestAvailableFixes: true },
-        resultObj,
-        schemaPack = new Converter.SchemaPack({ type: 'string', data: doubleValidationFixSpec }, options);
-
-      schemaPack.convert((err, conversionResult) => {
-        expect(err).to.be.null;
-        expect(conversionResult.result).to.equal(true);
-
-        let historyRequest = [];
-
-        getAllTransactions(conversionResult.output[0].data, historyRequest);
+        getAllTransactions(JSON.parse(implicitHeaderCollection), historyRequest);
 
         schemaPack.validateTransaction(historyRequest, (err, result) => {
           expect(err).to.be.null;
@@ -477,276 +551,358 @@ describe('VALIDATE FUNCTION TESTS ', function () {
           expect(resultObj.mismatches).to.have.lengthOf(1);
 
           /**
-            The spec contains request body which has name and identifier props as required which is
-            violated in collection. We expect both props to be present and valid according to schema.
+          header-1 is invalid according to schema, as request contains other 2 implicit headers(Content-Type and Accept)
+            the mismatch for header-1 should contain correct index as in request.
           */
-          expect(resultObj.mismatches[0].suggestedFix.suggestedValue).to.contain.keys(['name', 'identifier']);
-          expect(resultObj.mismatches[0].suggestedFix.suggestedValue.name).to.be.a('string');
-          expect(resultObj.mismatches[0].suggestedFix.suggestedValue.identifier).to.be.a('string');
+          expect(_.endsWith(resultObj.mismatches[0].transactionJsonPath, '[2].value')).to.eql(true);
+          _.forEach(resultObj.responses, (response) => {
+            expect(response.matched).to.be.true;
+            expect(response.mismatches).to.have.lengthOf(0);
+          });
           done();
         });
       });
     });
 
-    it('Should correctly handle internal $ref when present', function (done) {
-      let internalRefsSpec = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-          '/internalRefsSpec.yaml'), 'utf-8'),
-        internalRefsCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-          '/internalRefsCollection.json'), 'utf-8'),
-        resultObj,
-        options = {
-          showMissingInSchemaErrors: true,
-          strictRequestMatching: true,
-          ignoreUnresolvedVariables: true,
-          validateMetadata: true,
-          suggestAvailableFixes: true,
-          detailedBlobValidation: false
-        },
-        historyRequest = [],
-        schemaPack = new Converter.SchemaPack({ type: 'string', data: internalRefsSpec }, options);
+    rootKeywordViolationSpecs.forEach((specData) => {
+      it('Should correctly suggest value when violated keyword is at root level - version: ' +
+        specData.version, function (done) {
+        let rootKeywordViolationSpec = fs.readFileSync(specData.path, 'utf-8'),
+          rootKeywordViolationCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
+            '/rootKeywordViolationCollection.json'), 'utf-8'),
+          options = { suggestAvailableFixes: true },
+          resultObj,
+          historyRequest = [],
+          schemaPack = new Converter.SchemaPack({ type: 'string', data: rootKeywordViolationSpec }, options);
 
-      getAllTransactions(JSON.parse(internalRefsCollection), historyRequest);
+        getAllTransactions(JSON.parse(rootKeywordViolationCollection), historyRequest);
 
-      schemaPack.validateTransaction(historyRequest, (err, result) => {
-        expect(err).to.be.null;
-        expect(result).to.be.an('object');
+        schemaPack.validateTransaction(historyRequest, (err, result) => {
+          expect(err).to.be.null;
+          expect(result).to.be.an('object');
+          resultObj = result.requests[historyRequest[0].id].endpoints[0];
 
-        _.forEach(historyRequest, (hr) => {
-          resultObj = result.requests[hr.id].endpoints[0];
+          expect(resultObj.mismatches).to.have.lengthOf(1);
 
-          // no mismatches should be found when resolved correctly
-          expect(resultObj.matched).to.be.true;
-          expect(resultObj.mismatches).to.have.lengthOf(0);
-          _.forEach(resultObj.responses, (response) => {
-            expect(response.matched).to.be.true;
-            expect(response.mismatches).to.have.lengthOf(0);
+          /**
+            The spec contains "POST /pet" endpoint with request body as Pet object which requires minimum property of 4
+            as this property is root (Json path to prop is ''(empty), we expect suggested value to be according to spec)
+          */
+          expect(_.keys(resultObj.mismatches[0].suggestedFix.actualValue)).to.have.lengthOf(3);
+          expect(_.keys(resultObj.mismatches[0].suggestedFix.suggestedValue)).to.have.lengthOf(4);
+          done();
+        });
+      });
+    });
+
+    doubleValidationFixSpecs.forEach((specData) => {
+      it('Should correctly suggest value when property is vioalting multiple keywords - version: ' +
+        specData.version, function (done) {
+        let doubleValidationFixSpec = fs.readFileSync(specData.path, 'utf-8'),
+          options = { requestParametersResolution: 'Example', suggestAvailableFixes: true },
+          resultObj,
+          schemaPack = new Converter.SchemaPack({ type: 'string', data: doubleValidationFixSpec }, options);
+
+        schemaPack.convert((err, conversionResult) => {
+          expect(err).to.be.null;
+          expect(conversionResult.result).to.equal(true);
+
+          let historyRequest = [];
+
+          getAllTransactions(conversionResult.output[0].data, historyRequest);
+
+          schemaPack.validateTransaction(historyRequest, (err, result) => {
+            expect(err).to.be.null;
+            expect(result).to.be.an('object');
+            resultObj = result.requests[historyRequest[0].id].endpoints[0];
+
+            expect(resultObj.mismatches).to.have.lengthOf(1);
+
+            /**
+              The spec contains request body which has name and identifier props as required which is
+              violated in collection. We expect both props to be present and valid according to schema.
+            */
+            expect(resultObj.mismatches[0].suggestedFix.suggestedValue).to.contain.keys(['name', 'identifier']);
+            expect(resultObj.mismatches[0].suggestedFix.suggestedValue.name).to.be.a('string');
+            expect(resultObj.mismatches[0].suggestedFix.suggestedValue.identifier).to.be.a('string');
+            done();
           });
         });
-        done();
       });
     });
 
-    it('Should correctly match and validate valid json content type with collection req/res body', function (done) {
-      let differentContentTypesSpec = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-          '/differentContentTypesSpec.yaml'), 'utf-8'),
-        differentContentTypesCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-          '/differentContentTypesCollection.json'), 'utf-8'),
-        resultObj,
-        historyRequest = [],
-        options = {
-          suggestAvailableFixes: true
-        },
-        schemaPack = new Converter.SchemaPack({ type: 'string', data: differentContentTypesSpec }, options);
+    internalRefsSpecs.forEach((specData) => {
+      it('Should correctly handle internal $ref when present - version: ' +
+        specData.version, function (done) {
+        let internalRefsSpec = fs.readFileSync(specData.path, 'utf-8'),
+          internalRefsCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
+            '/internalRefsCollection.json'), 'utf-8'),
+          resultObj,
+          options = {
+            showMissingInSchemaErrors: true,
+            strictRequestMatching: true,
+            ignoreUnresolvedVariables: true,
+            validateMetadata: true,
+            suggestAvailableFixes: true,
+            detailedBlobValidation: false
+          },
+          historyRequest = [],
+          schemaPack = new Converter.SchemaPack({ type: 'string', data: internalRefsSpec }, options);
 
-      getAllTransactions(JSON.parse(differentContentTypesCollection), historyRequest);
+        getAllTransactions(JSON.parse(internalRefsCollection), historyRequest);
 
-      schemaPack.validateTransaction(historyRequest, (err, result) => {
-        expect(err).to.be.null;
-        expect(result).to.be.an('object');
-        resultObj = result.requests[historyRequest[0].id].endpoints[0];
+        schemaPack.validateTransaction(historyRequest, (err, result) => {
+          expect(err).to.be.null;
+          expect(result).to.be.an('object');
 
-        /**
-         * Both req and res body should match with schema content object and each have one mismatch
-         */
-        expect(resultObj.mismatches).to.have.lengthOf(1);
-        expect(resultObj.mismatches[0].property).to.equal('BODY');
-        expect(resultObj.responses[_.keys(resultObj.responses)[0]].mismatches).to.have.lengthOf(1);
-        expect(resultObj.responses[_.keys(resultObj.responses)[0]].mismatches[0].property).to.equal('RESPONSE_BODY');
-        done();
-      });
-    });
+          _.forEach(historyRequest, (hr) => {
+            resultObj = result.requests[hr.id].endpoints[0];
 
-    it('Should be able to validate and suggest correct value for body with primitive data type', function (done) {
-      let primitiveDataTypeBodySpec = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-          '/primitiveDataTypeBodySpec.yaml'), 'utf-8'),
-        primitiveDataTypeBodyCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-          '/primitiveDataTypeBodyCollection.json'), 'utf-8'),
-        resultObj,
-        responseObj,
-        historyRequest = [],
-        options = {
-          showMissingInSchemaErrors: true,
-          strictRequestMatching: true,
-          ignoreUnresolvedVariables: true,
-          validateMetadata: true,
-          suggestAvailableFixes: true,
-          detailedBlobValidation: false
-        },
-        schemaPack = new Converter.SchemaPack({ type: 'string', data: primitiveDataTypeBodySpec }, options);
-
-      getAllTransactions(JSON.parse(primitiveDataTypeBodyCollection), historyRequest);
-
-      schemaPack.validateTransaction(historyRequest, (err, result) => {
-        expect(err).to.be.null;
-        expect(result).to.be.an('object');
-
-        // request body is boolean
-        resultObj = result.requests[historyRequest[0].id].endpoints[0];
-        expect(resultObj.mismatches).to.have.lengthOf(0);
-
-        // request body is integer
-        responseObj = resultObj.responses[_.keys(resultObj.responses)[0]];
-        expect(responseObj.mismatches).to.have.lengthOf(1);
-        expect(responseObj.mismatches[0].suggestedFix.suggestedValue).to.be.within(5, 10);
-        done();
-      });
-    });
-
-    it('Should correctly validate schema having path with various path variables', function (done) {
-      let multiplePathVarSpec = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-          '/multiplePathVarSpec.json'), 'utf-8'),
-        multiplePathVarCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-          '/multiplePathVarCollection.json'), 'utf-8'),
-        resultObj1,
-        resultObj2,
-        historyRequest = [],
-        options = {
-          showMissingInSchemaErrors: true,
-          strictRequestMatching: true,
-          ignoreUnresolvedVariables: true,
-          suggestAvailableFixes: true
-        },
-        schemaPack = new Converter.SchemaPack({ type: 'string', data: multiplePathVarSpec }, options);
-
-      getAllTransactions(JSON.parse(multiplePathVarCollection), historyRequest);
-
-      schemaPack.validateTransaction(historyRequest, (err, result) => {
-        expect(err).to.be.null;
-        expect(result).to.be.an('object');
-
-        resultObj1 = result.requests[historyRequest[0].id].endpoints[0];
-        expect(resultObj1.mismatches).to.have.lengthOf(0);
-
-        resultObj2 = result.requests[historyRequest[1].id].endpoints[0];
-        expect(resultObj2.mismatches).to.have.lengthOf(1);
-        expect(resultObj2.mismatches[0].reasonCode).to.eql('MISSING_IN_REQUEST');
-        done();
-      });
-    });
-
-    it('Should ignore mismatches for nested objects in parameters', function (done) {
-      let nestedObjectParamsSpec = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-        '/nestedObjectParamsSpec.yaml'), 'utf-8'),
-        nestedObjectParamsCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-          '/nestedObjectParamsCollection.json'), 'utf-8'),
-        resultObj,
-        historyRequest = [],
-        options = {
-          showMissingInSchemaErrors: true,
-          strictRequestMatching: true,
-          ignoreUnresolvedVariables: true,
-          suggestAvailableFixes: true
-        },
-        schemaPack = new Converter.SchemaPack({ type: 'string', data: nestedObjectParamsSpec }, options);
-
-      getAllTransactions(JSON.parse(nestedObjectParamsCollection), historyRequest);
-
-      schemaPack.validateTransaction(historyRequest, (err, result) => {
-        expect(err).to.be.null;
-        expect(result).to.be.an('object');
-
-        resultObj = result.requests[historyRequest[0].id].endpoints[0];
-        expect(resultObj.mismatches).to.have.lengthOf(0);
-        done();
-      });
-    });
-
-    it('Should be able to validate schema with deepObject style query params against corresponding ' +
-    'transactions', function (done) {
-      let queryParamDeepObjectSpec = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-        '/queryParamDeepObjectSpec.yaml'), 'utf-8'),
-        queryParamDeepObjectCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-          '/queryParamDeepObjectCollection.json'), 'utf-8'),
-        resultObj,
-        historyRequest = [],
-        schemaPack = new Converter.SchemaPack({ type: 'string', data: queryParamDeepObjectSpec },
-          { suggestAvailableFixes: true, showMissingInSchemaErrors: true });
-
-      getAllTransactions(JSON.parse(queryParamDeepObjectCollection), historyRequest);
-
-      schemaPack.validateTransaction(historyRequest, (err, result) => {
-        expect(err).to.be.null;
-        expect(result).to.be.an('object');
-        resultObj = result.requests[historyRequest[0].id].endpoints[0];
-        expect(resultObj.mismatches).to.have.lengthOf(2);
-
-        /**
-         * no mismatches should be found for complex array type params as validation is skipped for them,
-         * even though corresponding value is of incorrect type
-         */
-        _.forEach(resultObj.mismatches, (mismatch) => {
-          expect(mismatch.suggestedFix.key).to.not.eql('propArrayComplex[0][prop1ArrayComp]');
+            // no mismatches should be found when resolved correctly
+            expect(resultObj.matched).to.be.true;
+            expect(resultObj.mismatches).to.have.lengthOf(0);
+            _.forEach(resultObj.responses, (response) => {
+              expect(response.matched).to.be.true;
+              expect(response.mismatches).to.have.lengthOf(0);
+            });
+          });
+          done();
         });
-
-        // for deepObject param "user", child param "user[id]" is of incorrect type
-        expect(resultObj.mismatches[0].reasonCode).to.eql('INVALID_TYPE');
-        expect(resultObj.mismatches[0].transactionJsonPath).to.eql('$.request.url.query[0].value');
-        expect(resultObj.mismatches[0].suggestedFix.actualValue).to.eql('notAnInteger');
-        expect(resultObj.mismatches[0].suggestedFix.suggestedValue).to.eql(123);
-
-        // for deepObject param "user", child param "user[address][country]" is missing in transaction
-        expect(resultObj.mismatches[1].reasonCode).to.eql('MISSING_IN_REQUEST');
-        expect(resultObj.mismatches[1].suggestedFix.key).to.eql('user[address][country]');
-        expect(resultObj.mismatches[1].suggestedFix.actualValue).to.be.null;
-        expect(resultObj.mismatches[1].suggestedFix.suggestedValue).to.eql({
-          key: 'user[address][country]',
-          value: 'India',
-          description: '(Required) info about user'
-        });
-        done();
       });
     });
 
-    it('Should be able to correctly validate composite schemas with anyOf, oneOf and allOf keywords correctly ' +
-    'against corresponding transactions', function (done) {
-      let compositeSchemaSpec = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-        '/compositeSchemaSpec.yaml'), 'utf-8'),
-        compositeSchemaCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
-          '/compositeSchemaCollection.json'), 'utf-8'),
-        resultObjAnyOf,
-        resultObjOneOf,
-        resultObjAllOf,
-        historyRequest = [],
-        schemaPack = new Converter.SchemaPack({ type: 'string', data: compositeSchemaSpec },
-          { suggestAvailableFixes: true, showMissingInSchemaErrors: true });
+    differentContentTypesSpecs.forEach((specData) => {
+      it('Should correctly match and validate valid json content type with collection req/res body - version:' +
+       specData.version, function (done) {
+        let differentContentTypesSpec = fs.readFileSync(specData.path, 'utf-8'),
+          differentContentTypesCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
+            '/differentContentTypesCollection.json'), 'utf-8'),
+          resultObj,
+          historyRequest = [],
+          options = {
+            suggestAvailableFixes: true
+          },
+          schemaPack = new Converter.SchemaPack({ type: 'string', data: differentContentTypesSpec }, options);
 
-      getAllTransactions(JSON.parse(compositeSchemaCollection), historyRequest);
+        getAllTransactions(JSON.parse(differentContentTypesCollection), historyRequest);
 
-      schemaPack.validateTransaction(historyRequest, (err, result) => {
-        expect(err).to.be.null;
-        expect(result).to.be.an('object');
-        resultObjAnyOf = result.requests[historyRequest[0].id].endpoints[0];
-        resultObjOneOf = result.requests[historyRequest[1].id].endpoints[0];
-        resultObjAllOf = result.requests[historyRequest[2].id].endpoints[0];
+        schemaPack.validateTransaction(historyRequest, (err, result) => {
+          expect(err).to.be.null;
+          expect(result).to.be.an('object');
+          resultObj = result.requests[historyRequest[0].id].endpoints[0];
 
-        /**
-         * no mismatches should be found here even though value present in collection
-         * is only valid as per 2nd element of anyOf keyword here
-         */
-        expect(resultObjAnyOf.mismatches).to.have.lengthOf(0);
-
-        /**
-         * no mismatches should be found here even though key present in collection request body
-         * is only valid as per 2nd element of oneOf keyword here
-         */
-        expect(resultObjOneOf.mismatches).to.have.lengthOf(0);
-
-        //
-        expect(resultObjAllOf.mismatches).to.have.lengthOf(1);
-        expect(resultObjAllOf.mismatches[0].reasonCode).to.eql('INVALID_BODY');
-        expect(resultObjAllOf.mismatches[0].transactionJsonPath).to.eql('$.request.body');
-        expect(resultObjAllOf.mismatches[0].schemaJsonPath).to
-          .eql('$.paths[/pets/allOf].post.requestBody.content[application/json].schema');
-        expect(resultObjAllOf.mismatches[0].suggestedFix.actualValue).to.eql({
-          objectType: 'not an integer',
-          objectType2: 'prop named objectType2'
+          /**
+           * Both req and res body should match with schema content object and each have one mismatch
+           */
+          expect(resultObj.mismatches).to.have.lengthOf(1);
+          expect(resultObj.mismatches[0].property).to.equal('BODY');
+          expect(resultObj.responses[_.keys(resultObj.responses)[0]].mismatches).to.have.lengthOf(1);
+          expect(resultObj.responses[_.keys(resultObj.responses)[0]].mismatches[0].property).to.equal('RESPONSE_BODY');
+          done();
         });
-        expect(resultObjAllOf.mismatches[0].suggestedFix.suggestedValue).to.eql({
-          objectType: 4321,
-          objectType2: 'prop named objectType2'
-        });
+      });
+    });
 
-        done();
+    primitiveDataTypeBodySpecs.forEach((specData) => {
+      it('Should be able to validate and suggest correct value for body with primitive data type - version: ' +
+        specData.version, function (done) {
+        let primitiveDataTypeBodySpec = fs.readFileSync(specData.path, 'utf-8'),
+          primitiveDataTypeBodyCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
+            '/primitiveDataTypeBodyCollection.json'), 'utf-8'),
+          resultObj,
+          responseObj,
+          historyRequest = [],
+          options = {
+            showMissingInSchemaErrors: true,
+            strictRequestMatching: true,
+            ignoreUnresolvedVariables: true,
+            validateMetadata: true,
+            suggestAvailableFixes: true,
+            detailedBlobValidation: false
+          },
+          schemaPack = new Converter.SchemaPack({ type: 'string', data: primitiveDataTypeBodySpec }, options);
+
+        getAllTransactions(JSON.parse(primitiveDataTypeBodyCollection), historyRequest);
+
+        schemaPack.validateTransaction(historyRequest, (err, result) => {
+          expect(err).to.be.null;
+          expect(result).to.be.an('object');
+
+          // request body is boolean
+          resultObj = result.requests[historyRequest[0].id].endpoints[0];
+          expect(resultObj.mismatches).to.have.lengthOf(0);
+
+          // request body is integer
+          responseObj = resultObj.responses[_.keys(resultObj.responses)[0]];
+          expect(responseObj.mismatches).to.have.lengthOf(1);
+          expect(responseObj.mismatches[0].suggestedFix.suggestedValue).to.be.within(5, 10);
+          done();
+        });
+      });
+    });
+
+    multiplePathVarSpecs.forEach((specData) => {
+      it('Should correctly validate schema having path with various path variables - version: ' +
+        specData.version, function (done) {
+        let multiplePathVarSpec = fs.readFileSync(specData.path, 'utf-8'),
+          multiplePathVarCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
+            '/multiplePathVarCollection.json'), 'utf-8'),
+          resultObj1,
+          resultObj2,
+          historyRequest = [],
+          options = {
+            showMissingInSchemaErrors: true,
+            strictRequestMatching: true,
+            ignoreUnresolvedVariables: true,
+            suggestAvailableFixes: true
+          },
+          schemaPack = new Converter.SchemaPack({ type: 'string', data: multiplePathVarSpec }, options);
+
+        getAllTransactions(JSON.parse(multiplePathVarCollection), historyRequest);
+
+        schemaPack.validateTransaction(historyRequest, (err, result) => {
+          expect(err).to.be.null;
+          expect(result).to.be.an('object');
+
+          resultObj1 = result.requests[historyRequest[0].id].endpoints[0];
+          expect(resultObj1.mismatches).to.have.lengthOf(0);
+
+          resultObj2 = result.requests[historyRequest[1].id].endpoints[0];
+          expect(resultObj2.mismatches).to.have.lengthOf(1);
+          expect(resultObj2.mismatches[0].reasonCode).to.eql('MISSING_IN_REQUEST');
+          done();
+        });
+      });
+    });
+
+    nestedObjectParamsSpecs.forEach((specData) => {
+      it('Should ignore mismatches for nested objects in parameters - version: ' +
+        specData.version, function (done) {
+        let nestedObjectParamsSpec = fs.readFileSync(specData.path, 'utf-8'),
+          nestedObjectParamsCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
+            '/nestedObjectParamsCollection.json'), 'utf-8'),
+          resultObj,
+          historyRequest = [],
+          options = {
+            showMissingInSchemaErrors: true,
+            strictRequestMatching: true,
+            ignoreUnresolvedVariables: true,
+            suggestAvailableFixes: true
+          },
+          schemaPack = new Converter.SchemaPack({ type: 'string', data: nestedObjectParamsSpec }, options);
+
+        getAllTransactions(JSON.parse(nestedObjectParamsCollection), historyRequest);
+
+        schemaPack.validateTransaction(historyRequest, (err, result) => {
+          expect(err).to.be.null;
+          expect(result).to.be.an('object');
+
+          resultObj = result.requests[historyRequest[0].id].endpoints[0];
+          expect(resultObj.mismatches).to.have.lengthOf(0);
+          done();
+        });
+      });
+    });
+
+    queryParamDeepObjectSpecs.forEach((specData) => {
+      it('Should be able to validate schema with deepObject style query params against corresponding ' +
+      'transactions - version: ' + specData.version, function (done) {
+        let queryParamDeepObjectSpec = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
+          '/queryParamDeepObjectSpec.yaml'), 'utf-8'),
+          queryParamDeepObjectCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
+            '/queryParamDeepObjectCollection.json'), 'utf-8'),
+          resultObj,
+          historyRequest = [],
+          schemaPack = new Converter.SchemaPack({ type: 'string', data: queryParamDeepObjectSpec },
+            { suggestAvailableFixes: true, showMissingInSchemaErrors: true });
+
+        getAllTransactions(JSON.parse(queryParamDeepObjectCollection), historyRequest);
+
+        schemaPack.validateTransaction(historyRequest, (err, result) => {
+          expect(err).to.be.null;
+          expect(result).to.be.an('object');
+          resultObj = result.requests[historyRequest[0].id].endpoints[0];
+          expect(resultObj.mismatches).to.have.lengthOf(2);
+
+          /**
+           * no mismatches should be found for complex array type params as validation is skipped for them,
+           * even though corresponding value is of incorrect type
+           */
+          _.forEach(resultObj.mismatches, (mismatch) => {
+            expect(mismatch.suggestedFix.key).to.not.eql('propArrayComplex[0][prop1ArrayComp]');
+          });
+
+          // for deepObject param "user", child param "user[id]" is of incorrect type
+          expect(resultObj.mismatches[0].reasonCode).to.eql('INVALID_TYPE');
+          expect(resultObj.mismatches[0].transactionJsonPath).to.eql('$.request.url.query[0].value');
+          expect(resultObj.mismatches[0].suggestedFix.actualValue).to.eql('notAnInteger');
+          expect(resultObj.mismatches[0].suggestedFix.suggestedValue).to.eql(123);
+
+          // for deepObject param "user", child param "user[address][country]" is missing in transaction
+          expect(resultObj.mismatches[1].reasonCode).to.eql('MISSING_IN_REQUEST');
+          expect(resultObj.mismatches[1].suggestedFix.key).to.eql('user[address][country]');
+          expect(resultObj.mismatches[1].suggestedFix.actualValue).to.be.null;
+          expect(resultObj.mismatches[1].suggestedFix.suggestedValue).to.eql({
+            key: 'user[address][country]',
+            value: 'India',
+            description: '(Required) info about user'
+          });
+          done();
+        });
+      });
+    });
+
+    compositeSchemaSpecs.forEach((specData) => {
+      it('Should be able to correctly validate composite schemas with anyOf, oneOf and allOf keywords correctly ' +
+      'against corresponding transactions - version: ' + specData.version, function (done) {
+        let compositeSchemaSpec = fs.readFileSync(specData.path, 'utf-8'),
+          compositeSchemaCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
+            '/compositeSchemaCollection.json'), 'utf-8'),
+          resultObjAnyOf,
+          resultObjOneOf,
+          resultObjAllOf,
+          historyRequest = [],
+          schemaPack = new Converter.SchemaPack({ type: 'string', data: compositeSchemaSpec },
+            { suggestAvailableFixes: true, showMissingInSchemaErrors: true });
+
+        getAllTransactions(JSON.parse(compositeSchemaCollection), historyRequest);
+
+        schemaPack.validateTransaction(historyRequest, (err, result) => {
+          expect(err).to.be.null;
+          expect(result).to.be.an('object');
+          resultObjAnyOf = result.requests[historyRequest[0].id].endpoints[0];
+          resultObjOneOf = result.requests[historyRequest[1].id].endpoints[0];
+          resultObjAllOf = result.requests[historyRequest[2].id].endpoints[0];
+
+          /**
+           * no mismatches should be found here even though value present in collection
+           * is only valid as per 2nd element of anyOf keyword here
+           */
+          expect(resultObjAnyOf.mismatches).to.have.lengthOf(0);
+
+          /**
+           * no mismatches should be found here even though key present in collection request body
+           * is only valid as per 2nd element of oneOf keyword here
+           */
+          expect(resultObjOneOf.mismatches).to.have.lengthOf(0);
+
+          //
+          expect(resultObjAllOf.mismatches).to.have.lengthOf(1);
+          expect(resultObjAllOf.mismatches[0].reasonCode).to.eql('INVALID_BODY');
+          expect(resultObjAllOf.mismatches[0].transactionJsonPath).to.eql('$.request.body');
+          expect(resultObjAllOf.mismatches[0].schemaJsonPath).to
+            .eql('$.paths[/pets/allOf].post.requestBody.content[application/json].schema');
+          expect(resultObjAllOf.mismatches[0].suggestedFix.actualValue).to.eql({
+            objectType: 'not an integer',
+            objectType2: 'prop named objectType2'
+          });
+          expect(resultObjAllOf.mismatches[0].suggestedFix.suggestedValue).to.eql({
+            objectType: 4321,
+            objectType2: 'prop named objectType2'
+          });
+
+          done();
+        });
       });
     });
   });

--- a/test/unit/versionUtils.test.js
+++ b/test/unit/versionUtils.test.js
@@ -200,8 +200,10 @@ describe('filterOptionsByVersion method', function() {
         }
       ],
       optionsFiltered = filterOptionsByVersion(optionsMock, '3.1');
-    expect(optionsFiltered).to.be.an('object');
-    expect(Object.keys(optionsFiltered)).to.include.members(['optionC', 'optionD']);
+    expect(optionsFiltered).to.be.an('array');
+    expect(optionsFiltered.map((option) => {
+      return option.id;
+    })).to.include.members(['optionC', 'optionD']);
   });
 
   it('Should return the options supported in version 3.0', function() {
@@ -232,7 +234,9 @@ describe('filterOptionsByVersion method', function() {
         }
       ],
       optionsFiltered = filterOptionsByVersion(optionsMock, '3.0');
-    expect(optionsFiltered).to.be.an('object');
-    expect(Object.keys(optionsFiltered)).to.include.members(['optionA', 'optionB', 'optionD']);
+    expect(optionsFiltered).to.be.an('array');
+    expect(optionsFiltered.map((option) => {
+      return option.id;
+    })).to.include.members(['optionA', 'optionB', 'optionD']);
   });
 });

--- a/test/unit/versionUtils.test.js
+++ b/test/unit/versionUtils.test.js
@@ -1,4 +1,4 @@
-const { getSpecVersion } = require('../../lib/common/versionUtils'),
+const { getSpecVersion, filterOptionsByVersion } = require('../../lib/common/versionUtils'),
   expect = require('chai').expect;
 
 describe('getSpecVersion', function() {
@@ -168,5 +168,71 @@ describe('getSpecVersion', function() {
       },
       specVersion = getSpecVersion({ type: jsonType, data: inputData });
     expect(specVersion).to.be.equal('2.0');
+  });
+});
+
+describe('filterOptionsByVersion method', function() {
+  it('Should return the options supported in version 3.1', function() {
+    const optionsMock = [
+        {
+          id: 'optionA',
+          name: 'option A',
+          supportedIn: ['3.0'],
+          default: 'A default value for option A'
+        },
+        {
+          id: 'optionB',
+          name: 'option B',
+          supportedIn: ['3.0'],
+          default: 'A default value for option B'
+        },
+        {
+          id: 'optionC',
+          name: 'option C',
+          supportedIn: ['3.1'],
+          default: 'A default value for option C'
+        },
+        {
+          id: 'optionD',
+          name: 'option D',
+          supportedIn: ['3.0', '3.1'],
+          default: 'A default value for option D'
+        }
+      ],
+      optionsFiltered = filterOptionsByVersion(optionsMock, '3.1');
+    expect(optionsFiltered).to.be.an('object');
+    expect(Object.keys(optionsFiltered)).to.include.members(['optionC', 'optionD']);
+  });
+
+  it('Should return the options supported in version 3.0', function() {
+    const optionsMock = [
+        {
+          id: 'optionA',
+          name: 'option A',
+          supportedIn: ['3.0'],
+          default: 'A default value for option A'
+        },
+        {
+          id: 'optionB',
+          name: 'option B',
+          supportedIn: ['3.0'],
+          default: 'A default value for option B'
+        },
+        {
+          id: 'optionC',
+          name: 'option C',
+          supportedIn: ['3.1'],
+          default: 'A default value for option C'
+        },
+        {
+          id: 'optionD',
+          name: 'option D',
+          supportedIn: ['3.0', '3.1'],
+          default: 'A default value for option D'
+        }
+      ],
+      optionsFiltered = filterOptionsByVersion(optionsMock, '3.0');
+    expect(optionsFiltered).to.be.an('object');
+    expect(Object.keys(optionsFiltered)).to.include.members(['optionA', 'optionB', 'optionD']);
   });
 });


### PR DESCRIPTION
- getOptions now can receive the version of spec being used
- getOptions will resolve the parameters when the user provides less than the expected arguments
- Adding the supported version to the options
- Adding files to test the validateTransaction options
- Adding tests to validate the validator.test scenarios using the implementation of 3.1 version
- Adding tests to validate resolved issues scenarios in 3.1