### PR TITLE
Added support for Accept header in conversion.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2513,8 +2513,8 @@ module.exports = {
       });
     }
 
-    // add accept header if found
-    if (!_.isEmpty(acceptHeader)) {
+    // add accept header if found and not present already
+    if (!_.isEmpty(acceptHeader) && !item.request.headers.has('accept')) {
       item.request.addHeader(acceptHeader);
     }
     return item;

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2202,7 +2202,9 @@ module.exports = {
       localServers = _.get(operationItem, 'properties.servers'),
       exampleRequestBody,
       sanitizeResult,
-      globalServers = _.get(operationItem, 'servers');
+      globalServers = _.get(operationItem, 'servers'),
+      responseMediaTypes,
+      acceptHeader;
 
     // handling path templating in request url if any
     // convert all {anything} to {{anything}}
@@ -2493,12 +2495,28 @@ module.exports = {
           // 'Exception:', e);
           thisOriginalRequest.body = {};
         }
+
+        // set accept header value as first found response content's media type
+        if (_.isEmpty(acceptHeader)) {
+          responseMediaTypes = _.keys(_.get(swagResponse, 'content'));
+          if (responseMediaTypes.length > 0) {
+            acceptHeader = {
+              key: 'Accept',
+              value: responseMediaTypes[0]
+            };
+          }
+        }
+
         convertedResponse = this.convertToPmResponse(swagResponse, code, thisOriginalRequest,
           components, options, schemaCache);
         convertedResponse && item.responses.add(convertedResponse);
       });
     }
 
+    // add accept header if found
+    if (!_.isEmpty(acceptHeader)) {
+      item.request.addHeader(acceptHeader);
+    }
     return item;
   },
 

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -317,7 +317,11 @@ describe('CONVERT FUNCTION TESTS ', function() {
           .to.equal('Content-Type');
         expect(conversionResult.output[0].data.item[0].item[1].request.header[1].value)
           .to.equal('application/json');
-        expect(conversionResult.output[0].data.item[0].item[1].request.header).to.have.length(2);
+        expect(conversionResult.output[0].data.item[0].item[1].request.header[2].key)
+          .to.equal('Accept');
+        expect(conversionResult.output[0].data.item[0].item[1].request.header[2].value)
+          .to.equal('application/json');
+        expect(conversionResult.output[0].data.item[0].item[1].request.header).to.have.length(3);
         done();
       });
     });
@@ -329,10 +333,14 @@ describe('CONVERT FUNCTION TESTS ', function() {
         keepImplicitHeaders: false
       }, (err, conversionResult) => {
         expect(err).to.be.null;
-        expect(conversionResult.output[0].data.item[0].item[1].request.header).to.have.length(1);
+        expect(conversionResult.output[0].data.item[0].item[1].request.header).to.have.length(2);
         expect(conversionResult.output[0].data.item[0].item[1].request.header[0].key)
           .to.equal('Content-Type');
         expect(conversionResult.output[0].data.item[0].item[1].request.header[0].value)
+          .to.equal('application/json');
+        expect(conversionResult.output[0].data.item[0].item[1].request.header[1].key)
+          .to.equal('Accept');
+        expect(conversionResult.output[0].data.item[0].item[1].request.header[1].value)
           .to.equal('application/json');
         done();
       });


### PR DESCRIPTION
This PR adds support for the inclusion of the `Accept` header similar to how `Content-Type` gets added in each request based on the first response media type that's found.\

Reference: https://swagger.io/docs/specification/describing-parameters/ 