### PR TITLE
change ajv draft 4 to ajv 6 and validate using schema for 04

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           node-version: '14.x'
       - run: npm install
+      - run: npm run test-lint
       - run: npm run test-unit
 
   Regression:

--- a/assets/ajv6faker.js
+++ b/assets/ajv6faker.js
@@ -1,0 +1,7191 @@
+/* eslint-disable */
+
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.ajv6faker = f()}})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+  'use strict';
+
+  var compileSchema = require('./compile')
+    , resolve = require('./compile/resolve')
+    , Cache = require('./cache')
+    , SchemaObject = require('./compile/schema_obj')
+    , stableStringify = require('fast-json-stable-stringify')
+    , formats = require('./compile/formats')
+    , rules = require('./compile/rules')
+    , $dataMetaSchema = require('./data')
+    , util = require('./compile/util');
+
+  module.exports = Ajv;
+
+  Ajv.prototype.validate = validate;
+  Ajv.prototype.compile = compile;
+  Ajv.prototype.addSchema = addSchema;
+  Ajv.prototype.addMetaSchema = addMetaSchema;
+  Ajv.prototype.validateSchema = validateSchema;
+  Ajv.prototype.getSchema = getSchema;
+  Ajv.prototype.removeSchema = removeSchema;
+  Ajv.prototype.addFormat = addFormat;
+  Ajv.prototype.errorsText = errorsText;
+
+  Ajv.prototype._addSchema = _addSchema;
+  Ajv.prototype._compile = _compile;
+
+  Ajv.prototype.compileAsync = require('./compile/async');
+  var customKeyword = require('./keyword');
+  Ajv.prototype.addKeyword = customKeyword.add;
+  Ajv.prototype.getKeyword = customKeyword.get;
+  Ajv.prototype.removeKeyword = customKeyword.remove;
+  Ajv.prototype.validateKeyword = customKeyword.validate;
+
+  var errorClasses = require('./compile/error_classes');
+  Ajv.ValidationError = errorClasses.Validation;
+  Ajv.MissingRefError = errorClasses.MissingRef;
+  Ajv.$dataMetaSchema = $dataMetaSchema;
+
+  var META_SCHEMA_ID = 'http://json-schema.org/draft-07/schema';
+
+  var META_IGNORE_OPTIONS = [ 'removeAdditional', 'useDefaults', 'coerceTypes', 'strictDefaults' ];
+  var META_SUPPORT_DATA = ['/properties'];
+
+  /**
+   * Creates validator instance.
+   * Usage: `Ajv(opts)`
+   * @param {Object} opts optional options
+   * @return {Object} ajv instance
+   */
+  function Ajv(opts) {
+    if (!(this instanceof Ajv)) return new Ajv(opts);
+    opts = this._opts = util.copy(opts) || {};
+    setLogger(this);
+    this._schemas = {};
+    this._refs = {};
+    this._fragments = {};
+    this._formats = formats(opts.format);
+
+    this._cache = opts.cache || new Cache;
+    this._loadingSchemas = {};
+    this._compilations = [];
+    this.RULES = rules();
+    this._getId = chooseGetId(opts);
+
+    opts.loopRequired = opts.loopRequired || Infinity;
+    if (opts.errorDataPath == 'property') opts._errorDataPathProperty = true;
+    if (opts.serialize === undefined) opts.serialize = stableStringify;
+    this._metaOpts = getMetaSchemaOptions(this);
+
+    if (opts.formats) addInitialFormats(this);
+    if (opts.keywords) addInitialKeywords(this);
+    addDefaultMetaSchema(this);
+    if (typeof opts.meta == 'object') this.addMetaSchema(opts.meta);
+    if (opts.nullable) this.addKeyword('nullable', {metaSchema: {type: 'boolean'}});
+    addInitialSchemas(this);
+  }
+
+
+
+  /**
+   * Validate data using schema
+   * Schema will be compiled and cached (using serialized JSON as key. [fast-json-stable-stringify](https://github.com/epoberezkin/fast-json-stable-stringify) is used to serialize.
+   * @this   Ajv
+   * @param  {String|Object} schemaKeyRef key, ref or schema object
+   * @param  {Any} data to be validated
+   * @return {Boolean} validation result. Errors from the last validation will be available in `ajv.errors` (and also in compiled schema: `schema.errors`).
+   */
+  function validate(schemaKeyRef, data) {
+    var v;
+    if (typeof schemaKeyRef == 'string') {
+      v = this.getSchema(schemaKeyRef);
+      if (!v) throw new Error('no schema with key or ref "' + schemaKeyRef + '"');
+    } else {
+      var schemaObj = this._addSchema(schemaKeyRef);
+      v = schemaObj.validate || this._compile(schemaObj);
+    }
+
+    var valid = v(data);
+    if (v.$async !== true) this.errors = v.errors;
+    return valid;
+  }
+
+
+  /**
+   * Create validating function for passed schema.
+   * @this   Ajv
+   * @param  {Object} schema schema object
+   * @param  {Boolean} _meta true if schema is a meta-schema. Used internally to compile meta schemas of custom keywords.
+   * @return {Function} validating function
+   */
+  function compile(schema, _meta) {
+    var schemaObj = this._addSchema(schema, undefined, _meta);
+    return schemaObj.validate || this._compile(schemaObj);
+  }
+
+
+  /**
+   * Adds schema to the instance.
+   * @this   Ajv
+   * @param {Object|Array} schema schema or array of schemas. If array is passed, `key` and other parameters will be ignored.
+   * @param {String} key Optional schema key. Can be passed to `validate` method instead of schema object or id/ref. One schema per instance can have empty `id` and `key`.
+   * @param {Boolean} _skipValidation true to skip schema validation. Used internally, option validateSchema should be used instead.
+   * @param {Boolean} _meta true if schema is a meta-schema. Used internally, addMetaSchema should be used instead.
+   * @return {Ajv} this for method chaining
+   */
+  function addSchema(schema, key, _skipValidation, _meta) {
+    if (Array.isArray(schema)){
+      for (var i=0; i<schema.length; i++) this.addSchema(schema[i], undefined, _skipValidation, _meta);
+      return this;
+    }
+    var id = this._getId(schema);
+    if (id !== undefined && typeof id != 'string')
+      throw new Error('schema id must be string');
+    key = resolve.normalizeId(key || id);
+    checkUnique(this, key);
+    this._schemas[key] = this._addSchema(schema, _skipValidation, _meta, true);
+    return this;
+  }
+
+
+  /**
+   * Add schema that will be used to validate other schemas
+   * options in META_IGNORE_OPTIONS are alway set to false
+   * @this   Ajv
+   * @param {Object} schema schema object
+   * @param {String} key optional schema key
+   * @param {Boolean} skipValidation true to skip schema validation, can be used to override validateSchema option for meta-schema
+   * @return {Ajv} this for method chaining
+   */
+  function addMetaSchema(schema, key, skipValidation) {
+    this.addSchema(schema, key, skipValidation, true);
+    return this;
+  }
+
+
+  /**
+   * Validate schema
+   * @this   Ajv
+   * @param {Object} schema schema to validate
+   * @param {Boolean} throwOrLogError pass true to throw (or log) an error if invalid
+   * @return {Boolean} true if schema is valid
+   */
+  function validateSchema(schema, throwOrLogError) {
+    var $schema = schema.$schema;
+    if ($schema !== undefined && typeof $schema != 'string')
+      throw new Error('$schema must be a string');
+    $schema = $schema || this._opts.defaultMeta || defaultMeta(this);
+    if (!$schema) {
+      this.logger.warn('meta-schema not available');
+      this.errors = null;
+      return true;
+    }
+    var valid = this.validate($schema, schema);
+    if (!valid && throwOrLogError) {
+      var message = 'schema is invalid: ' + this.errorsText();
+      if (this._opts.validateSchema == 'log') this.logger.error(message);
+      else throw new Error(message);
+    }
+    return valid;
+  }
+
+
+  function defaultMeta(self) {
+    var meta = self._opts.meta;
+    self._opts.defaultMeta = typeof meta == 'object'
+                              ? self._getId(meta) || meta
+                              : self.getSchema(META_SCHEMA_ID)
+                                ? META_SCHEMA_ID
+                                : undefined;
+    return self._opts.defaultMeta;
+  }
+
+
+  /**
+   * Get compiled schema from the instance by `key` or `ref`.
+   * @this   Ajv
+   * @param  {String} keyRef `key` that was passed to `addSchema` or full schema reference (`schema.id` or resolved id).
+   * @return {Function} schema validating function (with property `schema`).
+   */
+  function getSchema(keyRef) {
+    var schemaObj = _getSchemaObj(this, keyRef);
+    switch (typeof schemaObj) {
+      case 'object': return schemaObj.validate || this._compile(schemaObj);
+      case 'string': return this.getSchema(schemaObj);
+      case 'undefined': return _getSchemaFragment(this, keyRef);
+    }
+  }
+
+
+  function _getSchemaFragment(self, ref) {
+    var res = resolve.schema.call(self, { schema: {} }, ref);
+    if (res) {
+      var schema = res.schema
+        , root = res.root
+        , baseId = res.baseId;
+      var v = compileSchema.call(self, schema, root, undefined, baseId);
+      self._fragments[ref] = new SchemaObject({
+        ref: ref,
+        fragment: true,
+        schema: schema,
+        root: root,
+        baseId: baseId,
+        validate: v
+      });
+      return v;
+    }
+  }
+
+
+  function _getSchemaObj(self, keyRef) {
+    keyRef = resolve.normalizeId(keyRef);
+    return self._schemas[keyRef] || self._refs[keyRef] || self._fragments[keyRef];
+  }
+
+
+  /**
+   * Remove cached schema(s).
+   * If no parameter is passed all schemas but meta-schemas are removed.
+   * If RegExp is passed all schemas with key/id matching pattern but meta-schemas are removed.
+   * Even if schema is referenced by other schemas it still can be removed as other schemas have local references.
+   * @this   Ajv
+   * @param  {String|Object|RegExp} schemaKeyRef key, ref, pattern to match key/ref or schema object
+   * @return {Ajv} this for method chaining
+   */
+  function removeSchema(schemaKeyRef) {
+    if (schemaKeyRef instanceof RegExp) {
+      _removeAllSchemas(this, this._schemas, schemaKeyRef);
+      _removeAllSchemas(this, this._refs, schemaKeyRef);
+      return this;
+    }
+    switch (typeof schemaKeyRef) {
+      case 'undefined':
+        _removeAllSchemas(this, this._schemas);
+        _removeAllSchemas(this, this._refs);
+        this._cache.clear();
+        return this;
+      case 'string':
+        var schemaObj = _getSchemaObj(this, schemaKeyRef);
+        if (schemaObj) this._cache.del(schemaObj.cacheKey);
+        delete this._schemas[schemaKeyRef];
+        delete this._refs[schemaKeyRef];
+        return this;
+      case 'object':
+        var serialize = this._opts.serialize;
+        var cacheKey = serialize ? serialize(schemaKeyRef) : schemaKeyRef;
+        this._cache.del(cacheKey);
+        var id = this._getId(schemaKeyRef);
+        if (id) {
+          id = resolve.normalizeId(id);
+          delete this._schemas[id];
+          delete this._refs[id];
+        }
+    }
+    return this;
+  }
+
+
+  function _removeAllSchemas(self, schemas, regex) {
+    for (var keyRef in schemas) {
+      var schemaObj = schemas[keyRef];
+      if (!schemaObj.meta && (!regex || regex.test(keyRef))) {
+        self._cache.del(schemaObj.cacheKey);
+        delete schemas[keyRef];
+      }
+    }
+  }
+
+
+  /* @this   Ajv */
+  function _addSchema(schema, skipValidation, meta, shouldAddSchema) {
+    if (typeof schema != 'object' && typeof schema != 'boolean')
+      throw new Error('schema should be object or boolean');
+    var serialize = this._opts.serialize;
+    var cacheKey = serialize ? serialize(schema) : schema;
+    var cached = this._cache.get(cacheKey);
+    if (cached) return cached;
+
+    shouldAddSchema = shouldAddSchema || this._opts.addUsedSchema !== false;
+
+    var id = resolve.normalizeId(this._getId(schema));
+    if (id && shouldAddSchema) checkUnique(this, id);
+
+    var willValidate = this._opts.validateSchema !== false && !skipValidation;
+    var recursiveMeta;
+    if (willValidate && !(recursiveMeta = id && id == resolve.normalizeId(schema.$schema)))
+      this.validateSchema(schema, true);
+
+    var localRefs = resolve.ids.call(this, schema);
+
+    var schemaObj = new SchemaObject({
+      id: id,
+      schema: schema,
+      localRefs: localRefs,
+      cacheKey: cacheKey,
+      meta: meta
+    });
+
+    if (id[0] != '#' && shouldAddSchema) this._refs[id] = schemaObj;
+    this._cache.put(cacheKey, schemaObj);
+
+    if (willValidate && recursiveMeta) this.validateSchema(schema, true);
+
+    return schemaObj;
+  }
+
+
+  /* @this   Ajv */
+  function _compile(schemaObj, root) {
+    if (schemaObj.compiling) {
+      schemaObj.validate = callValidate;
+      callValidate.schema = schemaObj.schema;
+      callValidate.errors = null;
+      callValidate.root = root ? root : callValidate;
+      if (schemaObj.schema.$async === true)
+        callValidate.$async = true;
+      return callValidate;
+    }
+    schemaObj.compiling = true;
+
+    var currentOpts;
+    if (schemaObj.meta) {
+      currentOpts = this._opts;
+      this._opts = this._metaOpts;
+    }
+
+    var v;
+    try { v = compileSchema.call(this, schemaObj.schema, root, schemaObj.localRefs); }
+    catch(e) {
+      delete schemaObj.validate;
+      throw e;
+    }
+    finally {
+      schemaObj.compiling = false;
+      if (schemaObj.meta) this._opts = currentOpts;
+    }
+
+    schemaObj.validate = v;
+    schemaObj.refs = v.refs;
+    schemaObj.refVal = v.refVal;
+    schemaObj.root = v.root;
+    return v;
+
+
+    /* @this   {*} - custom context, see passContext option */
+    function callValidate() {
+      /* jshint validthis: true */
+      var _validate = schemaObj.validate;
+      var result = _validate.apply(this, arguments);
+      callValidate.errors = _validate.errors;
+      return result;
+    }
+  }
+
+
+  function chooseGetId(opts) {
+    switch (opts.schemaId) {
+      case 'auto': return _get$IdOrId;
+      case 'id': return _getId;
+      default: return _get$Id;
+    }
+  }
+
+  /* @this   Ajv */
+  function _getId(schema) {
+    if (schema.$id) this.logger.warn('schema $id ignored', schema.$id);
+    return schema.id;
+  }
+
+  /* @this   Ajv */
+  function _get$Id(schema) {
+    if (schema.id) this.logger.warn('schema id ignored', schema.id);
+    return schema.$id;
+  }
+
+
+  function _get$IdOrId(schema) {
+    if (schema.$id && schema.id && schema.$id != schema.id)
+      throw new Error('schema $id is different from id');
+    return schema.$id || schema.id;
+  }
+
+
+  /**
+   * Convert array of error message objects to string
+   * @this   Ajv
+   * @param  {Array<Object>} errors optional array of validation errors, if not passed errors from the instance are used.
+   * @param  {Object} options optional options with properties `separator` and `dataVar`.
+   * @return {String} human readable string with all errors descriptions
+   */
+  function errorsText(errors, options) {
+    errors = errors || this.errors;
+    if (!errors) return 'No errors';
+    options = options || {};
+    var separator = options.separator === undefined ? ', ' : options.separator;
+    var dataVar = options.dataVar === undefined ? 'data' : options.dataVar;
+
+    var text = '';
+    for (var i=0; i<errors.length; i++) {
+      var e = errors[i];
+      if (e) text += dataVar + e.dataPath + ' ' + e.message + separator;
+    }
+    return text.slice(0, -separator.length);
+  }
+
+
+  /**
+   * Add custom format
+   * @this   Ajv
+   * @param {String} name format name
+   * @param {String|RegExp|Function} format string is converted to RegExp; function should return boolean (true when valid)
+   * @return {Ajv} this for method chaining
+   */
+  function addFormat(name, format) {
+    if (typeof format == 'string') format = new RegExp(format);
+    this._formats[name] = format;
+    return this;
+  }
+
+
+  function addDefaultMetaSchema(self) {
+    var $dataSchema;
+    if (self._opts.$data) {
+      $dataSchema = require('./refs/data.json');
+      self.addMetaSchema($dataSchema, $dataSchema.$id, true);
+    }
+    if (self._opts.meta === false) return;
+    var metaSchema = require('./refs/json-schema-draft-07.json');
+    if (self._opts.$data) metaSchema = $dataMetaSchema(metaSchema, META_SUPPORT_DATA);
+    self.addMetaSchema(metaSchema, META_SCHEMA_ID, true);
+    self._refs['http://json-schema.org/schema'] = META_SCHEMA_ID;
+  }
+
+
+  function addInitialSchemas(self) {
+    var optsSchemas = self._opts.schemas;
+    if (!optsSchemas) return;
+    if (Array.isArray(optsSchemas)) self.addSchema(optsSchemas);
+    else for (var key in optsSchemas) self.addSchema(optsSchemas[key], key);
+  }
+
+
+  function addInitialFormats(self) {
+    for (var name in self._opts.formats) {
+      var format = self._opts.formats[name];
+      self.addFormat(name, format);
+    }
+  }
+
+
+  function addInitialKeywords(self) {
+    for (var name in self._opts.keywords) {
+      var keyword = self._opts.keywords[name];
+      self.addKeyword(name, keyword);
+    }
+  }
+
+
+  function checkUnique(self, id) {
+    if (self._schemas[id] || self._refs[id])
+      throw new Error('schema with key or id "' + id + '" already exists');
+  }
+
+
+  function getMetaSchemaOptions(self) {
+    var metaOpts = util.copy(self._opts);
+    for (var i=0; i<META_IGNORE_OPTIONS.length; i++)
+      delete metaOpts[META_IGNORE_OPTIONS[i]];
+    return metaOpts;
+  }
+
+
+  function setLogger(self) {
+    var logger = self._opts.logger;
+    if (logger === false) {
+      self.logger = {log: noop, warn: noop, error: noop};
+    } else {
+      if (logger === undefined) logger = console;
+      if (!(typeof logger == 'object' && logger.log && logger.warn && logger.error))
+        throw new Error('logger must implement log, warn and error methods');
+      self.logger = logger;
+    }
+  }
+
+
+  function noop() {}
+
+  },{"./cache":2,"./compile":6,"./compile/async":3,"./compile/error_classes":4,"./compile/formats":5,"./compile/resolve":7,"./compile/rules":8,"./compile/schema_obj":9,"./compile/util":11,"./data":12,"./keyword":40,"./refs/data.json":41,"./refs/json-schema-draft-07.json":42,"fast-json-stable-stringify":44}],2:[function(require,module,exports){
+  'use strict';
+
+
+  var Cache = module.exports = function Cache() {
+    this._cache = {};
+  };
+
+
+  Cache.prototype.put = function Cache_put(key, value) {
+    this._cache[key] = value;
+  };
+
+
+  Cache.prototype.get = function Cache_get(key) {
+    return this._cache[key];
+  };
+
+
+  Cache.prototype.del = function Cache_del(key) {
+    delete this._cache[key];
+  };
+
+
+  Cache.prototype.clear = function Cache_clear() {
+    this._cache = {};
+  };
+
+  },{}],3:[function(require,module,exports){
+  'use strict';
+
+  var MissingRefError = require('./error_classes').MissingRef;
+
+  module.exports = compileAsync;
+
+
+  /**
+   * Creates validating function for passed schema with asynchronous loading of missing schemas.
+   * `loadSchema` option should be a function that accepts schema uri and returns promise that resolves with the schema.
+   * @this  Ajv
+   * @param {Object}   schema schema object
+   * @param {Boolean}  meta optional true to compile meta-schema; this parameter can be skipped
+   * @param {Function} callback an optional node-style callback, it is called with 2 parameters: error (or null) and validating function.
+   * @return {Promise} promise that resolves with a validating function.
+   */
+  function compileAsync(schema, meta, callback) {
+    /* eslint no-shadow: 0 */
+    /* global Promise */
+    /* jshint validthis: true */
+    var self = this;
+    if (typeof this._opts.loadSchema != 'function')
+      throw new Error('options.loadSchema should be a function');
+
+    if (typeof meta == 'function') {
+      callback = meta;
+      meta = undefined;
+    }
+
+    var p = loadMetaSchemaOf(schema).then(function () {
+      var schemaObj = self._addSchema(schema, undefined, meta);
+      return schemaObj.validate || _compileAsync(schemaObj);
+    });
+
+    if (callback) {
+      p.then(
+        function(v) { callback(null, v); },
+        callback
+      );
+    }
+
+    return p;
+
+
+    function loadMetaSchemaOf(sch) {
+      var $schema = sch.$schema;
+      return $schema && !self.getSchema($schema)
+              ? compileAsync.call(self, { $ref: $schema }, true)
+              : Promise.resolve();
+    }
+
+
+    function _compileAsync(schemaObj) {
+      try { return self._compile(schemaObj); }
+      catch(e) {
+        if (e instanceof MissingRefError) return loadMissingSchema(e);
+        throw e;
+      }
+
+
+      function loadMissingSchema(e) {
+        var ref = e.missingSchema;
+        if (added(ref)) throw new Error('Schema ' + ref + ' is loaded but ' + e.missingRef + ' cannot be resolved');
+
+        var schemaPromise = self._loadingSchemas[ref];
+        if (!schemaPromise) {
+          schemaPromise = self._loadingSchemas[ref] = self._opts.loadSchema(ref);
+          schemaPromise.then(removePromise, removePromise);
+        }
+
+        return schemaPromise.then(function (sch) {
+          if (!added(ref)) {
+            return loadMetaSchemaOf(sch).then(function () {
+              if (!added(ref)) self.addSchema(sch, ref, undefined, meta);
+            });
+          }
+        }).then(function() {
+          return _compileAsync(schemaObj);
+        });
+
+        function removePromise() {
+          delete self._loadingSchemas[ref];
+        }
+
+        function added(ref) {
+          return self._refs[ref] || self._schemas[ref];
+        }
+      }
+    }
+  }
+
+  },{"./error_classes":4}],4:[function(require,module,exports){
+  'use strict';
+
+  var resolve = require('./resolve');
+
+  module.exports = {
+    Validation: errorSubclass(ValidationError),
+    MissingRef: errorSubclass(MissingRefError)
+  };
+
+
+  function ValidationError(errors) {
+    this.message = 'validation failed';
+    this.errors = errors;
+    this.ajv = this.validation = true;
+  }
+
+
+  MissingRefError.message = function (baseId, ref) {
+    return 'can\'t resolve reference ' + ref + ' from id ' + baseId;
+  };
+
+
+  function MissingRefError(baseId, ref, message) {
+    this.message = message || MissingRefError.message(baseId, ref);
+    this.missingRef = resolve.url(baseId, ref);
+    this.missingSchema = resolve.normalizeId(resolve.fullPath(this.missingRef));
+  }
+
+
+  function errorSubclass(Subclass) {
+    Subclass.prototype = Object.create(Error.prototype);
+    Subclass.prototype.constructor = Subclass;
+    return Subclass;
+  }
+
+  },{"./resolve":7}],5:[function(require,module,exports){
+  'use strict';
+
+  var util = require('./util');
+
+  var DATE = /^(\d\d\d\d)-(\d\d)-(\d\d)$/;
+  var DAYS = [0,31,28,31,30,31,30,31,31,30,31,30,31];
+  var TIME = /^(\d\d):(\d\d):(\d\d)(\.\d+)?(z|[+-]\d\d(?::?\d\d)?)?$/i;
+  var HOSTNAME = /^(?=.{1,253}\.?$)[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[-0-9a-z]{0,61}[0-9a-z])?)*\.?$/i;
+  var URI = /^(?:[a-z][a-z0-9+\-.]*:)(?:\/?\/(?:(?:[a-z0-9\-._~!$&'()*+,;=:]|%[0-9a-f]{2})*@)?(?:\[(?:(?:(?:(?:[0-9a-f]{1,4}:){6}|::(?:[0-9a-f]{1,4}:){5}|(?:[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){4}|(?:(?:[0-9a-f]{1,4}:){0,1}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){3}|(?:(?:[0-9a-f]{1,4}:){0,2}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){2}|(?:(?:[0-9a-f]{1,4}:){0,3}[0-9a-f]{1,4})?::[0-9a-f]{1,4}:|(?:(?:[0-9a-f]{1,4}:){0,4}[0-9a-f]{1,4})?::)(?:[0-9a-f]{1,4}:[0-9a-f]{1,4}|(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?))|(?:(?:[0-9a-f]{1,4}:){0,5}[0-9a-f]{1,4})?::[0-9a-f]{1,4}|(?:(?:[0-9a-f]{1,4}:){0,6}[0-9a-f]{1,4})?::)|[Vv][0-9a-f]+\.[a-z0-9\-._~!$&'()*+,;=:]+)\]|(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)|(?:[a-z0-9\-._~!$&'()*+,;=]|%[0-9a-f]{2})*)(?::\d*)?(?:\/(?:[a-z0-9\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})*)*|\/(?:(?:[a-z0-9\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})+(?:\/(?:[a-z0-9\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})*)*)?|(?:[a-z0-9\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})+(?:\/(?:[a-z0-9\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})*)*)(?:\?(?:[a-z0-9\-._~!$&'()*+,;=:@/?]|%[0-9a-f]{2})*)?(?:#(?:[a-z0-9\-._~!$&'()*+,;=:@/?]|%[0-9a-f]{2})*)?$/i;
+  var URIREF = /^(?:[a-z][a-z0-9+\-.]*:)?(?:\/?\/(?:(?:[a-z0-9\-._~!$&'()*+,;=:]|%[0-9a-f]{2})*@)?(?:\[(?:(?:(?:(?:[0-9a-f]{1,4}:){6}|::(?:[0-9a-f]{1,4}:){5}|(?:[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){4}|(?:(?:[0-9a-f]{1,4}:){0,1}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){3}|(?:(?:[0-9a-f]{1,4}:){0,2}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){2}|(?:(?:[0-9a-f]{1,4}:){0,3}[0-9a-f]{1,4})?::[0-9a-f]{1,4}:|(?:(?:[0-9a-f]{1,4}:){0,4}[0-9a-f]{1,4})?::)(?:[0-9a-f]{1,4}:[0-9a-f]{1,4}|(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?))|(?:(?:[0-9a-f]{1,4}:){0,5}[0-9a-f]{1,4})?::[0-9a-f]{1,4}|(?:(?:[0-9a-f]{1,4}:){0,6}[0-9a-f]{1,4})?::)|[Vv][0-9a-f]+\.[a-z0-9\-._~!$&'()*+,;=:]+)\]|(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)|(?:[a-z0-9\-._~!$&'"()*+,;=]|%[0-9a-f]{2})*)(?::\d*)?(?:\/(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})*)*|\/(?:(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})+(?:\/(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})*)*)?|(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})+(?:\/(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})*)*)?(?:\?(?:[a-z0-9\-._~!$&'"()*+,;=:@/?]|%[0-9a-f]{2})*)?(?:#(?:[a-z0-9\-._~!$&'"()*+,;=:@/?]|%[0-9a-f]{2})*)?$/i;
+  // uri-template: https://tools.ietf.org/html/rfc6570
+  var URITEMPLATE = /^(?:(?:[^\x00-\x20"'<>%\\^`{|}]|%[0-9a-f]{2})|\{[+#./;?&=,!@|]?(?:[a-z0-9_]|%[0-9a-f]{2})+(?::[1-9][0-9]{0,3}|\*)?(?:,(?:[a-z0-9_]|%[0-9a-f]{2})+(?::[1-9][0-9]{0,3}|\*)?)*\})*$/i;
+  // For the source: https://gist.github.com/dperini/729294
+  // For test cases: https://mathiasbynens.be/demo/url-regex
+  // @todo Delete current URL in favour of the commented out URL rule when this issue is fixed https://github.com/eslint/eslint/issues/7983.
+  // var URL = /^(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!10(?:\.\d{1,3}){3})(?!127(?:\.\d{1,3}){3})(?!169\.254(?:\.\d{1,3}){2})(?!192\.168(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u{00a1}-\u{ffff}0-9]+-?)*[a-z\u{00a1}-\u{ffff}0-9]+)(?:\.(?:[a-z\u{00a1}-\u{ffff}0-9]+-?)*[a-z\u{00a1}-\u{ffff}0-9]+)*(?:\.(?:[a-z\u{00a1}-\u{ffff}]{2,})))(?::\d{2,5})?(?:\/[^\s]*)?$/iu;
+  var URL = /^(?:(?:http[s\u017F]?|ftp):\/\/)(?:(?:[\0-\x08\x0E-\x1F!-\x9F\xA1-\u167F\u1681-\u1FFF\u200B-\u2027\u202A-\u202E\u2030-\u205E\u2060-\u2FFF\u3001-\uD7FF\uE000-\uFEFE\uFF00-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])+(?::(?:[\0-\x08\x0E-\x1F!-\x9F\xA1-\u167F\u1681-\u1FFF\u200B-\u2027\u202A-\u202E\u2030-\u205E\u2060-\u2FFF\u3001-\uD7FF\uE000-\uFEFE\uFF00-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])*)?@)?(?:(?!10(?:\.[0-9]{1,3}){3})(?!127(?:\.[0-9]{1,3}){3})(?!169\.254(?:\.[0-9]{1,3}){2})(?!192\.168(?:\.[0-9]{1,3}){2})(?!172\.(?:1[6-9]|2[0-9]|3[01])(?:\.[0-9]{1,3}){2})(?:[1-9][0-9]?|1[0-9][0-9]|2[01][0-9]|22[0-3])(?:\.(?:1?[0-9]{1,2}|2[0-4][0-9]|25[0-5])){2}(?:\.(?:[1-9][0-9]?|1[0-9][0-9]|2[0-4][0-9]|25[0-4]))|(?:(?:(?:[0-9KSa-z\xA1-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])+-?)*(?:[0-9KSa-z\xA1-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])+)(?:\.(?:(?:[0-9KSa-z\xA1-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])+-?)*(?:[0-9KSa-z\xA1-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])+)*(?:\.(?:(?:[KSa-z\xA1-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]){2,})))(?::[0-9]{2,5})?(?:\/(?:[\0-\x08\x0E-\x1F!-\x9F\xA1-\u167F\u1681-\u1FFF\u200B-\u2027\u202A-\u202E\u2030-\u205E\u2060-\u2FFF\u3001-\uD7FF\uE000-\uFEFE\uFF00-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])*)?$/i;
+  var UUID = /^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i;
+  var JSON_POINTER = /^(?:\/(?:[^~/]|~0|~1)*)*$/;
+  var JSON_POINTER_URI_FRAGMENT = /^#(?:\/(?:[a-z0-9_\-.!$&'()*+,;:=@]|%[0-9a-f]{2}|~0|~1)*)*$/i;
+  var RELATIVE_JSON_POINTER = /^(?:0|[1-9][0-9]*)(?:#|(?:\/(?:[^~/]|~0|~1)*)*)$/;
+
+
+  module.exports = formats;
+
+  function formats(mode) {
+    mode = mode == 'full' ? 'full' : 'fast';
+    return util.copy(formats[mode]);
+  }
+
+
+  formats.fast = {
+    // date: http://tools.ietf.org/html/rfc3339#section-5.6
+    date: /^\d\d\d\d-[0-1]\d-[0-3]\d$/,
+    // date-time: http://tools.ietf.org/html/rfc3339#section-5.6
+    time: /^(?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?(?:z|[+-]\d\d(?::?\d\d)?)?$/i,
+    'date-time': /^\d\d\d\d-[0-1]\d-[0-3]\d[t\s](?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?(?:z|[+-]\d\d(?::?\d\d)?)$/i,
+    // uri: https://github.com/mafintosh/is-my-json-valid/blob/master/formats.js
+    uri: /^(?:[a-z][a-z0-9+\-.]*:)(?:\/?\/)?[^\s]*$/i,
+    'uri-reference': /^(?:(?:[a-z][a-z0-9+\-.]*:)?\/?\/)?(?:[^\\\s#][^\s#]*)?(?:#[^\\\s]*)?$/i,
+    'uri-template': URITEMPLATE,
+    url: URL,
+    // email (sources from jsen validator):
+    // http://stackoverflow.com/questions/201323/using-a-regular-expression-to-validate-an-email-address#answer-8829363
+    // http://www.w3.org/TR/html5/forms.html#valid-e-mail-address (search for 'willful violation')
+    email: /^[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/i,
+    hostname: HOSTNAME,
+    // optimized https://www.safaribooksonline.com/library/view/regular-expressions-cookbook/9780596802837/ch07s16.html
+    ipv4: /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)$/,
+    // optimized http://stackoverflow.com/questions/53497/regular-expression-that-matches-valid-ipv6-addresses
+    ipv6: /^\s*(?:(?:(?:[0-9a-f]{1,4}:){7}(?:[0-9a-f]{1,4}|:))|(?:(?:[0-9a-f]{1,4}:){6}(?::[0-9a-f]{1,4}|(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(?:(?:[0-9a-f]{1,4}:){5}(?:(?:(?::[0-9a-f]{1,4}){1,2})|:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(?:(?:[0-9a-f]{1,4}:){4}(?:(?:(?::[0-9a-f]{1,4}){1,3})|(?:(?::[0-9a-f]{1,4})?:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[0-9a-f]{1,4}:){3}(?:(?:(?::[0-9a-f]{1,4}){1,4})|(?:(?::[0-9a-f]{1,4}){0,2}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[0-9a-f]{1,4}:){2}(?:(?:(?::[0-9a-f]{1,4}){1,5})|(?:(?::[0-9a-f]{1,4}){0,3}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[0-9a-f]{1,4}:){1}(?:(?:(?::[0-9a-f]{1,4}){1,6})|(?:(?::[0-9a-f]{1,4}){0,4}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?::(?:(?:(?::[0-9a-f]{1,4}){1,7})|(?:(?::[0-9a-f]{1,4}){0,5}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(?:%.+)?\s*$/i,
+    regex: regex,
+    // uuid: http://tools.ietf.org/html/rfc4122
+    uuid: UUID,
+    // JSON-pointer: https://tools.ietf.org/html/rfc6901
+    // uri fragment: https://tools.ietf.org/html/rfc3986#appendix-A
+    'json-pointer': JSON_POINTER,
+    'json-pointer-uri-fragment': JSON_POINTER_URI_FRAGMENT,
+    // relative JSON-pointer: http://tools.ietf.org/html/draft-luff-relative-json-pointer-00
+    'relative-json-pointer': RELATIVE_JSON_POINTER
+  };
+
+
+  formats.full = {
+    date: date,
+    time: time,
+    'date-time': date_time,
+    uri: uri,
+    'uri-reference': URIREF,
+    'uri-template': URITEMPLATE,
+    url: URL,
+    email: /^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i,
+    hostname: HOSTNAME,
+    ipv4: /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)$/,
+    ipv6: /^\s*(?:(?:(?:[0-9a-f]{1,4}:){7}(?:[0-9a-f]{1,4}|:))|(?:(?:[0-9a-f]{1,4}:){6}(?::[0-9a-f]{1,4}|(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(?:(?:[0-9a-f]{1,4}:){5}(?:(?:(?::[0-9a-f]{1,4}){1,2})|:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(?:(?:[0-9a-f]{1,4}:){4}(?:(?:(?::[0-9a-f]{1,4}){1,3})|(?:(?::[0-9a-f]{1,4})?:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[0-9a-f]{1,4}:){3}(?:(?:(?::[0-9a-f]{1,4}){1,4})|(?:(?::[0-9a-f]{1,4}){0,2}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[0-9a-f]{1,4}:){2}(?:(?:(?::[0-9a-f]{1,4}){1,5})|(?:(?::[0-9a-f]{1,4}){0,3}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[0-9a-f]{1,4}:){1}(?:(?:(?::[0-9a-f]{1,4}){1,6})|(?:(?::[0-9a-f]{1,4}){0,4}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?::(?:(?:(?::[0-9a-f]{1,4}){1,7})|(?:(?::[0-9a-f]{1,4}){0,5}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(?:%.+)?\s*$/i,
+    regex: regex,
+    uuid: UUID,
+    'json-pointer': JSON_POINTER,
+    'json-pointer-uri-fragment': JSON_POINTER_URI_FRAGMENT,
+    'relative-json-pointer': RELATIVE_JSON_POINTER
+  };
+
+
+  function isLeapYear(year) {
+    // https://tools.ietf.org/html/rfc3339#appendix-C
+    return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  }
+
+
+  function date(str) {
+    // full-date from http://tools.ietf.org/html/rfc3339#section-5.6
+    var matches = str.match(DATE);
+    if (!matches) return false;
+
+    var year = +matches[1];
+    var month = +matches[2];
+    var day = +matches[3];
+
+    return month >= 1 && month <= 12 && day >= 1 &&
+            day <= (month == 2 && isLeapYear(year) ? 29 : DAYS[month]);
+  }
+
+
+  function time(str, full) {
+    var matches = str.match(TIME);
+    if (!matches) return false;
+
+    var hour = matches[1];
+    var minute = matches[2];
+    var second = matches[3];
+    var timeZone = matches[5];
+    return ((hour <= 23 && minute <= 59 && second <= 59) ||
+            (hour == 23 && minute == 59 && second == 60)) &&
+           (!full || timeZone);
+  }
+
+
+  var DATE_TIME_SEPARATOR = /t|\s/i;
+  function date_time(str) {
+    // http://tools.ietf.org/html/rfc3339#section-5.6
+    var dateTime = str.split(DATE_TIME_SEPARATOR);
+    return dateTime.length == 2 && date(dateTime[0]) && time(dateTime[1], true);
+  }
+
+
+  var NOT_URI_FRAGMENT = /\/|:/;
+  function uri(str) {
+    // http://jmrware.com/articles/2009/uri_regexp/URI_regex.html + optional protocol + required "."
+    return NOT_URI_FRAGMENT.test(str) && URI.test(str);
+  }
+
+
+  var Z_ANCHOR = /[^\\]\\Z/;
+  function regex(str) {
+    if (Z_ANCHOR.test(str)) return false;
+    try {
+      new RegExp(str);
+      return true;
+    } catch(e) {
+      return false;
+    }
+  }
+
+  },{"./util":11}],6:[function(require,module,exports){
+  'use strict';
+
+  var resolve = require('./resolve')
+    , util = require('./util')
+    , errorClasses = require('./error_classes')
+    , stableStringify = require('fast-json-stable-stringify');
+
+  var validateGenerator = require('../dotjs/validate');
+
+  /**
+   * Functions below are used inside compiled validations function
+   */
+
+  var ucs2length = util.ucs2length;
+  var equal = require('fast-deep-equal');
+
+  // this error is thrown by async schemas to return validation errors via exception
+  var ValidationError = errorClasses.Validation;
+
+  module.exports = compile;
+
+
+  /**
+   * Compiles schema to validation function
+   * @this   Ajv
+   * @param  {Object} schema schema object
+   * @param  {Object} root object with information about the root schema for this schema
+   * @param  {Object} localRefs the hash of local references inside the schema (created by resolve.id), used for inline resolution
+   * @param  {String} baseId base ID for IDs in the schema
+   * @return {Function} validation function
+   */
+  function compile(schema, root, localRefs, baseId) {
+    /* jshint validthis: true, evil: true */
+    /* eslint no-shadow: 0 */
+    var self = this
+      , opts = this._opts
+      , refVal = [ undefined ]
+      , refs = {}
+      , patterns = []
+      , patternsHash = {}
+      , defaults = []
+      , defaultsHash = {}
+      , customRules = [];
+
+    root = root || { schema: schema, refVal: refVal, refs: refs };
+
+    var c = checkCompiling.call(this, schema, root, baseId);
+    var compilation = this._compilations[c.index];
+    if (c.compiling) return (compilation.callValidate = callValidate);
+
+    var formats = this._formats;
+    var RULES = this.RULES;
+
+    try {
+      var v = localCompile(schema, root, localRefs, baseId);
+      compilation.validate = v;
+      var cv = compilation.callValidate;
+      if (cv) {
+        cv.schema = v.schema;
+        cv.errors = null;
+        cv.refs = v.refs;
+        cv.refVal = v.refVal;
+        cv.root = v.root;
+        cv.$async = v.$async;
+        if (opts.sourceCode) cv.source = v.source;
+      }
+      return v;
+    } finally {
+      endCompiling.call(this, schema, root, baseId);
+    }
+
+    /* @this   {*} - custom context, see passContext option */
+    function callValidate() {
+      /* jshint validthis: true */
+      var validate = compilation.validate;
+      var result = validate.apply(this, arguments);
+      callValidate.errors = validate.errors;
+      return result;
+    }
+
+    function localCompile(_schema, _root, localRefs, baseId) {
+      var isRoot = !_root || (_root && _root.schema == _schema);
+      if (_root.schema != root.schema)
+        return compile.call(self, _schema, _root, localRefs, baseId);
+
+      var $async = _schema.$async === true;
+
+      var sourceCode = validateGenerator({
+        isTop: true,
+        schema: _schema,
+        isRoot: isRoot,
+        baseId: baseId,
+        root: _root,
+        schemaPath: '',
+        errSchemaPath: '#',
+        errorPath: '""',
+        MissingRefError: errorClasses.MissingRef,
+        RULES: RULES,
+        validate: validateGenerator,
+        util: util,
+        resolve: resolve,
+        resolveRef: resolveRef,
+        usePattern: usePattern,
+        useDefault: useDefault,
+        useCustomRule: useCustomRule,
+        opts: opts,
+        formats: formats,
+        logger: self.logger,
+        self: self
+      });
+
+      sourceCode = vars(refVal, refValCode) + vars(patterns, patternCode)
+                     + vars(defaults, defaultCode) + vars(customRules, customRuleCode)
+                     + sourceCode;
+
+      if (opts.processCode) sourceCode = opts.processCode(sourceCode, _schema);
+      // console.log('\n\n\n *** \n', JSON.stringify(sourceCode));
+      var validate;
+      try {
+        var makeValidate = new Function(
+          'self',
+          'RULES',
+          'formats',
+          'root',
+          'refVal',
+          'defaults',
+          'customRules',
+          'equal',
+          'ucs2length',
+          'ValidationError',
+          sourceCode
+        );
+
+        validate = makeValidate(
+          self,
+          RULES,
+          formats,
+          root,
+          refVal,
+          defaults,
+          customRules,
+          equal,
+          ucs2length,
+          ValidationError
+        );
+
+        refVal[0] = validate;
+      } catch(e) {
+        self.logger.error('Error compiling schema, function code:', sourceCode);
+        throw e;
+      }
+
+      validate.schema = _schema;
+      validate.errors = null;
+      validate.refs = refs;
+      validate.refVal = refVal;
+      validate.root = isRoot ? validate : _root;
+      if ($async) validate.$async = true;
+      if (opts.sourceCode === true) {
+        validate.source = {
+          code: sourceCode,
+          patterns: patterns,
+          defaults: defaults
+        };
+      }
+
+      return validate;
+    }
+
+    function resolveRef(baseId, ref, isRoot) {
+      ref = resolve.url(baseId, ref);
+      var refIndex = refs[ref];
+      var _refVal, refCode;
+      if (refIndex !== undefined) {
+        _refVal = refVal[refIndex];
+        refCode = 'refVal[' + refIndex + ']';
+        return resolvedRef(_refVal, refCode);
+      }
+      if (!isRoot && root.refs) {
+        var rootRefId = root.refs[ref];
+        if (rootRefId !== undefined) {
+          _refVal = root.refVal[rootRefId];
+          refCode = addLocalRef(ref, _refVal);
+          return resolvedRef(_refVal, refCode);
+        }
+      }
+
+      refCode = addLocalRef(ref);
+      var v = resolve.call(self, localCompile, root, ref);
+      if (v === undefined) {
+        var localSchema = localRefs && localRefs[ref];
+        if (localSchema) {
+          v = resolve.inlineRef(localSchema, opts.inlineRefs)
+              ? localSchema
+              : compile.call(self, localSchema, root, localRefs, baseId);
+        }
+      }
+
+      if (v === undefined) {
+        removeLocalRef(ref);
+      } else {
+        replaceLocalRef(ref, v);
+        return resolvedRef(v, refCode);
+      }
+    }
+
+    function addLocalRef(ref, v) {
+      var refId = refVal.length;
+      refVal[refId] = v;
+      refs[ref] = refId;
+      return 'refVal' + refId;
+    }
+
+    function removeLocalRef(ref) {
+      delete refs[ref];
+    }
+
+    function replaceLocalRef(ref, v) {
+      var refId = refs[ref];
+      refVal[refId] = v;
+    }
+
+    function resolvedRef(refVal, code) {
+      return typeof refVal == 'object' || typeof refVal == 'boolean'
+              ? { code: code, schema: refVal, inline: true }
+              : { code: code, $async: refVal && !!refVal.$async };
+    }
+
+    function usePattern(regexStr) {
+      var index = patternsHash[regexStr];
+      if (index === undefined) {
+        index = patternsHash[regexStr] = patterns.length;
+        patterns[index] = regexStr;
+      }
+      return 'pattern' + index;
+    }
+
+    function useDefault(value) {
+      switch (typeof value) {
+        case 'boolean':
+        case 'number':
+          return '' + value;
+        case 'string':
+          return util.toQuotedString(value);
+        case 'object':
+          if (value === null) return 'null';
+          var valueStr = stableStringify(value);
+          var index = defaultsHash[valueStr];
+          if (index === undefined) {
+            index = defaultsHash[valueStr] = defaults.length;
+            defaults[index] = value;
+          }
+          return 'default' + index;
+      }
+    }
+
+    function useCustomRule(rule, schema, parentSchema, it) {
+      if (self._opts.validateSchema !== false) {
+        var deps = rule.definition.dependencies;
+        if (deps && !deps.every(function(keyword) {
+          return Object.prototype.hasOwnProperty.call(parentSchema, keyword);
+        }))
+          throw new Error('parent schema must have all required keywords: ' + deps.join(','));
+
+        var validateSchema = rule.definition.validateSchema;
+        if (validateSchema) {
+          var valid = validateSchema(schema);
+          if (!valid) {
+            var message = 'keyword schema is invalid: ' + self.errorsText(validateSchema.errors);
+            if (self._opts.validateSchema == 'log') self.logger.error(message);
+            else throw new Error(message);
+          }
+        }
+      }
+
+      var compile = rule.definition.compile
+        , inline = rule.definition.inline
+        , macro = rule.definition.macro;
+
+      var validate;
+      if (compile) {
+        validate = compile.call(self, schema, parentSchema, it);
+      } else if (macro) {
+        validate = macro.call(self, schema, parentSchema, it);
+        if (opts.validateSchema !== false) self.validateSchema(validate, true);
+      } else if (inline) {
+        validate = inline.call(self, it, rule.keyword, schema, parentSchema);
+      } else {
+        validate = rule.definition.validate;
+        if (!validate) return;
+      }
+
+      if (validate === undefined)
+        throw new Error('custom keyword "' + rule.keyword + '"failed to compile');
+
+      var index = customRules.length;
+      customRules[index] = validate;
+
+      return {
+        code: 'customRule' + index,
+        validate: validate
+      };
+    }
+  }
+
+
+  /**
+   * Checks if the schema is currently compiled
+   * @this   Ajv
+   * @param  {Object} schema schema to compile
+   * @param  {Object} root root object
+   * @param  {String} baseId base schema ID
+   * @return {Object} object with properties "index" (compilation index) and "compiling" (boolean)
+   */
+  function checkCompiling(schema, root, baseId) {
+    /* jshint validthis: true */
+    var index = compIndex.call(this, schema, root, baseId);
+    if (index >= 0) return { index: index, compiling: true };
+    index = this._compilations.length;
+    this._compilations[index] = {
+      schema: schema,
+      root: root,
+      baseId: baseId
+    };
+    return { index: index, compiling: false };
+  }
+
+
+  /**
+   * Removes the schema from the currently compiled list
+   * @this   Ajv
+   * @param  {Object} schema schema to compile
+   * @param  {Object} root root object
+   * @param  {String} baseId base schema ID
+   */
+  function endCompiling(schema, root, baseId) {
+    /* jshint validthis: true */
+    var i = compIndex.call(this, schema, root, baseId);
+    if (i >= 0) this._compilations.splice(i, 1);
+  }
+
+
+  /**
+   * Index of schema compilation in the currently compiled list
+   * @this   Ajv
+   * @param  {Object} schema schema to compile
+   * @param  {Object} root root object
+   * @param  {String} baseId base schema ID
+   * @return {Integer} compilation index
+   */
+  function compIndex(schema, root, baseId) {
+    /* jshint validthis: true */
+    for (var i=0; i<this._compilations.length; i++) {
+      var c = this._compilations[i];
+      if (c.schema == schema && c.root == root && c.baseId == baseId) return i;
+    }
+    return -1;
+  }
+
+
+  function patternCode(i, patterns) {
+    return 'var pattern' + i + ' = new RegExp(' + util.toQuotedString(patterns[i]) + ');';
+  }
+
+
+  function defaultCode(i) {
+    return 'var default' + i + ' = defaults[' + i + '];';
+  }
+
+
+  function refValCode(i, refVal) {
+    return refVal[i] === undefined ? '' : 'var refVal' + i + ' = refVal[' + i + '];';
+  }
+
+
+  function customRuleCode(i) {
+    return 'var customRule' + i + ' = customRules[' + i + '];';
+  }
+
+
+  function vars(arr, statement) {
+    if (!arr.length) return '';
+    var code = '';
+    for (var i=0; i<arr.length; i++)
+      code += statement(i, arr);
+    return code;
+  }
+
+  },{"../dotjs/validate":39,"./error_classes":4,"./resolve":7,"./util":11,"fast-deep-equal":43,"fast-json-stable-stringify":44}],7:[function(require,module,exports){
+  'use strict';
+
+  var URI = require('uri-js')
+    , equal = require('fast-deep-equal')
+    , util = require('./util')
+    , SchemaObject = require('./schema_obj')
+    , traverse = require('json-schema-traverse');
+
+  module.exports = resolve;
+
+  resolve.normalizeId = normalizeId;
+  resolve.fullPath = getFullPath;
+  resolve.url = resolveUrl;
+  resolve.ids = resolveIds;
+  resolve.inlineRef = inlineRef;
+  resolve.schema = resolveSchema;
+
+  /**
+   * [resolve and compile the references ($ref)]
+   * @this   Ajv
+   * @param  {Function} compile reference to schema compilation funciton (localCompile)
+   * @param  {Object} root object with information about the root schema for the current schema
+   * @param  {String} ref reference to resolve
+   * @return {Object|Function} schema object (if the schema can be inlined) or validation function
+   */
+  function resolve(compile, root, ref) {
+    /* jshint validthis: true */
+    var refVal = this._refs[ref];
+    if (typeof refVal == 'string') {
+      if (this._refs[refVal]) refVal = this._refs[refVal];
+      else return resolve.call(this, compile, root, refVal);
+    }
+
+    refVal = refVal || this._schemas[ref];
+    if (refVal instanceof SchemaObject) {
+      return inlineRef(refVal.schema, this._opts.inlineRefs)
+              ? refVal.schema
+              : refVal.validate || this._compile(refVal);
+    }
+
+    var res = resolveSchema.call(this, root, ref);
+    var schema, v, baseId;
+    if (res) {
+      schema = res.schema;
+      root = res.root;
+      baseId = res.baseId;
+    }
+
+    if (schema instanceof SchemaObject) {
+      v = schema.validate || compile.call(this, schema.schema, root, undefined, baseId);
+    } else if (schema !== undefined) {
+      v = inlineRef(schema, this._opts.inlineRefs)
+          ? schema
+          : compile.call(this, schema, root, undefined, baseId);
+    }
+
+    return v;
+  }
+
+
+  /**
+   * Resolve schema, its root and baseId
+   * @this Ajv
+   * @param  {Object} root root object with properties schema, refVal, refs
+   * @param  {String} ref  reference to resolve
+   * @return {Object} object with properties schema, root, baseId
+   */
+  function resolveSchema(root, ref) {
+    /* jshint validthis: true */
+    var p = URI.parse(ref)
+      , refPath = _getFullPath(p)
+      , baseId = getFullPath(this._getId(root.schema));
+    if (Object.keys(root.schema).length === 0 || refPath !== baseId) {
+      var id = normalizeId(refPath);
+      var refVal = this._refs[id];
+      if (typeof refVal == 'string') {
+        return resolveRecursive.call(this, root, refVal, p);
+      } else if (refVal instanceof SchemaObject) {
+        if (!refVal.validate) this._compile(refVal);
+        root = refVal;
+      } else {
+        refVal = this._schemas[id];
+        if (refVal instanceof SchemaObject) {
+          if (!refVal.validate) this._compile(refVal);
+          if (id == normalizeId(ref))
+            return { schema: refVal, root: root, baseId: baseId };
+          root = refVal;
+        } else {
+          return;
+        }
+      }
+      if (!root.schema) return;
+      baseId = getFullPath(this._getId(root.schema));
+    }
+    return getJsonPointer.call(this, p, baseId, root.schema, root);
+  }
+
+
+  /* @this Ajv */
+  function resolveRecursive(root, ref, parsedRef) {
+    /* jshint validthis: true */
+    var res = resolveSchema.call(this, root, ref);
+    if (res) {
+      var schema = res.schema;
+      var baseId = res.baseId;
+      root = res.root;
+      var id = this._getId(schema);
+      if (id) baseId = resolveUrl(baseId, id);
+      return getJsonPointer.call(this, parsedRef, baseId, schema, root);
+    }
+  }
+
+
+  var PREVENT_SCOPE_CHANGE = util.toHash(['properties', 'patternProperties', 'enum', 'dependencies', 'definitions']);
+  /* @this Ajv */
+  function getJsonPointer(parsedRef, baseId, schema, root) {
+    /* jshint validthis: true */
+    parsedRef.fragment = parsedRef.fragment || '';
+    if (parsedRef.fragment.slice(0,1) != '/') return;
+    var parts = parsedRef.fragment.split('/');
+
+    for (var i = 1; i < parts.length; i++) {
+      var part = parts[i];
+      if (part) {
+        part = util.unescapeFragment(part);
+        schema = schema[part];
+        if (schema === undefined) break;
+        var id;
+        if (!PREVENT_SCOPE_CHANGE[part]) {
+          id = this._getId(schema);
+          if (id) baseId = resolveUrl(baseId, id);
+          if (schema.$ref) {
+            var $ref = resolveUrl(baseId, schema.$ref);
+            var res = resolveSchema.call(this, root, $ref);
+            if (res) {
+              schema = res.schema;
+              root = res.root;
+              baseId = res.baseId;
+            }
+          }
+        }
+      }
+    }
+    if (schema !== undefined && schema !== root.schema)
+      return { schema: schema, root: root, baseId: baseId };
+  }
+
+
+  var SIMPLE_INLINED = util.toHash([
+    'type', 'format', 'pattern',
+    'maxLength', 'minLength',
+    'maxProperties', 'minProperties',
+    'maxItems', 'minItems',
+    'maximum', 'minimum',
+    'uniqueItems', 'multipleOf',
+    'required', 'enum'
+  ]);
+  function inlineRef(schema, limit) {
+    if (limit === false) return false;
+    if (limit === undefined || limit === true) return checkNoRef(schema);
+    else if (limit) return countKeys(schema) <= limit;
+  }
+
+
+  function checkNoRef(schema) {
+    var item;
+    if (Array.isArray(schema)) {
+      for (var i=0; i<schema.length; i++) {
+        item = schema[i];
+        if (typeof item == 'object' && !checkNoRef(item)) return false;
+      }
+    } else {
+      for (var key in schema) {
+        if (key == '$ref') return false;
+        item = schema[key];
+        if (typeof item == 'object' && !checkNoRef(item)) return false;
+      }
+    }
+    return true;
+  }
+
+
+  function countKeys(schema) {
+    var count = 0, item;
+    if (Array.isArray(schema)) {
+      for (var i=0; i<schema.length; i++) {
+        item = schema[i];
+        if (typeof item == 'object') count += countKeys(item);
+        if (count == Infinity) return Infinity;
+      }
+    } else {
+      for (var key in schema) {
+        if (key == '$ref') return Infinity;
+        if (SIMPLE_INLINED[key]) {
+          count++;
+        } else {
+          item = schema[key];
+          if (typeof item == 'object') count += countKeys(item) + 1;
+          if (count == Infinity) return Infinity;
+        }
+      }
+    }
+    return count;
+  }
+
+
+  function getFullPath(id, normalize) {
+    if (normalize !== false) id = normalizeId(id);
+    var p = URI.parse(id);
+    return _getFullPath(p);
+  }
+
+
+  function _getFullPath(p) {
+    return URI.serialize(p).split('#')[0] + '#';
+  }
+
+
+  var TRAILING_SLASH_HASH = /#\/?$/;
+  function normalizeId(id) {
+    return id ? id.replace(TRAILING_SLASH_HASH, '') : '';
+  }
+
+
+  function resolveUrl(baseId, id) {
+    id = normalizeId(id);
+    return URI.resolve(baseId, id);
+  }
+
+
+  /* @this Ajv */
+  function resolveIds(schema) {
+    var schemaId = normalizeId(this._getId(schema));
+    var baseIds = {'': schemaId};
+    var fullPaths = {'': getFullPath(schemaId, false)};
+    var localRefs = {};
+    var self = this;
+
+    traverse(schema, {allKeys: true}, function(sch, jsonPtr, rootSchema, parentJsonPtr, parentKeyword, parentSchema, keyIndex) {
+      if (jsonPtr === '') return;
+      var id = self._getId(sch);
+      var baseId = baseIds[parentJsonPtr];
+      var fullPath = fullPaths[parentJsonPtr] + '/' + parentKeyword;
+      if (keyIndex !== undefined)
+        fullPath += '/' + (typeof keyIndex == 'number' ? keyIndex : util.escapeFragment(keyIndex));
+
+      if (typeof id == 'string') {
+        id = baseId = normalizeId(baseId ? URI.resolve(baseId, id) : id);
+
+        var refVal = self._refs[id];
+        if (typeof refVal == 'string') refVal = self._refs[refVal];
+        if (refVal && refVal.schema) {
+          if (!equal(sch, refVal.schema))
+            throw new Error('id "' + id + '" resolves to more than one schema');
+        } else if (id != normalizeId(fullPath)) {
+          if (id[0] == '#') {
+            if (localRefs[id] && !equal(sch, localRefs[id]))
+              throw new Error('id "' + id + '" resolves to more than one schema');
+            localRefs[id] = sch;
+          } else {
+            self._refs[id] = fullPath;
+          }
+        }
+      }
+      baseIds[jsonPtr] = baseId;
+      fullPaths[jsonPtr] = fullPath;
+    });
+
+    return localRefs;
+  }
+
+  },{"./schema_obj":9,"./util":11,"fast-deep-equal":43,"json-schema-traverse":45,"uri-js":46}],8:[function(require,module,exports){
+  'use strict';
+
+  var ruleModules = require('../dotjs')
+    , toHash = require('./util').toHash;
+
+  module.exports = function rules() {
+    var RULES = [
+      { type: 'number',
+        rules: [ { 'maximum': ['exclusiveMaximum'] },
+                 { 'minimum': ['exclusiveMinimum'] }, 'multipleOf', 'format'] },
+      { type: 'string',
+        rules: [ 'maxLength', 'minLength', 'pattern', 'format' ] },
+      { type: 'array',
+        rules: [ 'maxItems', 'minItems', 'items', 'contains', 'uniqueItems' ] },
+      { type: 'object',
+        rules: [ 'maxProperties', 'minProperties', 'required', 'dependencies', 'propertyNames',
+                 { 'properties': ['additionalProperties', 'patternProperties'] } ] },
+      { rules: [ '$ref', 'const', 'enum', 'not', 'anyOf', 'oneOf', 'allOf', 'if' ] }
+    ];
+
+    var ALL = [ 'type', '$comment' ];
+    var KEYWORDS = [
+      '$schema', '$id', 'id', '$data', '$async', 'title',
+      'description', 'default', 'definitions',
+      'examples', 'readOnly', 'writeOnly',
+      'contentMediaType', 'contentEncoding',
+      'additionalItems', 'then', 'else'
+    ];
+    var TYPES = [ 'number', 'integer', 'string', 'array', 'object', 'boolean', 'null' ];
+    RULES.all = toHash(ALL);
+    RULES.types = toHash(TYPES);
+
+    RULES.forEach(function (group) {
+      group.rules = group.rules.map(function (keyword) {
+        var implKeywords;
+        if (typeof keyword == 'object') {
+          var key = Object.keys(keyword)[0];
+          implKeywords = keyword[key];
+          keyword = key;
+          implKeywords.forEach(function (k) {
+            ALL.push(k);
+            RULES.all[k] = true;
+          });
+        }
+        ALL.push(keyword);
+        var rule = RULES.all[keyword] = {
+          keyword: keyword,
+          code: ruleModules[keyword],
+          implements: implKeywords
+        };
+        return rule;
+      });
+
+      RULES.all.$comment = {
+        keyword: '$comment',
+        code: ruleModules.$comment
+      };
+
+      if (group.type) RULES.types[group.type] = group;
+    });
+
+    RULES.keywords = toHash(ALL.concat(KEYWORDS));
+    RULES.custom = {};
+
+    return RULES;
+  };
+
+  },{"../dotjs":28,"./util":11}],9:[function(require,module,exports){
+  'use strict';
+
+  var util = require('./util');
+
+  module.exports = SchemaObject;
+
+  function SchemaObject(obj) {
+    util.copy(obj, this);
+  }
+
+  },{"./util":11}],10:[function(require,module,exports){
+  'use strict';
+
+  // https://mathiasbynens.be/notes/javascript-encoding
+  // https://github.com/bestiejs/punycode.js - punycode.ucs2.decode
+  module.exports = function ucs2length(str) {
+    var length = 0
+      , len = str.length
+      , pos = 0
+      , value;
+    while (pos < len) {
+      length++;
+      value = str.charCodeAt(pos++);
+      if (value >= 0xD800 && value <= 0xDBFF && pos < len) {
+        // high surrogate, and there is a next character
+        value = str.charCodeAt(pos);
+        if ((value & 0xFC00) == 0xDC00) pos++; // low surrogate
+      }
+    }
+    return length;
+  };
+
+  },{}],11:[function(require,module,exports){
+  'use strict';
+
+
+  module.exports = {
+    copy: copy,
+    checkDataType: checkDataType,
+    checkDataTypes: checkDataTypes,
+    coerceToTypes: coerceToTypes,
+    toHash: toHash,
+    getProperty: getProperty,
+    escapeQuotes: escapeQuotes,
+    equal: require('fast-deep-equal'),
+    ucs2length: require('./ucs2length'),
+    varOccurences: varOccurences,
+    varReplace: varReplace,
+    schemaHasRules: schemaHasRules,
+    schemaHasRulesExcept: schemaHasRulesExcept,
+    schemaUnknownRules: schemaUnknownRules,
+    toQuotedString: toQuotedString,
+    getPathExpr: getPathExpr,
+    getPath: getPath,
+    getData: getData,
+    unescapeFragment: unescapeFragment,
+    unescapeJsonPointer: unescapeJsonPointer,
+    escapeFragment: escapeFragment,
+    escapeJsonPointer: escapeJsonPointer
+  };
+
+
+  function copy(o, to) {
+    to = to || {};
+    for (var key in o) to[key] = o[key];
+    return to;
+  }
+
+
+  function checkDataType(dataType, data, strictNumbers, negate) {
+    var EQUAL = negate ? ' !== ' : ' === '
+      , AND = negate ? ' || ' : ' && '
+      , OK = negate ? '!' : ''
+      , NOT = negate ? '' : '!';
+    switch (dataType) {
+      case 'null': return data + EQUAL + 'null';
+      case 'array': return OK + 'Array.isArray(' + data + ')';
+      case 'object': return '(' + OK + data + AND +
+                            'typeof ' + data + EQUAL + '"object"' + AND +
+                            NOT + 'Array.isArray(' + data + '))';
+      case 'integer': return '(typeof ' + data + EQUAL + '"number"' + AND +
+                             NOT + '(' + data + ' % 1)' +
+                             AND + data + EQUAL + data +
+                             (strictNumbers ? (AND + OK + 'isFinite(' + data + ')') : '') + ')';
+      case 'number': return '(typeof ' + data + EQUAL + '"' + dataType + '"' +
+                            (strictNumbers ? (AND + OK + 'isFinite(' + data + ')') : '') + ')';
+      default: return 'typeof ' + data + EQUAL + '"' + dataType + '"';
+    }
+  }
+
+
+  function checkDataTypes(dataTypes, data, strictNumbers) {
+    switch (dataTypes.length) {
+      case 1: return checkDataType(dataTypes[0], data, strictNumbers, true);
+      default:
+        var code = '';
+        var types = toHash(dataTypes);
+        if (types.array && types.object) {
+          code = types.null ? '(': '(!' + data + ' || ';
+          code += 'typeof ' + data + ' !== "object")';
+          delete types.null;
+          delete types.array;
+          delete types.object;
+        }
+        if (types.number) delete types.integer;
+        for (var t in types)
+          code += (code ? ' && ' : '' ) + checkDataType(t, data, strictNumbers, true);
+
+        return code;
+    }
+  }
+
+
+  var COERCE_TO_TYPES = toHash([ 'string', 'number', 'integer', 'boolean', 'null' ]);
+  function coerceToTypes(optionCoerceTypes, dataTypes) {
+    if (Array.isArray(dataTypes)) {
+      var types = [];
+      for (var i=0; i<dataTypes.length; i++) {
+        var t = dataTypes[i];
+        if (COERCE_TO_TYPES[t]) types[types.length] = t;
+        else if (optionCoerceTypes === 'array' && t === 'array') types[types.length] = t;
+      }
+      if (types.length) return types;
+    } else if (COERCE_TO_TYPES[dataTypes]) {
+      return [dataTypes];
+    } else if (optionCoerceTypes === 'array' && dataTypes === 'array') {
+      return ['array'];
+    }
+  }
+
+
+  function toHash(arr) {
+    var hash = {};
+    for (var i=0; i<arr.length; i++) hash[arr[i]] = true;
+    return hash;
+  }
+
+
+  var IDENTIFIER = /^[a-z$_][a-z$_0-9]*$/i;
+  var SINGLE_QUOTE = /'|\\/g;
+  function getProperty(key) {
+    return typeof key == 'number'
+            ? '[' + key + ']'
+            : IDENTIFIER.test(key)
+              ? '.' + key
+              : "['" + escapeQuotes(key) + "']";
+  }
+
+
+  function escapeQuotes(str) {
+    return str.replace(SINGLE_QUOTE, '\\$&')
+              .replace(/\n/g, '\\n')
+              .replace(/\r/g, '\\r')
+              .replace(/\f/g, '\\f')
+              .replace(/\t/g, '\\t');
+  }
+
+
+  function varOccurences(str, dataVar) {
+    dataVar += '[^0-9]';
+    var matches = str.match(new RegExp(dataVar, 'g'));
+    return matches ? matches.length : 0;
+  }
+
+
+  function varReplace(str, dataVar, expr) {
+    dataVar += '([^0-9])';
+    expr = expr.replace(/\$/g, '$$$$');
+    return str.replace(new RegExp(dataVar, 'g'), expr + '$1');
+  }
+
+
+  function schemaHasRules(schema, rules) {
+    if (typeof schema == 'boolean') return !schema;
+    for (var key in schema) if (rules[key]) return true;
+  }
+
+
+  function schemaHasRulesExcept(schema, rules, exceptKeyword) {
+    if (typeof schema == 'boolean') return !schema && exceptKeyword != 'not';
+    for (var key in schema) if (key != exceptKeyword && rules[key]) return true;
+  }
+
+
+  function schemaUnknownRules(schema, rules) {
+    if (typeof schema == 'boolean') return;
+    for (var key in schema) if (!rules[key]) return key;
+  }
+
+
+  function toQuotedString(str) {
+    return '\'' + escapeQuotes(str) + '\'';
+  }
+
+
+  function getPathExpr(currentPath, expr, jsonPointers, isNumber) {
+    var path = jsonPointers // false by default
+                ? '\'/\' + ' + expr + (isNumber ? '' : '.replace(/~/g, \'~0\').replace(/\\//g, \'~1\')')
+                : (isNumber ? '\'[\' + ' + expr + ' + \']\'' : '\'[\\\'\' + ' + expr + ' + \'\\\']\'');
+    return joinPaths(currentPath, path);
+  }
+
+
+  function getPath(currentPath, prop, jsonPointers) {
+    var path = jsonPointers // false by default
+                ? toQuotedString('/' + escapeJsonPointer(prop))
+                : toQuotedString(getProperty(prop));
+    return joinPaths(currentPath, path);
+  }
+
+
+  var JSON_POINTER = /^\/(?:[^~]|~0|~1)*$/;
+  var RELATIVE_JSON_POINTER = /^([0-9]+)(#|\/(?:[^~]|~0|~1)*)?$/;
+  function getData($data, lvl, paths) {
+    var up, jsonPointer, data, matches;
+    if ($data === '') return 'rootData';
+    if ($data[0] == '/') {
+      if (!JSON_POINTER.test($data)) throw new Error('Invalid JSON-pointer: ' + $data);
+      jsonPointer = $data;
+      data = 'rootData';
+    } else {
+      matches = $data.match(RELATIVE_JSON_POINTER);
+      if (!matches) throw new Error('Invalid JSON-pointer: ' + $data);
+      up = +matches[1];
+      jsonPointer = matches[2];
+      if (jsonPointer == '#') {
+        if (up >= lvl) throw new Error('Cannot access property/index ' + up + ' levels up, current level is ' + lvl);
+        return paths[lvl - up];
+      }
+
+      if (up > lvl) throw new Error('Cannot access data ' + up + ' levels up, current level is ' + lvl);
+      data = 'data' + ((lvl - up) || '');
+      if (!jsonPointer) return data;
+    }
+
+    var expr = data;
+    var segments = jsonPointer.split('/');
+    for (var i=0; i<segments.length; i++) {
+      var segment = segments[i];
+      if (segment) {
+        data += getProperty(unescapeJsonPointer(segment));
+        expr += ' && ' + data;
+      }
+    }
+    return expr;
+  }
+
+
+  function joinPaths (a, b) {
+    if (a == '""') return b;
+    return (a + ' + ' + b).replace(/([^\\])' \+ '/g, '$1');
+  }
+
+
+  function unescapeFragment(str) {
+    return unescapeJsonPointer(decodeURIComponent(str));
+  }
+
+
+  function escapeFragment(str) {
+    return encodeURIComponent(escapeJsonPointer(str));
+  }
+
+
+  function escapeJsonPointer(str) {
+    return str.replace(/~/g, '~0').replace(/\//g, '~1');
+  }
+
+
+  function unescapeJsonPointer(str) {
+    return str.replace(/~1/g, '/').replace(/~0/g, '~');
+  }
+
+  },{"./ucs2length":10,"fast-deep-equal":43}],12:[function(require,module,exports){
+  'use strict';
+
+  var KEYWORDS = [
+    'multipleOf',
+    'maximum',
+    'exclusiveMaximum',
+    'minimum',
+    'exclusiveMinimum',
+    'maxLength',
+    'minLength',
+    'pattern',
+    'additionalItems',
+    'maxItems',
+    'minItems',
+    'uniqueItems',
+    'maxProperties',
+    'minProperties',
+    'required',
+    'additionalProperties',
+    'enum',
+    'format',
+    'const'
+  ];
+
+  module.exports = function (metaSchema, keywordsJsonPointers) {
+    for (var i=0; i<keywordsJsonPointers.length; i++) {
+      metaSchema = JSON.parse(JSON.stringify(metaSchema));
+      var segments = keywordsJsonPointers[i].split('/');
+      var keywords = metaSchema;
+      var j;
+      for (j=1; j<segments.length; j++)
+        keywords = keywords[segments[j]];
+
+      for (j=0; j<KEYWORDS.length; j++) {
+        var key = KEYWORDS[j];
+        var schema = keywords[key];
+        if (schema) {
+          keywords[key] = {
+            anyOf: [
+              schema,
+              { $ref: 'https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#' }
+            ]
+          };
+        }
+      }
+    }
+
+    return metaSchema;
+  };
+
+  },{}],13:[function(require,module,exports){
+  'use strict';
+
+  var metaSchema = require('./refs/json-schema-draft-07.json');
+
+  module.exports = {
+    $id: 'https://github.com/ajv-validator/ajv/blob/master/lib/definition_schema.js',
+    definitions: {
+      simpleTypes: metaSchema.definitions.simpleTypes
+    },
+    type: 'object',
+    dependencies: {
+      schema: ['validate'],
+      $data: ['validate'],
+      statements: ['inline'],
+      valid: {not: {required: ['macro']}}
+    },
+    properties: {
+      type: metaSchema.properties.type,
+      schema: {type: 'boolean'},
+      statements: {type: 'boolean'},
+      dependencies: {
+        type: 'array',
+        items: {type: 'string'}
+      },
+      metaSchema: {type: 'object'},
+      modifying: {type: 'boolean'},
+      valid: {type: 'boolean'},
+      $data: {type: 'boolean'},
+      async: {type: 'boolean'},
+      errors: {
+        anyOf: [
+          {type: 'boolean'},
+          {const: 'full'}
+        ]
+      }
+    }
+  };
+
+  },{"./refs/json-schema-draft-07.json":42}],14:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate__limit(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $errorKeyword;
+    var $data = 'data' + ($dataLvl || '');
+    var $isData = it.opts.$data && $schema && $schema.$data,
+      $schemaValue;
+    if ($isData) {
+      out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
+      $schemaValue = 'schema' + $lvl;
+    } else {
+      $schemaValue = $schema;
+    }
+    var $isMax = $keyword == 'maximum',
+      $exclusiveKeyword = $isMax ? 'exclusiveMaximum' : 'exclusiveMinimum',
+      $schemaExcl = it.schema[$exclusiveKeyword],
+      $isDataExcl = it.opts.$data && $schemaExcl && $schemaExcl.$data,
+      $op = $isMax ? '<' : '>',
+      $notOp = $isMax ? '>' : '<',
+      $errorKeyword = undefined;
+    if (!($isData || typeof $schema == 'number' || $schema === undefined)) {
+      throw new Error($keyword + ' must be number');
+    }
+    if (!($isDataExcl || $schemaExcl === undefined || typeof $schemaExcl == 'number' || typeof $schemaExcl == 'boolean')) {
+      throw new Error($exclusiveKeyword + ' must be number or boolean');
+    }
+    if ($isDataExcl) {
+      var $schemaValueExcl = it.util.getData($schemaExcl.$data, $dataLvl, it.dataPathArr),
+        $exclusive = 'exclusive' + $lvl,
+        $exclType = 'exclType' + $lvl,
+        $exclIsNumber = 'exclIsNumber' + $lvl,
+        $opExpr = 'op' + $lvl,
+        $opStr = '\' + ' + $opExpr + ' + \'';
+      out += ' var schemaExcl' + ($lvl) + ' = ' + ($schemaValueExcl) + '; ';
+      $schemaValueExcl = 'schemaExcl' + $lvl;
+      out += ' var ' + ($exclusive) + '; var ' + ($exclType) + ' = typeof ' + ($schemaValueExcl) + '; if (' + ($exclType) + ' != \'boolean\' && ' + ($exclType) + ' != \'undefined\' && ' + ($exclType) + ' != \'number\') { ';
+      var $errorKeyword = $exclusiveKeyword;
+      var $$outStack = $$outStack || [];
+      $$outStack.push(out);
+      out = ''; /* istanbul ignore else */
+      if (it.createErrors !== false) {
+        out += ' { keyword: \'' + ($errorKeyword || '_exclusiveLimit') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: {} ';
+        if (it.opts.messages !== false) {
+          out += ' , message: \'' + ($exclusiveKeyword) + ' should be boolean\' ';
+        }
+        if (it.opts.verbose) {
+          out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+        }
+        out += ' } ';
+      } else {
+        out += ' {} ';
+      }
+      var __err = out;
+      out = $$outStack.pop();
+      if (!it.compositeRule && $breakOnError) {
+        /* istanbul ignore if */
+        if (it.async) {
+          out += ' throw new ValidationError([' + (__err) + ']); ';
+        } else {
+          out += ' validate.errors = [' + (__err) + ']; return false; ';
+        }
+      } else {
+        out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+      }
+      out += ' } else if ( ';
+      if ($isData) {
+        out += ' (' + ($schemaValue) + ' !== undefined && typeof ' + ($schemaValue) + ' != \'number\') || ';
+      }
+      out += ' ' + ($exclType) + ' == \'number\' ? ( (' + ($exclusive) + ' = ' + ($schemaValue) + ' === undefined || ' + ($schemaValueExcl) + ' ' + ($op) + '= ' + ($schemaValue) + ') ? ' + ($data) + ' ' + ($notOp) + '= ' + ($schemaValueExcl) + ' : ' + ($data) + ' ' + ($notOp) + ' ' + ($schemaValue) + ' ) : ( (' + ($exclusive) + ' = ' + ($schemaValueExcl) + ' === true) ? ' + ($data) + ' ' + ($notOp) + '= ' + ($schemaValue) + ' : ' + ($data) + ' ' + ($notOp) + ' ' + ($schemaValue) + ' ) || ' + ($data) + ' !== ' + ($data) + ') { var op' + ($lvl) + ' = ' + ($exclusive) + ' ? \'' + ($op) + '\' : \'' + ($op) + '=\'; ';
+      if ($schema === undefined) {
+        $errorKeyword = $exclusiveKeyword;
+        $errSchemaPath = it.errSchemaPath + '/' + $exclusiveKeyword;
+        $schemaValue = $schemaValueExcl;
+        $isData = $isDataExcl;
+      }
+    } else {
+      var $exclIsNumber = typeof $schemaExcl == 'number',
+        $opStr = $op;
+      if ($exclIsNumber && $isData) {
+        var $opExpr = '\'' + $opStr + '\'';
+        out += ' if ( ';
+        if ($isData) {
+          out += ' (' + ($schemaValue) + ' !== undefined && typeof ' + ($schemaValue) + ' != \'number\') || ';
+        }
+        out += ' ( ' + ($schemaValue) + ' === undefined || ' + ($schemaExcl) + ' ' + ($op) + '= ' + ($schemaValue) + ' ? ' + ($data) + ' ' + ($notOp) + '= ' + ($schemaExcl) + ' : ' + ($data) + ' ' + ($notOp) + ' ' + ($schemaValue) + ' ) || ' + ($data) + ' !== ' + ($data) + ') { ';
+      } else {
+        if ($exclIsNumber && $schema === undefined) {
+          $exclusive = true;
+          $errorKeyword = $exclusiveKeyword;
+          $errSchemaPath = it.errSchemaPath + '/' + $exclusiveKeyword;
+          $schemaValue = $schemaExcl;
+          $notOp += '=';
+        } else {
+          if ($exclIsNumber) $schemaValue = Math[$isMax ? 'min' : 'max']($schemaExcl, $schema);
+          if ($schemaExcl === ($exclIsNumber ? $schemaValue : true)) {
+            $exclusive = true;
+            $errorKeyword = $exclusiveKeyword;
+            $errSchemaPath = it.errSchemaPath + '/' + $exclusiveKeyword;
+            $notOp += '=';
+          } else {
+            $exclusive = false;
+            $opStr += '=';
+          }
+        }
+        var $opExpr = '\'' + $opStr + '\'';
+        out += ' if ( ';
+        if ($isData) {
+          out += ' (' + ($schemaValue) + ' !== undefined && typeof ' + ($schemaValue) + ' != \'number\') || ';
+        }
+        out += ' ' + ($data) + ' ' + ($notOp) + ' ' + ($schemaValue) + ' || ' + ($data) + ' !== ' + ($data) + ') { ';
+      }
+    }
+    $errorKeyword = $errorKeyword || $keyword;
+    var $$outStack = $$outStack || [];
+    $$outStack.push(out);
+    out = ''; /* istanbul ignore else */
+    if (it.createErrors !== false) {
+      out += ' { keyword: \'' + ($errorKeyword || '_limit') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { comparison: ' + ($opExpr) + ', limit: ' + ($schemaValue) + ', exclusive: ' + ($exclusive) + ' } ';
+      if (it.opts.messages !== false) {
+        out += ' , message: \'should be ' + ($opStr) + ' ';
+        if ($isData) {
+          out += '\' + ' + ($schemaValue);
+        } else {
+          out += '' + ($schemaValue) + '\'';
+        }
+      }
+      if (it.opts.verbose) {
+        out += ' , schema:  ';
+        if ($isData) {
+          out += 'validate.schema' + ($schemaPath);
+        } else {
+          out += '' + ($schema);
+        }
+        out += '         , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+      }
+      out += ' } ';
+    } else {
+      out += ' {} ';
+    }
+    var __err = out;
+    out = $$outStack.pop();
+    if (!it.compositeRule && $breakOnError) {
+      /* istanbul ignore if */
+      if (it.async) {
+        out += ' throw new ValidationError([' + (__err) + ']); ';
+      } else {
+        out += ' validate.errors = [' + (__err) + ']; return false; ';
+      }
+    } else {
+      out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+    }
+    out += ' } ';
+    if ($breakOnError) {
+      out += ' else { ';
+    }
+    return out;
+  }
+
+  },{}],15:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate__limitItems(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $errorKeyword;
+    var $data = 'data' + ($dataLvl || '');
+    var $isData = it.opts.$data && $schema && $schema.$data,
+      $schemaValue;
+    if ($isData) {
+      out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
+      $schemaValue = 'schema' + $lvl;
+    } else {
+      $schemaValue = $schema;
+    }
+    if (!($isData || typeof $schema == 'number')) {
+      throw new Error($keyword + ' must be number');
+    }
+    var $op = $keyword == 'maxItems' ? '>' : '<';
+    out += 'if ( ';
+    if ($isData) {
+      out += ' (' + ($schemaValue) + ' !== undefined && typeof ' + ($schemaValue) + ' != \'number\') || ';
+    }
+    out += ' ' + ($data) + '.length ' + ($op) + ' ' + ($schemaValue) + ') { ';
+    var $errorKeyword = $keyword;
+    var $$outStack = $$outStack || [];
+    $$outStack.push(out);
+    out = ''; /* istanbul ignore else */
+    if (it.createErrors !== false) {
+      out += ' { keyword: \'' + ($errorKeyword || '_limitItems') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { limit: ' + ($schemaValue) + ' } ';
+      if (it.opts.messages !== false) {
+        out += ' , message: \'should NOT have ';
+        if ($keyword == 'maxItems') {
+          out += 'more';
+        } else {
+          out += 'fewer';
+        }
+        out += ' than ';
+        if ($isData) {
+          out += '\' + ' + ($schemaValue) + ' + \'';
+        } else {
+          out += '' + ($schema);
+        }
+        out += ' items\' ';
+      }
+      if (it.opts.verbose) {
+        out += ' , schema:  ';
+        if ($isData) {
+          out += 'validate.schema' + ($schemaPath);
+        } else {
+          out += '' + ($schema);
+        }
+        out += '         , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+      }
+      out += ' } ';
+    } else {
+      out += ' {} ';
+    }
+    var __err = out;
+    out = $$outStack.pop();
+    if (!it.compositeRule && $breakOnError) {
+      /* istanbul ignore if */
+      if (it.async) {
+        out += ' throw new ValidationError([' + (__err) + ']); ';
+      } else {
+        out += ' validate.errors = [' + (__err) + ']; return false; ';
+      }
+    } else {
+      out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+    }
+    out += '} ';
+    if ($breakOnError) {
+      out += ' else { ';
+    }
+    return out;
+  }
+
+  },{}],16:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate__limitLength(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $errorKeyword;
+    var $data = 'data' + ($dataLvl || '');
+    var $isData = it.opts.$data && $schema && $schema.$data,
+      $schemaValue;
+    if ($isData) {
+      out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
+      $schemaValue = 'schema' + $lvl;
+    } else {
+      $schemaValue = $schema;
+    }
+    if (!($isData || typeof $schema == 'number')) {
+      throw new Error($keyword + ' must be number');
+    }
+    var $op = $keyword == 'maxLength' ? '>' : '<';
+    out += 'if ( ';
+    if ($isData) {
+      out += ' (' + ($schemaValue) + ' !== undefined && typeof ' + ($schemaValue) + ' != \'number\') || ';
+    }
+    if (it.opts.unicode === false) {
+      out += ' ' + ($data) + '.length ';
+    } else {
+      out += ' ucs2length(' + ($data) + ') ';
+    }
+    out += ' ' + ($op) + ' ' + ($schemaValue) + ') { ';
+    var $errorKeyword = $keyword;
+    var $$outStack = $$outStack || [];
+    $$outStack.push(out);
+    out = ''; /* istanbul ignore else */
+    if (it.createErrors !== false) {
+      out += ' { keyword: \'' + ($errorKeyword || '_limitLength') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { limit: ' + ($schemaValue) + ' } ';
+      if (it.opts.messages !== false) {
+        out += ' , message: \'should NOT be ';
+        if ($keyword == 'maxLength') {
+          out += 'longer';
+        } else {
+          out += 'shorter';
+        }
+        out += ' than ';
+        if ($isData) {
+          out += '\' + ' + ($schemaValue) + ' + \'';
+        } else {
+          out += '' + ($schema);
+        }
+        out += ' characters\' ';
+      }
+      if (it.opts.verbose) {
+        out += ' , schema:  ';
+        if ($isData) {
+          out += 'validate.schema' + ($schemaPath);
+        } else {
+          out += '' + ($schema);
+        }
+        out += '         , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+      }
+      out += ' } ';
+    } else {
+      out += ' {} ';
+    }
+    var __err = out;
+    out = $$outStack.pop();
+    if (!it.compositeRule && $breakOnError) {
+      /* istanbul ignore if */
+      if (it.async) {
+        out += ' throw new ValidationError([' + (__err) + ']); ';
+      } else {
+        out += ' validate.errors = [' + (__err) + ']; return false; ';
+      }
+    } else {
+      out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+    }
+    out += '} ';
+    if ($breakOnError) {
+      out += ' else { ';
+    }
+    return out;
+  }
+
+  },{}],17:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate__limitProperties(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $errorKeyword;
+    var $data = 'data' + ($dataLvl || '');
+    var $isData = it.opts.$data && $schema && $schema.$data,
+      $schemaValue;
+    if ($isData) {
+      out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
+      $schemaValue = 'schema' + $lvl;
+    } else {
+      $schemaValue = $schema;
+    }
+    if (!($isData || typeof $schema == 'number')) {
+      throw new Error($keyword + ' must be number');
+    }
+    var $op = $keyword == 'maxProperties' ? '>' : '<';
+    out += 'if ( ';
+    if ($isData) {
+      out += ' (' + ($schemaValue) + ' !== undefined && typeof ' + ($schemaValue) + ' != \'number\') || ';
+    }
+    out += ' Object.keys(' + ($data) + ').length ' + ($op) + ' ' + ($schemaValue) + ') { ';
+    var $errorKeyword = $keyword;
+    var $$outStack = $$outStack || [];
+    $$outStack.push(out);
+    out = ''; /* istanbul ignore else */
+    if (it.createErrors !== false) {
+      out += ' { keyword: \'' + ($errorKeyword || '_limitProperties') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { limit: ' + ($schemaValue) + ' } ';
+      if (it.opts.messages !== false) {
+        out += ' , message: \'should NOT have ';
+        if ($keyword == 'maxProperties') {
+          out += 'more';
+        } else {
+          out += 'fewer';
+        }
+        out += ' than ';
+        if ($isData) {
+          out += '\' + ' + ($schemaValue) + ' + \'';
+        } else {
+          out += '' + ($schema);
+        }
+        out += ' properties\' ';
+      }
+      if (it.opts.verbose) {
+        out += ' , schema:  ';
+        if ($isData) {
+          out += 'validate.schema' + ($schemaPath);
+        } else {
+          out += '' + ($schema);
+        }
+        out += '         , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+      }
+      out += ' } ';
+    } else {
+      out += ' {} ';
+    }
+    var __err = out;
+    out = $$outStack.pop();
+    if (!it.compositeRule && $breakOnError) {
+      /* istanbul ignore if */
+      if (it.async) {
+        out += ' throw new ValidationError([' + (__err) + ']); ';
+      } else {
+        out += ' validate.errors = [' + (__err) + ']; return false; ';
+      }
+    } else {
+      out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+    }
+    out += '} ';
+    if ($breakOnError) {
+      out += ' else { ';
+    }
+    return out;
+  }
+
+  },{}],18:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_allOf(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $it = it.util.copy(it);
+    var $closingBraces = '';
+    $it.level++;
+    var $nextValid = 'valid' + $it.level;
+    var $currentBaseId = $it.baseId,
+      $allSchemasEmpty = true;
+    var arr1 = $schema;
+    if (arr1) {
+      var $sch, $i = -1,
+        l1 = arr1.length - 1;
+      while ($i < l1) {
+        $sch = arr1[$i += 1];
+        if ((it.opts.strictKeywords ? (typeof $sch == 'object' && Object.keys($sch).length > 0) || $sch === false : it.util.schemaHasRules($sch, it.RULES.all))) {
+          $allSchemasEmpty = false;
+          $it.schema = $sch;
+          $it.schemaPath = $schemaPath + '[' + $i + ']';
+          $it.errSchemaPath = $errSchemaPath + '/' + $i;
+          out += '  ' + (it.validate($it)) + ' ';
+          $it.baseId = $currentBaseId;
+          if ($breakOnError) {
+            out += ' if (' + ($nextValid) + ') { ';
+            $closingBraces += '}';
+          }
+        }
+      }
+    }
+    if ($breakOnError) {
+      if ($allSchemasEmpty) {
+        out += ' if (true) { ';
+      } else {
+        out += ' ' + ($closingBraces.slice(0, -1)) + ' ';
+      }
+    }
+    return out;
+  }
+
+  },{}],19:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_anyOf(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $data = 'data' + ($dataLvl || '');
+    var $valid = 'valid' + $lvl;
+    var $errs = 'errs__' + $lvl;
+    var $it = it.util.copy(it);
+    var $closingBraces = '';
+    $it.level++;
+    var $nextValid = 'valid' + $it.level;
+    var $noEmptySchema = $schema.every(function($sch) {
+      return (it.opts.strictKeywords ? (typeof $sch == 'object' && Object.keys($sch).length > 0) || $sch === false : it.util.schemaHasRules($sch, it.RULES.all));
+    });
+    if ($noEmptySchema) {
+      var $currentBaseId = $it.baseId;
+      out += ' var ' + ($errs) + ' = errors; var ' + ($valid) + ' = false;  ';
+      var $wasComposite = it.compositeRule;
+      it.compositeRule = $it.compositeRule = true;
+      var arr1 = $schema;
+      if (arr1) {
+        var $sch, $i = -1,
+          l1 = arr1.length - 1;
+        while ($i < l1) {
+          $sch = arr1[$i += 1];
+          $it.schema = $sch;
+          $it.schemaPath = $schemaPath + '[' + $i + ']';
+          $it.errSchemaPath = $errSchemaPath + '/' + $i;
+          out += '  ' + (it.validate($it)) + ' ';
+          $it.baseId = $currentBaseId;
+          out += ' ' + ($valid) + ' = ' + ($valid) + ' || ' + ($nextValid) + '; if (!' + ($valid) + ') { ';
+          $closingBraces += '}';
+        }
+      }
+      it.compositeRule = $it.compositeRule = $wasComposite;
+      out += ' ' + ($closingBraces) + ' if (!' + ($valid) + ') {   var err =   '; /* istanbul ignore else */
+      if (it.createErrors !== false) {
+        out += ' { keyword: \'' + ('anyOf') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: {} ';
+        if (it.opts.messages !== false) {
+          out += ' , message: \'should match some schema in anyOf\' ';
+        }
+        if (it.opts.verbose) {
+          out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+        }
+        out += ' } ';
+      } else {
+        out += ' {} ';
+      }
+      out += ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+      if (!it.compositeRule && $breakOnError) {
+        /* istanbul ignore if */
+        if (it.async) {
+          out += ' throw new ValidationError(vErrors); ';
+        } else {
+          out += ' validate.errors = vErrors; return false; ';
+        }
+      }
+      out += ' } else {  errors = ' + ($errs) + '; if (vErrors !== null) { if (' + ($errs) + ') vErrors.length = ' + ($errs) + '; else vErrors = null; } ';
+      if (it.opts.allErrors) {
+        out += ' } ';
+      }
+    } else {
+      if ($breakOnError) {
+        out += ' if (true) { ';
+      }
+    }
+    return out;
+  }
+
+  },{}],20:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_comment(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $schema = it.schema[$keyword];
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $comment = it.util.toQuotedString($schema);
+    if (it.opts.$comment === true) {
+      out += ' console.log(' + ($comment) + ');';
+    } else if (typeof it.opts.$comment == 'function') {
+      out += ' self._opts.$comment(' + ($comment) + ', ' + (it.util.toQuotedString($errSchemaPath)) + ', validate.root.schema);';
+    }
+    return out;
+  }
+
+  },{}],21:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_const(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $data = 'data' + ($dataLvl || '');
+    var $valid = 'valid' + $lvl;
+    var $isData = it.opts.$data && $schema && $schema.$data,
+      $schemaValue;
+    if ($isData) {
+      out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
+      $schemaValue = 'schema' + $lvl;
+    } else {
+      $schemaValue = $schema;
+    }
+    if (!$isData) {
+      out += ' var schema' + ($lvl) + ' = validate.schema' + ($schemaPath) + ';';
+    }
+    out += 'var ' + ($valid) + ' = equal(' + ($data) + ', schema' + ($lvl) + '); if (!' + ($valid) + ') {   ';
+    var $$outStack = $$outStack || [];
+    $$outStack.push(out);
+    out = ''; /* istanbul ignore else */
+    if (it.createErrors !== false) {
+      out += ' { keyword: \'' + ('const') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { allowedValue: schema' + ($lvl) + ' } ';
+      if (it.opts.messages !== false) {
+        out += ' , message: \'should be equal to constant\' ';
+      }
+      if (it.opts.verbose) {
+        out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+      }
+      out += ' } ';
+    } else {
+      out += ' {} ';
+    }
+    var __err = out;
+    out = $$outStack.pop();
+    if (!it.compositeRule && $breakOnError) {
+      /* istanbul ignore if */
+      if (it.async) {
+        out += ' throw new ValidationError([' + (__err) + ']); ';
+      } else {
+        out += ' validate.errors = [' + (__err) + ']; return false; ';
+      }
+    } else {
+      out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+    }
+    out += ' }';
+    if ($breakOnError) {
+      out += ' else { ';
+    }
+    return out;
+  }
+
+  },{}],22:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_contains(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $data = 'data' + ($dataLvl || '');
+    var $valid = 'valid' + $lvl;
+    var $errs = 'errs__' + $lvl;
+    var $it = it.util.copy(it);
+    var $closingBraces = '';
+    $it.level++;
+    var $nextValid = 'valid' + $it.level;
+    var $idx = 'i' + $lvl,
+      $dataNxt = $it.dataLevel = it.dataLevel + 1,
+      $nextData = 'data' + $dataNxt,
+      $currentBaseId = it.baseId,
+      $nonEmptySchema = (it.opts.strictKeywords ? (typeof $schema == 'object' && Object.keys($schema).length > 0) || $schema === false : it.util.schemaHasRules($schema, it.RULES.all));
+    out += 'var ' + ($errs) + ' = errors;var ' + ($valid) + ';';
+    if ($nonEmptySchema) {
+      var $wasComposite = it.compositeRule;
+      it.compositeRule = $it.compositeRule = true;
+      $it.schema = $schema;
+      $it.schemaPath = $schemaPath;
+      $it.errSchemaPath = $errSchemaPath;
+      out += ' var ' + ($nextValid) + ' = false; for (var ' + ($idx) + ' = 0; ' + ($idx) + ' < ' + ($data) + '.length; ' + ($idx) + '++) { ';
+      $it.errorPath = it.util.getPathExpr(it.errorPath, $idx, it.opts.jsonPointers, true);
+      var $passData = $data + '[' + $idx + ']';
+      $it.dataPathArr[$dataNxt] = $idx;
+      var $code = it.validate($it);
+      $it.baseId = $currentBaseId;
+      if (it.util.varOccurences($code, $nextData) < 2) {
+        out += ' ' + (it.util.varReplace($code, $nextData, $passData)) + ' ';
+      } else {
+        out += ' var ' + ($nextData) + ' = ' + ($passData) + '; ' + ($code) + ' ';
+      }
+      out += ' if (' + ($nextValid) + ') break; }  ';
+      it.compositeRule = $it.compositeRule = $wasComposite;
+      out += ' ' + ($closingBraces) + ' if (!' + ($nextValid) + ') {';
+    } else {
+      out += ' if (' + ($data) + '.length == 0) {';
+    }
+    var $$outStack = $$outStack || [];
+    $$outStack.push(out);
+    out = ''; /* istanbul ignore else */
+    if (it.createErrors !== false) {
+      out += ' { keyword: \'' + ('contains') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: {} ';
+      if (it.opts.messages !== false) {
+        out += ' , message: \'should contain a valid item\' ';
+      }
+      if (it.opts.verbose) {
+        out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+      }
+      out += ' } ';
+    } else {
+      out += ' {} ';
+    }
+    var __err = out;
+    out = $$outStack.pop();
+    if (!it.compositeRule && $breakOnError) {
+      /* istanbul ignore if */
+      if (it.async) {
+        out += ' throw new ValidationError([' + (__err) + ']); ';
+      } else {
+        out += ' validate.errors = [' + (__err) + ']; return false; ';
+      }
+    } else {
+      out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+    }
+    out += ' } else { ';
+    if ($nonEmptySchema) {
+      out += '  errors = ' + ($errs) + '; if (vErrors !== null) { if (' + ($errs) + ') vErrors.length = ' + ($errs) + '; else vErrors = null; } ';
+    }
+    if (it.opts.allErrors) {
+      out += ' } ';
+    }
+    return out;
+  }
+
+  },{}],23:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_custom(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $errorKeyword;
+    var $data = 'data' + ($dataLvl || '');
+    var $valid = 'valid' + $lvl;
+    var $errs = 'errs__' + $lvl;
+    var $isData = it.opts.$data && $schema && $schema.$data,
+      $schemaValue;
+    if ($isData) {
+      out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
+      $schemaValue = 'schema' + $lvl;
+    } else {
+      $schemaValue = $schema;
+    }
+    var $rule = this,
+      $definition = 'definition' + $lvl,
+      $rDef = $rule.definition,
+      $closingBraces = '';
+    var $compile, $inline, $macro, $ruleValidate, $validateCode;
+    if ($isData && $rDef.$data) {
+      $validateCode = 'keywordValidate' + $lvl;
+      var $validateSchema = $rDef.validateSchema;
+      out += ' var ' + ($definition) + ' = RULES.custom[\'' + ($keyword) + '\'].definition; var ' + ($validateCode) + ' = ' + ($definition) + '.validate;';
+    } else {
+      $ruleValidate = it.useCustomRule($rule, $schema, it.schema, it);
+      if (!$ruleValidate) return;
+      $schemaValue = 'validate.schema' + $schemaPath;
+      $validateCode = $ruleValidate.code;
+      $compile = $rDef.compile;
+      $inline = $rDef.inline;
+      $macro = $rDef.macro;
+    }
+    var $ruleErrs = $validateCode + '.errors',
+      $i = 'i' + $lvl,
+      $ruleErr = 'ruleErr' + $lvl,
+      $asyncKeyword = $rDef.async;
+    if ($asyncKeyword && !it.async) throw new Error('async keyword in sync schema');
+    if (!($inline || $macro)) {
+      out += '' + ($ruleErrs) + ' = null;';
+    }
+    out += 'var ' + ($errs) + ' = errors;var ' + ($valid) + ';';
+    if ($isData && $rDef.$data) {
+      $closingBraces += '}';
+      out += ' if (' + ($schemaValue) + ' === undefined) { ' + ($valid) + ' = true; } else { ';
+      if ($validateSchema) {
+        $closingBraces += '}';
+        out += ' ' + ($valid) + ' = ' + ($definition) + '.validateSchema(' + ($schemaValue) + '); if (' + ($valid) + ') { ';
+      }
+    }
+    if ($inline) {
+      if ($rDef.statements) {
+        out += ' ' + ($ruleValidate.validate) + ' ';
+      } else {
+        out += ' ' + ($valid) + ' = ' + ($ruleValidate.validate) + '; ';
+      }
+    } else if ($macro) {
+      var $it = it.util.copy(it);
+      var $closingBraces = '';
+      $it.level++;
+      var $nextValid = 'valid' + $it.level;
+      $it.schema = $ruleValidate.validate;
+      $it.schemaPath = '';
+      var $wasComposite = it.compositeRule;
+      it.compositeRule = $it.compositeRule = true;
+      var $code = it.validate($it).replace(/validate\.schema/g, $validateCode);
+      it.compositeRule = $it.compositeRule = $wasComposite;
+      out += ' ' + ($code);
+    } else {
+      var $$outStack = $$outStack || [];
+      $$outStack.push(out);
+      out = '';
+      out += '  ' + ($validateCode) + '.call( ';
+      if (it.opts.passContext) {
+        out += 'this';
+      } else {
+        out += 'self';
+      }
+      if ($compile || $rDef.schema === false) {
+        out += ' , ' + ($data) + ' ';
+      } else {
+        out += ' , ' + ($schemaValue) + ' , ' + ($data) + ' , validate.schema' + (it.schemaPath) + ' ';
+      }
+      out += ' , (dataPath || \'\')';
+      if (it.errorPath != '""') {
+        out += ' + ' + (it.errorPath);
+      }
+      var $parentData = $dataLvl ? 'data' + (($dataLvl - 1) || '') : 'parentData',
+        $parentDataProperty = $dataLvl ? it.dataPathArr[$dataLvl] : 'parentDataProperty';
+      out += ' , ' + ($parentData) + ' , ' + ($parentDataProperty) + ' , rootData )  ';
+      var def_callRuleValidate = out;
+      out = $$outStack.pop();
+      if ($rDef.errors === false) {
+        out += ' ' + ($valid) + ' = ';
+        if ($asyncKeyword) {
+          out += 'await ';
+        }
+        out += '' + (def_callRuleValidate) + '; ';
+      } else {
+        if ($asyncKeyword) {
+          $ruleErrs = 'customErrors' + $lvl;
+          out += ' var ' + ($ruleErrs) + ' = null; try { ' + ($valid) + ' = await ' + (def_callRuleValidate) + '; } catch (e) { ' + ($valid) + ' = false; if (e instanceof ValidationError) ' + ($ruleErrs) + ' = e.errors; else throw e; } ';
+        } else {
+          out += ' ' + ($ruleErrs) + ' = null; ' + ($valid) + ' = ' + (def_callRuleValidate) + '; ';
+        }
+      }
+    }
+    if ($rDef.modifying) {
+      out += ' if (' + ($parentData) + ') ' + ($data) + ' = ' + ($parentData) + '[' + ($parentDataProperty) + '];';
+    }
+    out += '' + ($closingBraces);
+    if ($rDef.valid) {
+      if ($breakOnError) {
+        out += ' if (true) { ';
+      }
+    } else {
+      out += ' if ( ';
+      if ($rDef.valid === undefined) {
+        out += ' !';
+        if ($macro) {
+          out += '' + ($nextValid);
+        } else {
+          out += '' + ($valid);
+        }
+      } else {
+        out += ' ' + (!$rDef.valid) + ' ';
+      }
+      out += ') { ';
+      $errorKeyword = $rule.keyword;
+      var $$outStack = $$outStack || [];
+      $$outStack.push(out);
+      out = '';
+      var $$outStack = $$outStack || [];
+      $$outStack.push(out);
+      out = ''; /* istanbul ignore else */
+      if (it.createErrors !== false) {
+        out += ' { keyword: \'' + ($errorKeyword || 'custom') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { keyword: \'' + ($rule.keyword) + '\' } ';
+        if (it.opts.messages !== false) {
+          out += ' , message: \'should pass "' + ($rule.keyword) + '" keyword validation\' ';
+        }
+        if (it.opts.verbose) {
+          out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+        }
+        out += ' } ';
+      } else {
+        out += ' {} ';
+      }
+      var __err = out;
+      out = $$outStack.pop();
+      if (!it.compositeRule && $breakOnError) {
+        /* istanbul ignore if */
+        if (it.async) {
+          out += ' throw new ValidationError([' + (__err) + ']); ';
+        } else {
+          out += ' validate.errors = [' + (__err) + ']; return false; ';
+        }
+      } else {
+        out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+      }
+      var def_customError = out;
+      out = $$outStack.pop();
+      if ($inline) {
+        if ($rDef.errors) {
+          if ($rDef.errors != 'full') {
+            out += '  for (var ' + ($i) + '=' + ($errs) + '; ' + ($i) + '<errors; ' + ($i) + '++) { var ' + ($ruleErr) + ' = vErrors[' + ($i) + ']; if (' + ($ruleErr) + '.dataPath === undefined) ' + ($ruleErr) + '.dataPath = (dataPath || \'\') + ' + (it.errorPath) + '; if (' + ($ruleErr) + '.schemaPath === undefined) { ' + ($ruleErr) + '.schemaPath = "' + ($errSchemaPath) + '"; } ';
+            if (it.opts.verbose) {
+              out += ' ' + ($ruleErr) + '.schema = ' + ($schemaValue) + '; ' + ($ruleErr) + '.data = ' + ($data) + '; ';
+            }
+            out += ' } ';
+          }
+        } else {
+          if ($rDef.errors === false) {
+            out += ' ' + (def_customError) + ' ';
+          } else {
+            out += ' if (' + ($errs) + ' == errors) { ' + (def_customError) + ' } else {  for (var ' + ($i) + '=' + ($errs) + '; ' + ($i) + '<errors; ' + ($i) + '++) { var ' + ($ruleErr) + ' = vErrors[' + ($i) + ']; if (' + ($ruleErr) + '.dataPath === undefined) ' + ($ruleErr) + '.dataPath = (dataPath || \'\') + ' + (it.errorPath) + '; if (' + ($ruleErr) + '.schemaPath === undefined) { ' + ($ruleErr) + '.schemaPath = "' + ($errSchemaPath) + '"; } ';
+            if (it.opts.verbose) {
+              out += ' ' + ($ruleErr) + '.schema = ' + ($schemaValue) + '; ' + ($ruleErr) + '.data = ' + ($data) + '; ';
+            }
+            out += ' } } ';
+          }
+        }
+      } else if ($macro) {
+        out += '   var err =   '; /* istanbul ignore else */
+        if (it.createErrors !== false) {
+          out += ' { keyword: \'' + ($errorKeyword || 'custom') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { keyword: \'' + ($rule.keyword) + '\' } ';
+          if (it.opts.messages !== false) {
+            out += ' , message: \'should pass "' + ($rule.keyword) + '" keyword validation\' ';
+          }
+          if (it.opts.verbose) {
+            out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+          }
+          out += ' } ';
+        } else {
+          out += ' {} ';
+        }
+        out += ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+        if (!it.compositeRule && $breakOnError) {
+          /* istanbul ignore if */
+          if (it.async) {
+            out += ' throw new ValidationError(vErrors); ';
+          } else {
+            out += ' validate.errors = vErrors; return false; ';
+          }
+        }
+      } else {
+        if ($rDef.errors === false) {
+          out += ' ' + (def_customError) + ' ';
+        } else {
+          out += ' if (Array.isArray(' + ($ruleErrs) + ')) { if (vErrors === null) vErrors = ' + ($ruleErrs) + '; else vErrors = vErrors.concat(' + ($ruleErrs) + '); errors = vErrors.length;  for (var ' + ($i) + '=' + ($errs) + '; ' + ($i) + '<errors; ' + ($i) + '++) { var ' + ($ruleErr) + ' = vErrors[' + ($i) + ']; if (' + ($ruleErr) + '.dataPath === undefined) ' + ($ruleErr) + '.dataPath = (dataPath || \'\') + ' + (it.errorPath) + ';  ' + ($ruleErr) + '.schemaPath = "' + ($errSchemaPath) + '";  ';
+          if (it.opts.verbose) {
+            out += ' ' + ($ruleErr) + '.schema = ' + ($schemaValue) + '; ' + ($ruleErr) + '.data = ' + ($data) + '; ';
+          }
+          out += ' } } else { ' + (def_customError) + ' } ';
+        }
+      }
+      out += ' } ';
+      if ($breakOnError) {
+        out += ' else { ';
+      }
+    }
+    return out;
+  }
+
+  },{}],24:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_dependencies(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $data = 'data' + ($dataLvl || '');
+    var $errs = 'errs__' + $lvl;
+    var $it = it.util.copy(it);
+    var $closingBraces = '';
+    $it.level++;
+    var $nextValid = 'valid' + $it.level;
+    var $schemaDeps = {},
+      $propertyDeps = {},
+      $ownProperties = it.opts.ownProperties;
+    for ($property in $schema) {
+      if ($property == '__proto__') continue;
+      var $sch = $schema[$property];
+      var $deps = Array.isArray($sch) ? $propertyDeps : $schemaDeps;
+      $deps[$property] = $sch;
+    }
+    out += 'var ' + ($errs) + ' = errors;';
+    var $currentErrorPath = it.errorPath;
+    out += 'var missing' + ($lvl) + ';';
+    for (var $property in $propertyDeps) {
+      $deps = $propertyDeps[$property];
+      if ($deps.length) {
+        out += ' if ( ' + ($data) + (it.util.getProperty($property)) + ' !== undefined ';
+        if ($ownProperties) {
+          out += ' && Object.prototype.hasOwnProperty.call(' + ($data) + ', \'' + (it.util.escapeQuotes($property)) + '\') ';
+        }
+        if ($breakOnError) {
+          out += ' && ( ';
+          var arr1 = $deps;
+          if (arr1) {
+            var $propertyKey, $i = -1,
+              l1 = arr1.length - 1;
+            while ($i < l1) {
+              $propertyKey = arr1[$i += 1];
+              if ($i) {
+                out += ' || ';
+              }
+              var $prop = it.util.getProperty($propertyKey),
+                $useData = $data + $prop;
+              out += ' ( ( ' + ($useData) + ' === undefined ';
+              if ($ownProperties) {
+                out += ' || ! Object.prototype.hasOwnProperty.call(' + ($data) + ', \'' + (it.util.escapeQuotes($propertyKey)) + '\') ';
+              }
+              out += ') && (missing' + ($lvl) + ' = ' + (it.util.toQuotedString(it.opts.jsonPointers ? $propertyKey : $prop)) + ') ) ';
+            }
+          }
+          out += ')) {  ';
+          var $propertyPath = 'missing' + $lvl,
+            $missingProperty = '\' + ' + $propertyPath + ' + \'';
+          if (it.opts._errorDataPathProperty) {
+            it.errorPath = it.opts.jsonPointers ? it.util.getPathExpr($currentErrorPath, $propertyPath, true) : $currentErrorPath + ' + ' + $propertyPath;
+          }
+          var $$outStack = $$outStack || [];
+          $$outStack.push(out);
+          out = ''; /* istanbul ignore else */
+          if (it.createErrors !== false) {
+            out += ' { keyword: \'' + ('dependencies') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { property: \'' + (it.util.escapeQuotes($property)) + '\', missingProperty: \'' + ($missingProperty) + '\', depsCount: ' + ($deps.length) + ', deps: \'' + (it.util.escapeQuotes($deps.length == 1 ? $deps[0] : $deps.join(", "))) + '\' } ';
+            if (it.opts.messages !== false) {
+              out += ' , message: \'should have ';
+              if ($deps.length == 1) {
+                out += 'property ' + (it.util.escapeQuotes($deps[0]));
+              } else {
+                out += 'properties ' + (it.util.escapeQuotes($deps.join(", ")));
+              }
+              out += ' when property ' + (it.util.escapeQuotes($property)) + ' is present\' ';
+            }
+            if (it.opts.verbose) {
+              out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+            }
+            out += ' } ';
+          } else {
+            out += ' {} ';
+          }
+          var __err = out;
+          out = $$outStack.pop();
+          if (!it.compositeRule && $breakOnError) {
+            /* istanbul ignore if */
+            if (it.async) {
+              out += ' throw new ValidationError([' + (__err) + ']); ';
+            } else {
+              out += ' validate.errors = [' + (__err) + ']; return false; ';
+            }
+          } else {
+            out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+          }
+        } else {
+          out += ' ) { ';
+          var arr2 = $deps;
+          if (arr2) {
+            var $propertyKey, i2 = -1,
+              l2 = arr2.length - 1;
+            while (i2 < l2) {
+              $propertyKey = arr2[i2 += 1];
+              var $prop = it.util.getProperty($propertyKey),
+                $missingProperty = it.util.escapeQuotes($propertyKey),
+                $useData = $data + $prop;
+              if (it.opts._errorDataPathProperty) {
+                it.errorPath = it.util.getPath($currentErrorPath, $propertyKey, it.opts.jsonPointers);
+              }
+              out += ' if ( ' + ($useData) + ' === undefined ';
+              if ($ownProperties) {
+                out += ' || ! Object.prototype.hasOwnProperty.call(' + ($data) + ', \'' + (it.util.escapeQuotes($propertyKey)) + '\') ';
+              }
+              out += ') {  var err =   '; /* istanbul ignore else */
+              if (it.createErrors !== false) {
+                out += ' { keyword: \'' + ('dependencies') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { property: \'' + (it.util.escapeQuotes($property)) + '\', missingProperty: \'' + ($missingProperty) + '\', depsCount: ' + ($deps.length) + ', deps: \'' + (it.util.escapeQuotes($deps.length == 1 ? $deps[0] : $deps.join(", "))) + '\' } ';
+                if (it.opts.messages !== false) {
+                  out += ' , message: \'should have ';
+                  if ($deps.length == 1) {
+                    out += 'property ' + (it.util.escapeQuotes($deps[0]));
+                  } else {
+                    out += 'properties ' + (it.util.escapeQuotes($deps.join(", ")));
+                  }
+                  out += ' when property ' + (it.util.escapeQuotes($property)) + ' is present\' ';
+                }
+                if (it.opts.verbose) {
+                  out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+                }
+                out += ' } ';
+              } else {
+                out += ' {} ';
+              }
+              out += ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; } ';
+            }
+          }
+        }
+        out += ' }   ';
+        if ($breakOnError) {
+          $closingBraces += '}';
+          out += ' else { ';
+        }
+      }
+    }
+    it.errorPath = $currentErrorPath;
+    var $currentBaseId = $it.baseId;
+    for (var $property in $schemaDeps) {
+      var $sch = $schemaDeps[$property];
+      if ((it.opts.strictKeywords ? (typeof $sch == 'object' && Object.keys($sch).length > 0) || $sch === false : it.util.schemaHasRules($sch, it.RULES.all))) {
+        out += ' ' + ($nextValid) + ' = true; if ( ' + ($data) + (it.util.getProperty($property)) + ' !== undefined ';
+        if ($ownProperties) {
+          out += ' && Object.prototype.hasOwnProperty.call(' + ($data) + ', \'' + (it.util.escapeQuotes($property)) + '\') ';
+        }
+        out += ') { ';
+        $it.schema = $sch;
+        $it.schemaPath = $schemaPath + it.util.getProperty($property);
+        $it.errSchemaPath = $errSchemaPath + '/' + it.util.escapeFragment($property);
+        out += '  ' + (it.validate($it)) + ' ';
+        $it.baseId = $currentBaseId;
+        out += ' }  ';
+        if ($breakOnError) {
+          out += ' if (' + ($nextValid) + ') { ';
+          $closingBraces += '}';
+        }
+      }
+    }
+    if ($breakOnError) {
+      out += '   ' + ($closingBraces) + ' if (' + ($errs) + ' == errors) {';
+    }
+    return out;
+  }
+
+  },{}],25:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_enum(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $data = 'data' + ($dataLvl || '');
+    var $valid = 'valid' + $lvl;
+    var $isData = it.opts.$data && $schema && $schema.$data,
+      $schemaValue;
+    if ($isData) {
+      out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
+      $schemaValue = 'schema' + $lvl;
+    } else {
+      $schemaValue = $schema;
+    }
+    var $i = 'i' + $lvl,
+      $vSchema = 'schema' + $lvl;
+    if (!$isData) {
+      out += ' var ' + ($vSchema) + ' = validate.schema' + ($schemaPath) + ';';
+    }
+    out += 'var ' + ($valid) + ';';
+    if ($isData) {
+      out += ' if (schema' + ($lvl) + ' === undefined) ' + ($valid) + ' = true; else if (!Array.isArray(schema' + ($lvl) + ')) ' + ($valid) + ' = false; else {';
+    }
+    out += '' + ($valid) + ' = false;for (var ' + ($i) + '=0; ' + ($i) + '<' + ($vSchema) + '.length; ' + ($i) + '++) if (equal(' + ($data) + ', ' + ($vSchema) + '[' + ($i) + '])) { ' + ($valid) + ' = true; break; }';
+    if ($isData) {
+      out += '  }  ';
+    }
+    out += ' if (!' + ($valid) + ') {   ';
+    var $$outStack = $$outStack || [];
+    $$outStack.push(out);
+    out = ''; /* istanbul ignore else */
+    if (it.createErrors !== false) {
+      out += ' { keyword: \'' + ('enum') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { allowedValues: schema' + ($lvl) + ' } ';
+      if (it.opts.messages !== false) {
+        out += ' , message: \'should be equal to one of the allowed values\' ';
+      }
+      if (it.opts.verbose) {
+        out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+      }
+      out += ' } ';
+    } else {
+      out += ' {} ';
+    }
+    var __err = out;
+    out = $$outStack.pop();
+    if (!it.compositeRule && $breakOnError) {
+      /* istanbul ignore if */
+      if (it.async) {
+        out += ' throw new ValidationError([' + (__err) + ']); ';
+      } else {
+        out += ' validate.errors = [' + (__err) + ']; return false; ';
+      }
+    } else {
+      out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+    }
+    out += ' }';
+    if ($breakOnError) {
+      out += ' else { ';
+    }
+    return out;
+  }
+
+  },{}],26:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_format(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $data = 'data' + ($dataLvl || '');
+    if (it.opts.format === false) {
+      if ($breakOnError) {
+        out += ' if (true) { ';
+      }
+      return out;
+    }
+    var $isData = it.opts.$data && $schema && $schema.$data,
+      $schemaValue;
+    if ($isData) {
+      out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
+      $schemaValue = 'schema' + $lvl;
+    } else {
+      $schemaValue = $schema;
+    }
+    var $unknownFormats = it.opts.unknownFormats,
+      $allowUnknown = Array.isArray($unknownFormats);
+    if ($isData) {
+      var $format = 'format' + $lvl,
+        $isObject = 'isObject' + $lvl,
+        $formatType = 'formatType' + $lvl;
+      out += ' var ' + ($format) + ' = formats[' + ($schemaValue) + ']; var ' + ($isObject) + ' = typeof ' + ($format) + ' == \'object\' && !(' + ($format) + ' instanceof RegExp) && ' + ($format) + '.validate; var ' + ($formatType) + ' = ' + ($isObject) + ' && ' + ($format) + '.type || \'string\'; if (' + ($isObject) + ') { ';
+      if (it.async) {
+        out += ' var async' + ($lvl) + ' = ' + ($format) + '.async; ';
+      }
+      out += ' ' + ($format) + ' = ' + ($format) + '.validate; } if (  ';
+      if ($isData) {
+        out += ' (' + ($schemaValue) + ' !== undefined && typeof ' + ($schemaValue) + ' != \'string\') || ';
+      }
+      out += ' (';
+      if ($unknownFormats != 'ignore') {
+        out += ' (' + ($schemaValue) + ' && !' + ($format) + ' ';
+        if ($allowUnknown) {
+          out += ' && self._opts.unknownFormats.indexOf(' + ($schemaValue) + ') == -1 ';
+        }
+        out += ') || ';
+      }
+      out += ' (' + ($format) + ' && ' + ($formatType) + ' == \'' + ($ruleType) + '\' && !(typeof ' + ($format) + ' == \'function\' ? ';
+      if (it.async) {
+        out += ' (async' + ($lvl) + ' ? await ' + ($format) + '(' + ($data) + ') : ' + ($format) + '(' + ($data) + ')) ';
+      } else {
+        out += ' ' + ($format) + '(' + ($data) + ') ';
+      }
+      out += ' : ' + ($format) + '.test(' + ($data) + '))))) {';
+    } else {
+      var $format = it.formats[$schema];
+      if (!$format) {
+        if ($unknownFormats == 'ignore') {
+          it.logger.warn('unknown format "' + $schema + '" ignored in schema at path "' + it.errSchemaPath + '"');
+          if ($breakOnError) {
+            out += ' if (true) { ';
+          }
+          return out;
+        } else if ($allowUnknown && $unknownFormats.indexOf($schema) >= 0) {
+          if ($breakOnError) {
+            out += ' if (true) { ';
+          }
+          return out;
+        } else {
+          throw new Error('unknown format "' + $schema + '" is used in schema at path "' + it.errSchemaPath + '"');
+        }
+      }
+      var $isObject = typeof $format == 'object' && !($format instanceof RegExp) && $format.validate;
+      var $formatType = $isObject && $format.type || 'string';
+      if ($isObject) {
+        var $async = $format.async === true;
+        $format = $format.validate;
+      }
+      if ($formatType != $ruleType) {
+        if ($breakOnError) {
+          out += ' if (true) { ';
+        }
+        return out;
+      }
+      if ($async) {
+        if (!it.async) throw new Error('async format in sync schema');
+        var $formatRef = 'formats' + it.util.getProperty($schema) + '.validate';
+        out += ' if (!(await ' + ($formatRef) + '(' + ($data) + '))) { ';
+      } else {
+        out += ' if (! ';
+        var $formatRef = 'formats' + it.util.getProperty($schema);
+        if ($isObject) $formatRef += '.validate';
+        if (typeof $format == 'function') {
+          out += ' ' + ($formatRef) + '(' + ($data) + ') ';
+        } else {
+          out += ' ' + ($formatRef) + '.test(' + ($data) + ') ';
+        }
+        out += ') { ';
+      }
+    }
+    var $$outStack = $$outStack || [];
+    $$outStack.push(out);
+    out = ''; /* istanbul ignore else */
+    if (it.createErrors !== false) {
+      out += ' { keyword: \'' + ('format') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { format:  ';
+      if ($isData) {
+        out += '' + ($schemaValue);
+      } else {
+        out += '' + (it.util.toQuotedString($schema));
+      }
+      out += '  } ';
+      if (it.opts.messages !== false) {
+        out += ' , message: \'should match format "';
+        if ($isData) {
+          out += '\' + ' + ($schemaValue) + ' + \'';
+        } else {
+          out += '' + (it.util.escapeQuotes($schema));
+        }
+        out += '"\' ';
+      }
+      if (it.opts.verbose) {
+        out += ' , schema:  ';
+        if ($isData) {
+          out += 'validate.schema' + ($schemaPath);
+        } else {
+          out += '' + (it.util.toQuotedString($schema));
+        }
+        out += '         , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+      }
+      out += ' } ';
+    } else {
+      out += ' {} ';
+    }
+    var __err = out;
+    out = $$outStack.pop();
+    if (!it.compositeRule && $breakOnError) {
+      /* istanbul ignore if */
+      if (it.async) {
+        out += ' throw new ValidationError([' + (__err) + ']); ';
+      } else {
+        out += ' validate.errors = [' + (__err) + ']; return false; ';
+      }
+    } else {
+      out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+    }
+    out += ' } ';
+    if ($breakOnError) {
+      out += ' else { ';
+    }
+    return out;
+  }
+
+  },{}],27:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_if(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $data = 'data' + ($dataLvl || '');
+    var $valid = 'valid' + $lvl;
+    var $errs = 'errs__' + $lvl;
+    var $it = it.util.copy(it);
+    $it.level++;
+    var $nextValid = 'valid' + $it.level;
+    var $thenSch = it.schema['then'],
+      $elseSch = it.schema['else'],
+      $thenPresent = $thenSch !== undefined && (it.opts.strictKeywords ? (typeof $thenSch == 'object' && Object.keys($thenSch).length > 0) || $thenSch === false : it.util.schemaHasRules($thenSch, it.RULES.all)),
+      $elsePresent = $elseSch !== undefined && (it.opts.strictKeywords ? (typeof $elseSch == 'object' && Object.keys($elseSch).length > 0) || $elseSch === false : it.util.schemaHasRules($elseSch, it.RULES.all)),
+      $currentBaseId = $it.baseId;
+    if ($thenPresent || $elsePresent) {
+      var $ifClause;
+      $it.createErrors = false;
+      $it.schema = $schema;
+      $it.schemaPath = $schemaPath;
+      $it.errSchemaPath = $errSchemaPath;
+      out += ' var ' + ($errs) + ' = errors; var ' + ($valid) + ' = true;  ';
+      var $wasComposite = it.compositeRule;
+      it.compositeRule = $it.compositeRule = true;
+      out += '  ' + (it.validate($it)) + ' ';
+      $it.baseId = $currentBaseId;
+      $it.createErrors = true;
+      out += '  errors = ' + ($errs) + '; if (vErrors !== null) { if (' + ($errs) + ') vErrors.length = ' + ($errs) + '; else vErrors = null; }  ';
+      it.compositeRule = $it.compositeRule = $wasComposite;
+      if ($thenPresent) {
+        out += ' if (' + ($nextValid) + ') {  ';
+        $it.schema = it.schema['then'];
+        $it.schemaPath = it.schemaPath + '.then';
+        $it.errSchemaPath = it.errSchemaPath + '/then';
+        out += '  ' + (it.validate($it)) + ' ';
+        $it.baseId = $currentBaseId;
+        out += ' ' + ($valid) + ' = ' + ($nextValid) + '; ';
+        if ($thenPresent && $elsePresent) {
+          $ifClause = 'ifClause' + $lvl;
+          out += ' var ' + ($ifClause) + ' = \'then\'; ';
+        } else {
+          $ifClause = '\'then\'';
+        }
+        out += ' } ';
+        if ($elsePresent) {
+          out += ' else { ';
+        }
+      } else {
+        out += ' if (!' + ($nextValid) + ') { ';
+      }
+      if ($elsePresent) {
+        $it.schema = it.schema['else'];
+        $it.schemaPath = it.schemaPath + '.else';
+        $it.errSchemaPath = it.errSchemaPath + '/else';
+        out += '  ' + (it.validate($it)) + ' ';
+        $it.baseId = $currentBaseId;
+        out += ' ' + ($valid) + ' = ' + ($nextValid) + '; ';
+        if ($thenPresent && $elsePresent) {
+          $ifClause = 'ifClause' + $lvl;
+          out += ' var ' + ($ifClause) + ' = \'else\'; ';
+        } else {
+          $ifClause = '\'else\'';
+        }
+        out += ' } ';
+      }
+      out += ' if (!' + ($valid) + ') {   var err =   '; /* istanbul ignore else */
+      if (it.createErrors !== false) {
+        out += ' { keyword: \'' + ('if') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { failingKeyword: ' + ($ifClause) + ' } ';
+        if (it.opts.messages !== false) {
+          out += ' , message: \'should match "\' + ' + ($ifClause) + ' + \'" schema\' ';
+        }
+        if (it.opts.verbose) {
+          out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+        }
+        out += ' } ';
+      } else {
+        out += ' {} ';
+      }
+      out += ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+      if (!it.compositeRule && $breakOnError) {
+        /* istanbul ignore if */
+        if (it.async) {
+          out += ' throw new ValidationError(vErrors); ';
+        } else {
+          out += ' validate.errors = vErrors; return false; ';
+        }
+      }
+      out += ' }   ';
+      if ($breakOnError) {
+        out += ' else { ';
+      }
+    } else {
+      if ($breakOnError) {
+        out += ' if (true) { ';
+      }
+    }
+    return out;
+  }
+
+  },{}],28:[function(require,module,exports){
+  'use strict';
+
+  //all requires must be explicit because browserify won't work with dynamic requires
+  module.exports = {
+    '$ref': require('./ref'),
+    allOf: require('./allOf'),
+    anyOf: require('./anyOf'),
+    '$comment': require('./comment'),
+    const: require('./const'),
+    contains: require('./contains'),
+    dependencies: require('./dependencies'),
+    'enum': require('./enum'),
+    format: require('./format'),
+    'if': require('./if'),
+    items: require('./items'),
+    maximum: require('./_limit'),
+    minimum: require('./_limit'),
+    maxItems: require('./_limitItems'),
+    minItems: require('./_limitItems'),
+    maxLength: require('./_limitLength'),
+    minLength: require('./_limitLength'),
+    maxProperties: require('./_limitProperties'),
+    minProperties: require('./_limitProperties'),
+    multipleOf: require('./multipleOf'),
+    not: require('./not'),
+    oneOf: require('./oneOf'),
+    pattern: require('./pattern'),
+    properties: require('./properties'),
+    propertyNames: require('./propertyNames'),
+    required: require('./required'),
+    uniqueItems: require('./uniqueItems'),
+    validate: require('./validate')
+  };
+
+  },{"./_limit":14,"./_limitItems":15,"./_limitLength":16,"./_limitProperties":17,"./allOf":18,"./anyOf":19,"./comment":20,"./const":21,"./contains":22,"./dependencies":24,"./enum":25,"./format":26,"./if":27,"./items":29,"./multipleOf":30,"./not":31,"./oneOf":32,"./pattern":33,"./properties":34,"./propertyNames":35,"./ref":36,"./required":37,"./uniqueItems":38,"./validate":39}],29:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_items(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $data = 'data' + ($dataLvl || '');
+    var $valid = 'valid' + $lvl;
+    var $errs = 'errs__' + $lvl;
+    var $it = it.util.copy(it);
+    var $closingBraces = '';
+    $it.level++;
+    var $nextValid = 'valid' + $it.level;
+    var $idx = 'i' + $lvl,
+      $dataNxt = $it.dataLevel = it.dataLevel + 1,
+      $nextData = 'data' + $dataNxt,
+      $currentBaseId = it.baseId;
+    out += 'var ' + ($errs) + ' = errors;var ' + ($valid) + ';';
+    if (Array.isArray($schema)) {
+      var $additionalItems = it.schema.additionalItems;
+      if ($additionalItems === false) {
+        out += ' ' + ($valid) + ' = ' + ($data) + '.length <= ' + ($schema.length) + '; ';
+        var $currErrSchemaPath = $errSchemaPath;
+        $errSchemaPath = it.errSchemaPath + '/additionalItems';
+        out += '  if (!' + ($valid) + ') {   ';
+        var $$outStack = $$outStack || [];
+        $$outStack.push(out);
+        out = ''; /* istanbul ignore else */
+        if (it.createErrors !== false) {
+          out += ' { keyword: \'' + ('additionalItems') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { limit: ' + ($schema.length) + ' } ';
+          if (it.opts.messages !== false) {
+            out += ' , message: \'should NOT have more than ' + ($schema.length) + ' items\' ';
+          }
+          if (it.opts.verbose) {
+            out += ' , schema: false , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+          }
+          out += ' } ';
+        } else {
+          out += ' {} ';
+        }
+        var __err = out;
+        out = $$outStack.pop();
+        if (!it.compositeRule && $breakOnError) {
+          /* istanbul ignore if */
+          if (it.async) {
+            out += ' throw new ValidationError([' + (__err) + ']); ';
+          } else {
+            out += ' validate.errors = [' + (__err) + ']; return false; ';
+          }
+        } else {
+          out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+        }
+        out += ' } ';
+        $errSchemaPath = $currErrSchemaPath;
+        if ($breakOnError) {
+          $closingBraces += '}';
+          out += ' else { ';
+        }
+      }
+      var arr1 = $schema;
+      if (arr1) {
+        var $sch, $i = -1,
+          l1 = arr1.length - 1;
+        while ($i < l1) {
+          $sch = arr1[$i += 1];
+          if ((it.opts.strictKeywords ? (typeof $sch == 'object' && Object.keys($sch).length > 0) || $sch === false : it.util.schemaHasRules($sch, it.RULES.all))) {
+            out += ' ' + ($nextValid) + ' = true; if (' + ($data) + '.length > ' + ($i) + ') { ';
+            var $passData = $data + '[' + $i + ']';
+            $it.schema = $sch;
+            $it.schemaPath = $schemaPath + '[' + $i + ']';
+            $it.errSchemaPath = $errSchemaPath + '/' + $i;
+            $it.errorPath = it.util.getPathExpr(it.errorPath, $i, it.opts.jsonPointers, true);
+            $it.dataPathArr[$dataNxt] = $i;
+            var $code = it.validate($it);
+            $it.baseId = $currentBaseId;
+            if (it.util.varOccurences($code, $nextData) < 2) {
+              out += ' ' + (it.util.varReplace($code, $nextData, $passData)) + ' ';
+            } else {
+              out += ' var ' + ($nextData) + ' = ' + ($passData) + '; ' + ($code) + ' ';
+            }
+            out += ' }  ';
+            if ($breakOnError) {
+              out += ' if (' + ($nextValid) + ') { ';
+              $closingBraces += '}';
+            }
+          }
+        }
+      }
+      if (typeof $additionalItems == 'object' && (it.opts.strictKeywords ? (typeof $additionalItems == 'object' && Object.keys($additionalItems).length > 0) || $additionalItems === false : it.util.schemaHasRules($additionalItems, it.RULES.all))) {
+        $it.schema = $additionalItems;
+        $it.schemaPath = it.schemaPath + '.additionalItems';
+        $it.errSchemaPath = it.errSchemaPath + '/additionalItems';
+        out += ' ' + ($nextValid) + ' = true; if (' + ($data) + '.length > ' + ($schema.length) + ') {  for (var ' + ($idx) + ' = ' + ($schema.length) + '; ' + ($idx) + ' < ' + ($data) + '.length; ' + ($idx) + '++) { ';
+        $it.errorPath = it.util.getPathExpr(it.errorPath, $idx, it.opts.jsonPointers, true);
+        var $passData = $data + '[' + $idx + ']';
+        $it.dataPathArr[$dataNxt] = $idx;
+        var $code = it.validate($it);
+        $it.baseId = $currentBaseId;
+        if (it.util.varOccurences($code, $nextData) < 2) {
+          out += ' ' + (it.util.varReplace($code, $nextData, $passData)) + ' ';
+        } else {
+          out += ' var ' + ($nextData) + ' = ' + ($passData) + '; ' + ($code) + ' ';
+        }
+        if ($breakOnError) {
+          out += ' if (!' + ($nextValid) + ') break; ';
+        }
+        out += ' } }  ';
+        if ($breakOnError) {
+          out += ' if (' + ($nextValid) + ') { ';
+          $closingBraces += '}';
+        }
+      }
+    } else if ((it.opts.strictKeywords ? (typeof $schema == 'object' && Object.keys($schema).length > 0) || $schema === false : it.util.schemaHasRules($schema, it.RULES.all))) {
+      $it.schema = $schema;
+      $it.schemaPath = $schemaPath;
+      $it.errSchemaPath = $errSchemaPath;
+      out += '  for (var ' + ($idx) + ' = ' + (0) + '; ' + ($idx) + ' < ' + ($data) + '.length; ' + ($idx) + '++) { ';
+      $it.errorPath = it.util.getPathExpr(it.errorPath, $idx, it.opts.jsonPointers, true);
+      var $passData = $data + '[' + $idx + ']';
+      $it.dataPathArr[$dataNxt] = $idx;
+      var $code = it.validate($it);
+      $it.baseId = $currentBaseId;
+      if (it.util.varOccurences($code, $nextData) < 2) {
+        out += ' ' + (it.util.varReplace($code, $nextData, $passData)) + ' ';
+      } else {
+        out += ' var ' + ($nextData) + ' = ' + ($passData) + '; ' + ($code) + ' ';
+      }
+      if ($breakOnError) {
+        out += ' if (!' + ($nextValid) + ') break; ';
+      }
+      out += ' }';
+    }
+    if ($breakOnError) {
+      out += ' ' + ($closingBraces) + ' if (' + ($errs) + ' == errors) {';
+    }
+    return out;
+  }
+
+  },{}],30:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_multipleOf(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $data = 'data' + ($dataLvl || '');
+    var $isData = it.opts.$data && $schema && $schema.$data,
+      $schemaValue;
+    if ($isData) {
+      out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
+      $schemaValue = 'schema' + $lvl;
+    } else {
+      $schemaValue = $schema;
+    }
+    if (!($isData || typeof $schema == 'number')) {
+      throw new Error($keyword + ' must be number');
+    }
+    out += 'var division' + ($lvl) + ';if (';
+    if ($isData) {
+      out += ' ' + ($schemaValue) + ' !== undefined && ( typeof ' + ($schemaValue) + ' != \'number\' || ';
+    }
+    out += ' (division' + ($lvl) + ' = ' + ($data) + ' / ' + ($schemaValue) + ', ';
+    if (it.opts.multipleOfPrecision) {
+      out += ' Math.abs(Math.round(division' + ($lvl) + ') - division' + ($lvl) + ') > 1e-' + (it.opts.multipleOfPrecision) + ' ';
+    } else {
+      out += ' division' + ($lvl) + ' !== parseInt(division' + ($lvl) + ') ';
+    }
+    out += ' ) ';
+    if ($isData) {
+      out += '  )  ';
+    }
+    out += ' ) {   ';
+    var $$outStack = $$outStack || [];
+    $$outStack.push(out);
+    out = ''; /* istanbul ignore else */
+    if (it.createErrors !== false) {
+      out += ' { keyword: \'' + ('multipleOf') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { multipleOf: ' + ($schemaValue) + ' } ';
+      if (it.opts.messages !== false) {
+        out += ' , message: \'should be multiple of ';
+        if ($isData) {
+          out += '\' + ' + ($schemaValue);
+        } else {
+          out += '' + ($schemaValue) + '\'';
+        }
+      }
+      if (it.opts.verbose) {
+        out += ' , schema:  ';
+        if ($isData) {
+          out += 'validate.schema' + ($schemaPath);
+        } else {
+          out += '' + ($schema);
+        }
+        out += '         , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+      }
+      out += ' } ';
+    } else {
+      out += ' {} ';
+    }
+    var __err = out;
+    out = $$outStack.pop();
+    if (!it.compositeRule && $breakOnError) {
+      /* istanbul ignore if */
+      if (it.async) {
+        out += ' throw new ValidationError([' + (__err) + ']); ';
+      } else {
+        out += ' validate.errors = [' + (__err) + ']; return false; ';
+      }
+    } else {
+      out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+    }
+    out += '} ';
+    if ($breakOnError) {
+      out += ' else { ';
+    }
+    return out;
+  }
+
+  },{}],31:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_not(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $data = 'data' + ($dataLvl || '');
+    var $errs = 'errs__' + $lvl;
+    var $it = it.util.copy(it);
+    $it.level++;
+    var $nextValid = 'valid' + $it.level;
+    if ((it.opts.strictKeywords ? (typeof $schema == 'object' && Object.keys($schema).length > 0) || $schema === false : it.util.schemaHasRules($schema, it.RULES.all))) {
+      $it.schema = $schema;
+      $it.schemaPath = $schemaPath;
+      $it.errSchemaPath = $errSchemaPath;
+      out += ' var ' + ($errs) + ' = errors;  ';
+      var $wasComposite = it.compositeRule;
+      it.compositeRule = $it.compositeRule = true;
+      $it.createErrors = false;
+      var $allErrorsOption;
+      if ($it.opts.allErrors) {
+        $allErrorsOption = $it.opts.allErrors;
+        $it.opts.allErrors = false;
+      }
+      out += ' ' + (it.validate($it)) + ' ';
+      $it.createErrors = true;
+      if ($allErrorsOption) $it.opts.allErrors = $allErrorsOption;
+      it.compositeRule = $it.compositeRule = $wasComposite;
+      out += ' if (' + ($nextValid) + ') {   ';
+      var $$outStack = $$outStack || [];
+      $$outStack.push(out);
+      out = ''; /* istanbul ignore else */
+      if (it.createErrors !== false) {
+        out += ' { keyword: \'' + ('not') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: {} ';
+        if (it.opts.messages !== false) {
+          out += ' , message: \'should NOT be valid\' ';
+        }
+        if (it.opts.verbose) {
+          out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+        }
+        out += ' } ';
+      } else {
+        out += ' {} ';
+      }
+      var __err = out;
+      out = $$outStack.pop();
+      if (!it.compositeRule && $breakOnError) {
+        /* istanbul ignore if */
+        if (it.async) {
+          out += ' throw new ValidationError([' + (__err) + ']); ';
+        } else {
+          out += ' validate.errors = [' + (__err) + ']; return false; ';
+        }
+      } else {
+        out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+      }
+      out += ' } else {  errors = ' + ($errs) + '; if (vErrors !== null) { if (' + ($errs) + ') vErrors.length = ' + ($errs) + '; else vErrors = null; } ';
+      if (it.opts.allErrors) {
+        out += ' } ';
+      }
+    } else {
+      out += '  var err =   '; /* istanbul ignore else */
+      if (it.createErrors !== false) {
+        out += ' { keyword: \'' + ('not') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: {} ';
+        if (it.opts.messages !== false) {
+          out += ' , message: \'should NOT be valid\' ';
+        }
+        if (it.opts.verbose) {
+          out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+        }
+        out += ' } ';
+      } else {
+        out += ' {} ';
+      }
+      out += ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+      if ($breakOnError) {
+        out += ' if (false) { ';
+      }
+    }
+    return out;
+  }
+
+  },{}],32:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_oneOf(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $data = 'data' + ($dataLvl || '');
+    var $valid = 'valid' + $lvl;
+    var $errs = 'errs__' + $lvl;
+    var $it = it.util.copy(it);
+    var $closingBraces = '';
+    $it.level++;
+    var $nextValid = 'valid' + $it.level;
+    var $currentBaseId = $it.baseId,
+      $prevValid = 'prevValid' + $lvl,
+      $passingSchemas = 'passingSchemas' + $lvl;
+    out += 'var ' + ($errs) + ' = errors , ' + ($prevValid) + ' = false , ' + ($valid) + ' = false , ' + ($passingSchemas) + ' = null; ';
+    var $wasComposite = it.compositeRule;
+    it.compositeRule = $it.compositeRule = true;
+    var arr1 = $schema;
+    if (arr1) {
+      var $sch, $i = -1,
+        l1 = arr1.length - 1;
+      while ($i < l1) {
+        $sch = arr1[$i += 1];
+        if ((it.opts.strictKeywords ? (typeof $sch == 'object' && Object.keys($sch).length > 0) || $sch === false : it.util.schemaHasRules($sch, it.RULES.all))) {
+          $it.schema = $sch;
+          $it.schemaPath = $schemaPath + '[' + $i + ']';
+          $it.errSchemaPath = $errSchemaPath + '/' + $i;
+          out += '  ' + (it.validate($it)) + ' ';
+          $it.baseId = $currentBaseId;
+        } else {
+          out += ' var ' + ($nextValid) + ' = true; ';
+        }
+        if ($i) {
+          out += ' if (' + ($nextValid) + ' && ' + ($prevValid) + ') { ' + ($valid) + ' = false; ' + ($passingSchemas) + ' = [' + ($passingSchemas) + ', ' + ($i) + ']; } else { ';
+          $closingBraces += '}';
+        }
+        out += ' if (' + ($nextValid) + ') { ' + ($valid) + ' = ' + ($prevValid) + ' = true; ' + ($passingSchemas) + ' = ' + ($i) + '; }';
+      }
+    }
+    it.compositeRule = $it.compositeRule = $wasComposite;
+    out += '' + ($closingBraces) + 'if (!' + ($valid) + ') {   var err =   '; /* istanbul ignore else */
+    if (it.createErrors !== false) {
+      out += ' { keyword: \'' + ('oneOf') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { passingSchemas: ' + ($passingSchemas) + ' } ';
+      if (it.opts.messages !== false) {
+        out += ' , message: \'should match exactly one schema in oneOf\' ';
+      }
+      if (it.opts.verbose) {
+        out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+      }
+      out += ' } ';
+    } else {
+      out += ' {} ';
+    }
+    out += ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+    if (!it.compositeRule && $breakOnError) {
+      /* istanbul ignore if */
+      if (it.async) {
+        out += ' throw new ValidationError(vErrors); ';
+      } else {
+        out += ' validate.errors = vErrors; return false; ';
+      }
+    }
+    out += '} else {  errors = ' + ($errs) + '; if (vErrors !== null) { if (' + ($errs) + ') vErrors.length = ' + ($errs) + '; else vErrors = null; }';
+    if (it.opts.allErrors) {
+      out += ' } ';
+    }
+    return out;
+  }
+
+  },{}],33:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_pattern(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $data = 'data' + ($dataLvl || '');
+    var $isData = it.opts.$data && $schema && $schema.$data,
+      $schemaValue;
+    if ($isData) {
+      out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
+      $schemaValue = 'schema' + $lvl;
+    } else {
+      $schemaValue = $schema;
+    }
+    var $regexp = $isData ? '(new RegExp(' + $schemaValue + '))' : it.usePattern($schema);
+    out += 'if ( ';
+    if ($isData) {
+      out += ' (' + ($schemaValue) + ' !== undefined && typeof ' + ($schemaValue) + ' != \'string\') || ';
+    }
+    out += ' !' + ($regexp) + '.test(' + ($data) + ') ) {   ';
+    var $$outStack = $$outStack || [];
+    $$outStack.push(out);
+    out = ''; /* istanbul ignore else */
+    if (it.createErrors !== false) {
+      out += ' { keyword: \'' + ('pattern') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { pattern:  ';
+      if ($isData) {
+        out += '' + ($schemaValue);
+      } else {
+        out += '' + (it.util.toQuotedString($schema));
+      }
+      out += '  } ';
+      if (it.opts.messages !== false) {
+        out += ' , message: \'should match pattern "';
+        if ($isData) {
+          out += '\' + ' + ($schemaValue) + ' + \'';
+        } else {
+          out += '' + (it.util.escapeQuotes($schema));
+        }
+        out += '"\' ';
+      }
+      if (it.opts.verbose) {
+        out += ' , schema:  ';
+        if ($isData) {
+          out += 'validate.schema' + ($schemaPath);
+        } else {
+          out += '' + (it.util.toQuotedString($schema));
+        }
+        out += '         , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+      }
+      out += ' } ';
+    } else {
+      out += ' {} ';
+    }
+    var __err = out;
+    out = $$outStack.pop();
+    if (!it.compositeRule && $breakOnError) {
+      /* istanbul ignore if */
+      if (it.async) {
+        out += ' throw new ValidationError([' + (__err) + ']); ';
+      } else {
+        out += ' validate.errors = [' + (__err) + ']; return false; ';
+      }
+    } else {
+      out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+    }
+    out += '} ';
+    if ($breakOnError) {
+      out += ' else { ';
+    }
+    return out;
+  }
+
+  },{}],34:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_properties(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $data = 'data' + ($dataLvl || '');
+    var $errs = 'errs__' + $lvl;
+    var $it = it.util.copy(it);
+    var $closingBraces = '';
+    $it.level++;
+    var $nextValid = 'valid' + $it.level;
+    var $key = 'key' + $lvl,
+      $idx = 'idx' + $lvl,
+      $dataNxt = $it.dataLevel = it.dataLevel + 1,
+      $nextData = 'data' + $dataNxt,
+      $dataProperties = 'dataProperties' + $lvl;
+    var $schemaKeys = Object.keys($schema || {}).filter(notProto),
+      $pProperties = it.schema.patternProperties || {},
+      $pPropertyKeys = Object.keys($pProperties).filter(notProto),
+      $aProperties = it.schema.additionalProperties,
+      $someProperties = $schemaKeys.length || $pPropertyKeys.length,
+      $noAdditional = $aProperties === false,
+      $additionalIsSchema = typeof $aProperties == 'object' && Object.keys($aProperties).length,
+      $removeAdditional = it.opts.removeAdditional,
+      $checkAdditional = $noAdditional || $additionalIsSchema || $removeAdditional,
+      $ownProperties = it.opts.ownProperties,
+      $currentBaseId = it.baseId;
+    var $required = it.schema.required;
+    if ($required && !(it.opts.$data && $required.$data) && $required.length < it.opts.loopRequired) {
+      var $requiredHash = it.util.toHash($required);
+    }
+
+    function notProto(p) {
+      return p !== '__proto__';
+    }
+    out += 'var ' + ($errs) + ' = errors;var ' + ($nextValid) + ' = true;';
+    if ($ownProperties) {
+      out += ' var ' + ($dataProperties) + ' = undefined;';
+    }
+    if ($checkAdditional) {
+      if ($ownProperties) {
+        out += ' ' + ($dataProperties) + ' = ' + ($dataProperties) + ' || Object.keys(' + ($data) + '); for (var ' + ($idx) + '=0; ' + ($idx) + '<' + ($dataProperties) + '.length; ' + ($idx) + '++) { var ' + ($key) + ' = ' + ($dataProperties) + '[' + ($idx) + ']; ';
+      } else {
+        out += ' for (var ' + ($key) + ' in ' + ($data) + ') { ';
+      }
+      if ($someProperties) {
+        out += ' var isAdditional' + ($lvl) + ' = !(false ';
+        if ($schemaKeys.length) {
+          if ($schemaKeys.length > 8) {
+            out += ' || validate.schema' + ($schemaPath) + '.hasOwnProperty(' + ($key) + ') ';
+          } else {
+            var arr1 = $schemaKeys;
+            if (arr1) {
+              var $propertyKey, i1 = -1,
+                l1 = arr1.length - 1;
+              while (i1 < l1) {
+                $propertyKey = arr1[i1 += 1];
+                out += ' || ' + ($key) + ' == ' + (it.util.toQuotedString($propertyKey)) + ' ';
+              }
+            }
+          }
+        }
+        if ($pPropertyKeys.length) {
+          var arr2 = $pPropertyKeys;
+          if (arr2) {
+            var $pProperty, $i = -1,
+              l2 = arr2.length - 1;
+            while ($i < l2) {
+              $pProperty = arr2[$i += 1];
+              out += ' || ' + (it.usePattern($pProperty)) + '.test(' + ($key) + ') ';
+            }
+          }
+        }
+        out += ' ); if (isAdditional' + ($lvl) + ') { ';
+      }
+      if ($removeAdditional == 'all') {
+        out += ' delete ' + ($data) + '[' + ($key) + ']; ';
+      } else {
+        var $currentErrorPath = it.errorPath;
+        var $additionalProperty = '\' + ' + $key + ' + \'';
+        if (it.opts._errorDataPathProperty) {
+          it.errorPath = it.util.getPathExpr(it.errorPath, $key, it.opts.jsonPointers);
+        }
+        if ($noAdditional) {
+          if ($removeAdditional) {
+            out += ' delete ' + ($data) + '[' + ($key) + ']; ';
+          } else {
+            out += ' ' + ($nextValid) + ' = false; ';
+            var $currErrSchemaPath = $errSchemaPath;
+            $errSchemaPath = it.errSchemaPath + '/additionalProperties';
+            var $$outStack = $$outStack || [];
+            $$outStack.push(out);
+            out = ''; /* istanbul ignore else */
+            if (it.createErrors !== false) {
+              out += ' { keyword: \'' + ('additionalProperties') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { additionalProperty: \'' + ($additionalProperty) + '\' } ';
+              if (it.opts.messages !== false) {
+                out += ' , message: \'';
+                if (it.opts._errorDataPathProperty) {
+                  out += 'is an invalid additional property';
+                } else {
+                  out += 'should NOT have additional properties';
+                }
+                out += '\' ';
+              }
+              if (it.opts.verbose) {
+                out += ' , schema: false , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+              }
+              out += ' } ';
+            } else {
+              out += ' {} ';
+            }
+            var __err = out;
+            out = $$outStack.pop();
+            if (!it.compositeRule && $breakOnError) {
+              /* istanbul ignore if */
+              if (it.async) {
+                out += ' throw new ValidationError([' + (__err) + ']); ';
+              } else {
+                out += ' validate.errors = [' + (__err) + ']; return false; ';
+              }
+            } else {
+              out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+            }
+            $errSchemaPath = $currErrSchemaPath;
+            if ($breakOnError) {
+              out += ' break; ';
+            }
+          }
+        } else if ($additionalIsSchema) {
+          if ($removeAdditional == 'failing') {
+            out += ' var ' + ($errs) + ' = errors;  ';
+            var $wasComposite = it.compositeRule;
+            it.compositeRule = $it.compositeRule = true;
+            $it.schema = $aProperties;
+            $it.schemaPath = it.schemaPath + '.additionalProperties';
+            $it.errSchemaPath = it.errSchemaPath + '/additionalProperties';
+            $it.errorPath = it.opts._errorDataPathProperty ? it.errorPath : it.util.getPathExpr(it.errorPath, $key, it.opts.jsonPointers);
+            var $passData = $data + '[' + $key + ']';
+            $it.dataPathArr[$dataNxt] = $key;
+            var $code = it.validate($it);
+            $it.baseId = $currentBaseId;
+            if (it.util.varOccurences($code, $nextData) < 2) {
+              out += ' ' + (it.util.varReplace($code, $nextData, $passData)) + ' ';
+            } else {
+              out += ' var ' + ($nextData) + ' = ' + ($passData) + '; ' + ($code) + ' ';
+            }
+            out += ' if (!' + ($nextValid) + ') { errors = ' + ($errs) + '; if (validate.errors !== null) { if (errors) validate.errors.length = errors; else validate.errors = null; } delete ' + ($data) + '[' + ($key) + ']; }  ';
+            it.compositeRule = $it.compositeRule = $wasComposite;
+          } else {
+            $it.schema = $aProperties;
+            $it.schemaPath = it.schemaPath + '.additionalProperties';
+            $it.errSchemaPath = it.errSchemaPath + '/additionalProperties';
+            $it.errorPath = it.opts._errorDataPathProperty ? it.errorPath : it.util.getPathExpr(it.errorPath, $key, it.opts.jsonPointers);
+            var $passData = $data + '[' + $key + ']';
+            $it.dataPathArr[$dataNxt] = $key;
+            var $code = it.validate($it);
+            $it.baseId = $currentBaseId;
+            if (it.util.varOccurences($code, $nextData) < 2) {
+              out += ' ' + (it.util.varReplace($code, $nextData, $passData)) + ' ';
+            } else {
+              out += ' var ' + ($nextData) + ' = ' + ($passData) + '; ' + ($code) + ' ';
+            }
+            if ($breakOnError) {
+              out += ' if (!' + ($nextValid) + ') break; ';
+            }
+          }
+        }
+        it.errorPath = $currentErrorPath;
+      }
+      if ($someProperties) {
+        out += ' } ';
+      }
+      out += ' }  ';
+      if ($breakOnError) {
+        out += ' if (' + ($nextValid) + ') { ';
+        $closingBraces += '}';
+      }
+    }
+    var $useDefaults = it.opts.useDefaults && !it.compositeRule;
+    if ($schemaKeys.length) {
+      var arr3 = $schemaKeys;
+      if (arr3) {
+        var $propertyKey, i3 = -1,
+          l3 = arr3.length - 1;
+        while (i3 < l3) {
+          $propertyKey = arr3[i3 += 1];
+          var $sch = $schema[$propertyKey];
+          if ((it.opts.strictKeywords ? (typeof $sch == 'object' && Object.keys($sch).length > 0) || $sch === false : it.util.schemaHasRules($sch, it.RULES.all))) {
+            var $prop = it.util.getProperty($propertyKey),
+              $passData = $data + $prop,
+              $hasDefault = $useDefaults && $sch.default !== undefined;
+            $it.schema = $sch;
+            $it.schemaPath = $schemaPath + $prop;
+            $it.errSchemaPath = $errSchemaPath + '/' + it.util.escapeFragment($propertyKey);
+            $it.errorPath = it.util.getPath(it.errorPath, $propertyKey, it.opts.jsonPointers);
+            $it.dataPathArr[$dataNxt] = it.util.toQuotedString($propertyKey);
+            var $code = it.validate($it);
+            $it.baseId = $currentBaseId;
+            if (it.util.varOccurences($code, $nextData) < 2) {
+              $code = it.util.varReplace($code, $nextData, $passData);
+              var $useData = $passData;
+            } else {
+              var $useData = $nextData;
+              out += ' var ' + ($nextData) + ' = ' + ($passData) + '; ';
+            }
+            if ($hasDefault) {
+              out += ' ' + ($code) + ' ';
+            } else {
+              if ($requiredHash && $requiredHash[$propertyKey]) {
+                out += ' if ( ' + ($useData) + ' === undefined ';
+                if ($ownProperties) {
+                  out += ' || ! Object.prototype.hasOwnProperty.call(' + ($data) + ', \'' + (it.util.escapeQuotes($propertyKey)) + '\') ';
+                }
+                out += ') { ' + ($nextValid) + ' = false; ';
+                var $currentErrorPath = it.errorPath,
+                  $currErrSchemaPath = $errSchemaPath,
+                  $missingProperty = it.util.escapeQuotes($propertyKey);
+                if (it.opts._errorDataPathProperty) {
+                  it.errorPath = it.util.getPath($currentErrorPath, $propertyKey, it.opts.jsonPointers);
+                }
+                $errSchemaPath = it.errSchemaPath + '/required';
+                var $$outStack = $$outStack || [];
+                $$outStack.push(out);
+                out = ''; /* istanbul ignore else */
+                if (it.createErrors !== false) {
+                  out += ' { keyword: \'' + ('required') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { missingProperty: \'' + ($missingProperty) + '\' } ';
+                  if (it.opts.messages !== false) {
+                    out += ' , message: \'';
+                    if (it.opts._errorDataPathProperty) {
+                      out += 'is a required property';
+                    } else {
+                      out += 'should have required property \\\'' + ($missingProperty) + '\\\'';
+                    }
+                    out += '\' ';
+                  }
+                  if (it.opts.verbose) {
+                    out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+                  }
+                  out += ' } ';
+                } else {
+                  out += ' {} ';
+                }
+                var __err = out;
+                out = $$outStack.pop();
+                if (!it.compositeRule && $breakOnError) {
+                  /* istanbul ignore if */
+                  if (it.async) {
+                    out += ' throw new ValidationError([' + (__err) + ']); ';
+                  } else {
+                    out += ' validate.errors = [' + (__err) + ']; return false; ';
+                  }
+                } else {
+                  out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+                }
+                $errSchemaPath = $currErrSchemaPath;
+                it.errorPath = $currentErrorPath;
+                out += ' } else { ';
+              } else {
+                if ($breakOnError) {
+                  out += ' if ( ' + ($useData) + ' === undefined ';
+                  if ($ownProperties) {
+                    out += ' || ! Object.prototype.hasOwnProperty.call(' + ($data) + ', \'' + (it.util.escapeQuotes($propertyKey)) + '\') ';
+                  }
+                  out += ') { ' + ($nextValid) + ' = true; } else { ';
+                } else {
+                  out += ' if (' + ($useData) + ' !== undefined ';
+                  if ($ownProperties) {
+                    out += ' &&   Object.prototype.hasOwnProperty.call(' + ($data) + ', \'' + (it.util.escapeQuotes($propertyKey)) + '\') ';
+                  }
+                  out += ' ) { ';
+                }
+              }
+              out += ' ' + ($code) + ' } ';
+            }
+          }
+          if ($breakOnError) {
+            out += ' if (' + ($nextValid) + ') { ';
+            $closingBraces += '}';
+          }
+        }
+      }
+    }
+    if ($pPropertyKeys.length) {
+      var arr4 = $pPropertyKeys;
+      if (arr4) {
+        var $pProperty, i4 = -1,
+          l4 = arr4.length - 1;
+        while (i4 < l4) {
+          $pProperty = arr4[i4 += 1];
+          var $sch = $pProperties[$pProperty];
+          if ((it.opts.strictKeywords ? (typeof $sch == 'object' && Object.keys($sch).length > 0) || $sch === false : it.util.schemaHasRules($sch, it.RULES.all))) {
+            $it.schema = $sch;
+            $it.schemaPath = it.schemaPath + '.patternProperties' + it.util.getProperty($pProperty);
+            $it.errSchemaPath = it.errSchemaPath + '/patternProperties/' + it.util.escapeFragment($pProperty);
+            if ($ownProperties) {
+              out += ' ' + ($dataProperties) + ' = ' + ($dataProperties) + ' || Object.keys(' + ($data) + '); for (var ' + ($idx) + '=0; ' + ($idx) + '<' + ($dataProperties) + '.length; ' + ($idx) + '++) { var ' + ($key) + ' = ' + ($dataProperties) + '[' + ($idx) + ']; ';
+            } else {
+              out += ' for (var ' + ($key) + ' in ' + ($data) + ') { ';
+            }
+            out += ' if (' + (it.usePattern($pProperty)) + '.test(' + ($key) + ')) { ';
+            $it.errorPath = it.util.getPathExpr(it.errorPath, $key, it.opts.jsonPointers);
+            var $passData = $data + '[' + $key + ']';
+            $it.dataPathArr[$dataNxt] = $key;
+            var $code = it.validate($it);
+            $it.baseId = $currentBaseId;
+            if (it.util.varOccurences($code, $nextData) < 2) {
+              out += ' ' + (it.util.varReplace($code, $nextData, $passData)) + ' ';
+            } else {
+              out += ' var ' + ($nextData) + ' = ' + ($passData) + '; ' + ($code) + ' ';
+            }
+            if ($breakOnError) {
+              out += ' if (!' + ($nextValid) + ') break; ';
+            }
+            out += ' } ';
+            if ($breakOnError) {
+              out += ' else ' + ($nextValid) + ' = true; ';
+            }
+            out += ' }  ';
+            if ($breakOnError) {
+              out += ' if (' + ($nextValid) + ') { ';
+              $closingBraces += '}';
+            }
+          }
+        }
+      }
+    }
+    if ($breakOnError) {
+      out += ' ' + ($closingBraces) + ' if (' + ($errs) + ' == errors) {';
+    }
+    return out;
+  }
+
+  },{}],35:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_propertyNames(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $data = 'data' + ($dataLvl || '');
+    var $errs = 'errs__' + $lvl;
+    var $it = it.util.copy(it);
+    var $closingBraces = '';
+    $it.level++;
+    var $nextValid = 'valid' + $it.level;
+    out += 'var ' + ($errs) + ' = errors;';
+    if ((it.opts.strictKeywords ? (typeof $schema == 'object' && Object.keys($schema).length > 0) || $schema === false : it.util.schemaHasRules($schema, it.RULES.all))) {
+      $it.schema = $schema;
+      $it.schemaPath = $schemaPath;
+      $it.errSchemaPath = $errSchemaPath;
+      var $key = 'key' + $lvl,
+        $idx = 'idx' + $lvl,
+        $i = 'i' + $lvl,
+        $invalidName = '\' + ' + $key + ' + \'',
+        $dataNxt = $it.dataLevel = it.dataLevel + 1,
+        $nextData = 'data' + $dataNxt,
+        $dataProperties = 'dataProperties' + $lvl,
+        $ownProperties = it.opts.ownProperties,
+        $currentBaseId = it.baseId;
+      if ($ownProperties) {
+        out += ' var ' + ($dataProperties) + ' = undefined; ';
+      }
+      if ($ownProperties) {
+        out += ' ' + ($dataProperties) + ' = ' + ($dataProperties) + ' || Object.keys(' + ($data) + '); for (var ' + ($idx) + '=0; ' + ($idx) + '<' + ($dataProperties) + '.length; ' + ($idx) + '++) { var ' + ($key) + ' = ' + ($dataProperties) + '[' + ($idx) + ']; ';
+      } else {
+        out += ' for (var ' + ($key) + ' in ' + ($data) + ') { ';
+      }
+      out += ' var startErrs' + ($lvl) + ' = errors; ';
+      var $passData = $key;
+      var $wasComposite = it.compositeRule;
+      it.compositeRule = $it.compositeRule = true;
+      var $code = it.validate($it);
+      $it.baseId = $currentBaseId;
+      if (it.util.varOccurences($code, $nextData) < 2) {
+        out += ' ' + (it.util.varReplace($code, $nextData, $passData)) + ' ';
+      } else {
+        out += ' var ' + ($nextData) + ' = ' + ($passData) + '; ' + ($code) + ' ';
+      }
+      it.compositeRule = $it.compositeRule = $wasComposite;
+      out += ' if (!' + ($nextValid) + ') { for (var ' + ($i) + '=startErrs' + ($lvl) + '; ' + ($i) + '<errors; ' + ($i) + '++) { vErrors[' + ($i) + '].propertyName = ' + ($key) + '; }   var err =   '; /* istanbul ignore else */
+      if (it.createErrors !== false) {
+        out += ' { keyword: \'' + ('propertyNames') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { propertyName: \'' + ($invalidName) + '\' } ';
+        if (it.opts.messages !== false) {
+          out += ' , message: \'property name \\\'' + ($invalidName) + '\\\' is invalid\' ';
+        }
+        if (it.opts.verbose) {
+          out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+        }
+        out += ' } ';
+      } else {
+        out += ' {} ';
+      }
+      out += ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+      if (!it.compositeRule && $breakOnError) {
+        /* istanbul ignore if */
+        if (it.async) {
+          out += ' throw new ValidationError(vErrors); ';
+        } else {
+          out += ' validate.errors = vErrors; return false; ';
+        }
+      }
+      if ($breakOnError) {
+        out += ' break; ';
+      }
+      out += ' } }';
+    }
+    if ($breakOnError) {
+      out += ' ' + ($closingBraces) + ' if (' + ($errs) + ' == errors) {';
+    }
+    return out;
+  }
+
+  },{}],36:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_ref(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $data = 'data' + ($dataLvl || '');
+    var $valid = 'valid' + $lvl;
+    var $async, $refCode;
+    if ($schema == '#' || $schema == '#/') {
+      if (it.isRoot) {
+        $async = it.async;
+        $refCode = 'validate';
+      } else {
+        $async = it.root.schema.$async === true;
+        $refCode = 'root.refVal[0]';
+      }
+    } else {
+      var $refVal = it.resolveRef(it.baseId, $schema, it.isRoot);
+      if ($refVal === undefined) {
+        var $message = it.MissingRefError.message(it.baseId, $schema);
+        if (it.opts.missingRefs == 'fail') {
+          it.logger.error($message);
+          var $$outStack = $$outStack || [];
+          $$outStack.push(out);
+          out = ''; /* istanbul ignore else */
+          if (it.createErrors !== false) {
+            out += ' { keyword: \'' + ('$ref') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { ref: \'' + (it.util.escapeQuotes($schema)) + '\' } ';
+            if (it.opts.messages !== false) {
+              out += ' , message: \'can\\\'t resolve reference ' + (it.util.escapeQuotes($schema)) + '\' ';
+            }
+            if (it.opts.verbose) {
+              out += ' , schema: ' + (it.util.toQuotedString($schema)) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+            }
+            out += ' } ';
+          } else {
+            out += ' {} ';
+          }
+          var __err = out;
+          out = $$outStack.pop();
+          if (!it.compositeRule && $breakOnError) {
+            /* istanbul ignore if */
+            if (it.async) {
+              out += ' throw new ValidationError([' + (__err) + ']); ';
+            } else {
+              out += ' validate.errors = [' + (__err) + ']; return false; ';
+            }
+          } else {
+            out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+          }
+          if ($breakOnError) {
+            out += ' if (false) { ';
+          }
+        } else if (it.opts.missingRefs == 'ignore') {
+          it.logger.warn($message);
+          if ($breakOnError) {
+            out += ' if (true) { ';
+          }
+        } else {
+          throw new it.MissingRefError(it.baseId, $schema, $message);
+        }
+      } else if ($refVal.inline) {
+        var $it = it.util.copy(it);
+        $it.level++;
+        var $nextValid = 'valid' + $it.level;
+        $it.schema = $refVal.schema;
+        $it.schemaPath = '';
+        $it.errSchemaPath = $schema;
+        var $code = it.validate($it).replace(/validate\.schema/g, $refVal.code);
+        out += ' ' + ($code) + ' ';
+        if ($breakOnError) {
+          out += ' if (' + ($nextValid) + ') { ';
+        }
+      } else {
+        $async = $refVal.$async === true || (it.async && $refVal.$async !== false);
+        $refCode = $refVal.code;
+      }
+    }
+    if ($refCode) {
+      var $$outStack = $$outStack || [];
+      $$outStack.push(out);
+      out = '';
+      if (it.opts.passContext) {
+        out += ' ' + ($refCode) + '.call(this, ';
+      } else {
+        out += ' ' + ($refCode) + '( ';
+      }
+      out += ' ' + ($data) + ', (dataPath || \'\')';
+      if (it.errorPath != '""') {
+        out += ' + ' + (it.errorPath);
+      }
+      var $parentData = $dataLvl ? 'data' + (($dataLvl - 1) || '') : 'parentData',
+        $parentDataProperty = $dataLvl ? it.dataPathArr[$dataLvl] : 'parentDataProperty';
+      out += ' , ' + ($parentData) + ' , ' + ($parentDataProperty) + ', rootData)  ';
+      var __callValidate = out;
+      out = $$outStack.pop();
+      if ($async) {
+        if (!it.async) throw new Error('async schema referenced by sync schema');
+        if ($breakOnError) {
+          out += ' var ' + ($valid) + '; ';
+        }
+        out += ' try { await ' + (__callValidate) + '; ';
+        if ($breakOnError) {
+          out += ' ' + ($valid) + ' = true; ';
+        }
+        out += ' } catch (e) { if (!(e instanceof ValidationError)) throw e; if (vErrors === null) vErrors = e.errors; else vErrors = vErrors.concat(e.errors); errors = vErrors.length; ';
+        if ($breakOnError) {
+          out += ' ' + ($valid) + ' = false; ';
+        }
+        out += ' } ';
+        if ($breakOnError) {
+          out += ' if (' + ($valid) + ') { ';
+        }
+      } else {
+        out += ' if (!' + (__callValidate) + ') { if (vErrors === null) vErrors = ' + ($refCode) + '.errors; else vErrors = vErrors.concat(' + ($refCode) + '.errors); errors = vErrors.length; } ';
+        if ($breakOnError) {
+          out += ' else { ';
+        }
+      }
+    }
+    return out;
+  }
+
+  },{}],37:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_required(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $data = 'data' + ($dataLvl || '');
+    var $valid = 'valid' + $lvl;
+    var $isData = it.opts.$data && $schema && $schema.$data,
+      $schemaValue;
+    if ($isData) {
+      out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
+      $schemaValue = 'schema' + $lvl;
+    } else {
+      $schemaValue = $schema;
+    }
+    var $vSchema = 'schema' + $lvl;
+    if (!$isData) {
+      if ($schema.length < it.opts.loopRequired && it.schema.properties && Object.keys(it.schema.properties).length) {
+        var $required = [];
+        var arr1 = $schema;
+        if (arr1) {
+          var $property, i1 = -1,
+            l1 = arr1.length - 1;
+          while (i1 < l1) {
+            $property = arr1[i1 += 1];
+            var $propertySch = it.schema.properties[$property];
+            if (!($propertySch && (it.opts.strictKeywords ? (typeof $propertySch == 'object' && Object.keys($propertySch).length > 0) || $propertySch === false : it.util.schemaHasRules($propertySch, it.RULES.all)))) {
+              $required[$required.length] = $property;
+            }
+          }
+        }
+      } else {
+        var $required = $schema;
+      }
+    }
+    if ($isData || $required.length) {
+      var $currentErrorPath = it.errorPath,
+        $loopRequired = $isData || $required.length >= it.opts.loopRequired,
+        $ownProperties = it.opts.ownProperties;
+      if ($breakOnError) {
+        out += ' var missing' + ($lvl) + '; ';
+        if ($loopRequired) {
+          if (!$isData) {
+            out += ' var ' + ($vSchema) + ' = validate.schema' + ($schemaPath) + '; ';
+          }
+          var $i = 'i' + $lvl,
+            $propertyPath = 'schema' + $lvl + '[' + $i + ']',
+            $missingProperty = '\' + ' + $propertyPath + ' + \'';
+          if (it.opts._errorDataPathProperty) {
+            it.errorPath = it.util.getPathExpr($currentErrorPath, $propertyPath, it.opts.jsonPointers);
+          }
+          out += ' var ' + ($valid) + ' = true; ';
+          if ($isData) {
+            out += ' if (schema' + ($lvl) + ' === undefined) ' + ($valid) + ' = true; else if (!Array.isArray(schema' + ($lvl) + ')) ' + ($valid) + ' = false; else {';
+          }
+          out += ' for (var ' + ($i) + ' = 0; ' + ($i) + ' < ' + ($vSchema) + '.length; ' + ($i) + '++) { ' + ($valid) + ' = ' + ($data) + '[' + ($vSchema) + '[' + ($i) + ']] !== undefined ';
+          if ($ownProperties) {
+            out += ' &&   Object.prototype.hasOwnProperty.call(' + ($data) + ', ' + ($vSchema) + '[' + ($i) + ']) ';
+          }
+          out += '; if (!' + ($valid) + ') break; } ';
+          if ($isData) {
+            out += '  }  ';
+          }
+          out += '  if (!' + ($valid) + ') {   ';
+          var $$outStack = $$outStack || [];
+          $$outStack.push(out);
+          out = ''; /* istanbul ignore else */
+          if (it.createErrors !== false) {
+            out += ' { keyword: \'' + ('required') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { missingProperty: \'' + ($missingProperty) + '\' } ';
+            if (it.opts.messages !== false) {
+              out += ' , message: \'';
+              if (it.opts._errorDataPathProperty) {
+                out += 'is a required property';
+              } else {
+                out += 'should have required property \\\'' + ($missingProperty) + '\\\'';
+              }
+              out += '\' ';
+            }
+            if (it.opts.verbose) {
+              out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+            }
+            out += ' } ';
+          } else {
+            out += ' {} ';
+          }
+          var __err = out;
+          out = $$outStack.pop();
+          if (!it.compositeRule && $breakOnError) {
+            /* istanbul ignore if */
+            if (it.async) {
+              out += ' throw new ValidationError([' + (__err) + ']); ';
+            } else {
+              out += ' validate.errors = [' + (__err) + ']; return false; ';
+            }
+          } else {
+            out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+          }
+          out += ' } else { ';
+        } else {
+          out += ' if ( ';
+          var arr2 = $required;
+          if (arr2) {
+            var $propertyKey, $i = -1,
+              l2 = arr2.length - 1;
+            while ($i < l2) {
+              $propertyKey = arr2[$i += 1];
+              if ($i) {
+                out += ' || ';
+              }
+              var $prop = it.util.getProperty($propertyKey),
+                $useData = $data + $prop;
+              out += ' ( ( ' + ($useData) + ' === undefined ';
+              if ($ownProperties) {
+                out += ' || ! Object.prototype.hasOwnProperty.call(' + ($data) + ', \'' + (it.util.escapeQuotes($propertyKey)) + '\') ';
+              }
+              out += ') && (missing' + ($lvl) + ' = ' + (it.util.toQuotedString(it.opts.jsonPointers ? $propertyKey : $prop)) + ') ) ';
+            }
+          }
+          out += ') {  ';
+          var $propertyPath = 'missing' + $lvl,
+            $missingProperty = '\' + ' + $propertyPath + ' + \'';
+          if (it.opts._errorDataPathProperty) {
+            it.errorPath = it.opts.jsonPointers ? it.util.getPathExpr($currentErrorPath, $propertyPath, true) : $currentErrorPath + ' + ' + $propertyPath;
+          }
+          var $$outStack = $$outStack || [];
+          $$outStack.push(out);
+          out = ''; /* istanbul ignore else */
+          if (it.createErrors !== false) {
+            out += ' { keyword: \'' + ('required') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { missingProperty: \'' + ($missingProperty) + '\' } ';
+            if (it.opts.messages !== false) {
+              out += ' , message: \'';
+              if (it.opts._errorDataPathProperty) {
+                out += 'is a required property';
+              } else {
+                out += 'should have required property \\\'' + ($missingProperty) + '\\\'';
+              }
+              out += '\' ';
+            }
+            if (it.opts.verbose) {
+              out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+            }
+            out += ' } ';
+          } else {
+            out += ' {} ';
+          }
+          var __err = out;
+          out = $$outStack.pop();
+          if (!it.compositeRule && $breakOnError) {
+            /* istanbul ignore if */
+            if (it.async) {
+              out += ' throw new ValidationError([' + (__err) + ']); ';
+            } else {
+              out += ' validate.errors = [' + (__err) + ']; return false; ';
+            }
+          } else {
+            out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+          }
+          out += ' } else { ';
+        }
+      } else {
+        if ($loopRequired) {
+          if (!$isData) {
+            out += ' var ' + ($vSchema) + ' = validate.schema' + ($schemaPath) + '; ';
+          }
+          var $i = 'i' + $lvl,
+            $propertyPath = 'schema' + $lvl + '[' + $i + ']',
+            $missingProperty = '\' + ' + $propertyPath + ' + \'';
+          if (it.opts._errorDataPathProperty) {
+            it.errorPath = it.util.getPathExpr($currentErrorPath, $propertyPath, it.opts.jsonPointers);
+          }
+          if ($isData) {
+            out += ' if (' + ($vSchema) + ' && !Array.isArray(' + ($vSchema) + ')) {  var err =   '; /* istanbul ignore else */
+            if (it.createErrors !== false) {
+              out += ' { keyword: \'' + ('required') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { missingProperty: \'' + ($missingProperty) + '\' } ';
+              if (it.opts.messages !== false) {
+                out += ' , message: \'';
+                if (it.opts._errorDataPathProperty) {
+                  out += 'is a required property';
+                } else {
+                  out += 'should have required property \\\'' + ($missingProperty) + '\\\'';
+                }
+                out += '\' ';
+              }
+              if (it.opts.verbose) {
+                out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+              }
+              out += ' } ';
+            } else {
+              out += ' {} ';
+            }
+            out += ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; } else if (' + ($vSchema) + ' !== undefined) { ';
+          }
+          out += ' for (var ' + ($i) + ' = 0; ' + ($i) + ' < ' + ($vSchema) + '.length; ' + ($i) + '++) { if (' + ($data) + '[' + ($vSchema) + '[' + ($i) + ']] === undefined ';
+          if ($ownProperties) {
+            out += ' || ! Object.prototype.hasOwnProperty.call(' + ($data) + ', ' + ($vSchema) + '[' + ($i) + ']) ';
+          }
+          out += ') {  var err =   '; /* istanbul ignore else */
+          if (it.createErrors !== false) {
+            out += ' { keyword: \'' + ('required') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { missingProperty: \'' + ($missingProperty) + '\' } ';
+            if (it.opts.messages !== false) {
+              out += ' , message: \'';
+              if (it.opts._errorDataPathProperty) {
+                out += 'is a required property';
+              } else {
+                out += 'should have required property \\\'' + ($missingProperty) + '\\\'';
+              }
+              out += '\' ';
+            }
+            if (it.opts.verbose) {
+              out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+            }
+            out += ' } ';
+          } else {
+            out += ' {} ';
+          }
+          out += ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; } } ';
+          if ($isData) {
+            out += '  }  ';
+          }
+        } else {
+          var arr3 = $required;
+          if (arr3) {
+            var $propertyKey, i3 = -1,
+              l3 = arr3.length - 1;
+            while (i3 < l3) {
+              $propertyKey = arr3[i3 += 1];
+              var $prop = it.util.getProperty($propertyKey),
+                $missingProperty = it.util.escapeQuotes($propertyKey),
+                $useData = $data + $prop;
+              if (it.opts._errorDataPathProperty) {
+                it.errorPath = it.util.getPath($currentErrorPath, $propertyKey, it.opts.jsonPointers);
+              }
+              out += ' if ( ' + ($useData) + ' === undefined ';
+              if ($ownProperties) {
+                out += ' || ! Object.prototype.hasOwnProperty.call(' + ($data) + ', \'' + (it.util.escapeQuotes($propertyKey)) + '\') ';
+              }
+              out += ') {  var err =   '; /* istanbul ignore else */
+              if (it.createErrors !== false) {
+                out += ' { keyword: \'' + ('required') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { missingProperty: \'' + ($missingProperty) + '\' } ';
+                if (it.opts.messages !== false) {
+                  out += ' , message: \'';
+                  if (it.opts._errorDataPathProperty) {
+                    out += 'is a required property';
+                  } else {
+                    out += 'should have required property \\\'' + ($missingProperty) + '\\\'';
+                  }
+                  out += '\' ';
+                }
+                if (it.opts.verbose) {
+                  out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+                }
+                out += ' } ';
+              } else {
+                out += ' {} ';
+              }
+              out += ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; } ';
+            }
+          }
+        }
+      }
+      it.errorPath = $currentErrorPath;
+    } else if ($breakOnError) {
+      out += ' if (true) {';
+    }
+    return out;
+  }
+
+  },{}],38:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_uniqueItems(it, $keyword, $ruleType) {
+    var out = ' ';
+    var $lvl = it.level;
+    var $dataLvl = it.dataLevel;
+    var $schema = it.schema[$keyword];
+    var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+    var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+    var $breakOnError = !it.opts.allErrors;
+    var $data = 'data' + ($dataLvl || '');
+    var $valid = 'valid' + $lvl;
+    var $isData = it.opts.$data && $schema && $schema.$data,
+      $schemaValue;
+    if ($isData) {
+      out += ' var schema' + ($lvl) + ' = ' + (it.util.getData($schema.$data, $dataLvl, it.dataPathArr)) + '; ';
+      $schemaValue = 'schema' + $lvl;
+    } else {
+      $schemaValue = $schema;
+    }
+    if (($schema || $isData) && it.opts.uniqueItems !== false) {
+      if ($isData) {
+        out += ' var ' + ($valid) + '; if (' + ($schemaValue) + ' === false || ' + ($schemaValue) + ' === undefined) ' + ($valid) + ' = true; else if (typeof ' + ($schemaValue) + ' != \'boolean\') ' + ($valid) + ' = false; else { ';
+      }
+      out += ' var i = ' + ($data) + '.length , ' + ($valid) + ' = true , j; if (i > 1) { ';
+      var $itemType = it.schema.items && it.schema.items.type,
+        $typeIsArray = Array.isArray($itemType);
+      if (!$itemType || $itemType == 'object' || $itemType == 'array' || ($typeIsArray && ($itemType.indexOf('object') >= 0 || $itemType.indexOf('array') >= 0))) {
+        out += ' outer: for (;i--;) { for (j = i; j--;) { if (equal(' + ($data) + '[i], ' + ($data) + '[j])) { ' + ($valid) + ' = false; break outer; } } } ';
+      } else {
+        out += ' var itemIndices = {}, item; for (;i--;) { var item = ' + ($data) + '[i]; ';
+        var $method = 'checkDataType' + ($typeIsArray ? 's' : '');
+        out += ' if (' + (it.util[$method]($itemType, 'item', it.opts.strictNumbers, true)) + ') continue; ';
+        if ($typeIsArray) {
+          out += ' if (typeof item == \'string\') item = \'"\' + item; ';
+        }
+        out += ' if (typeof itemIndices[item] == \'number\') { ' + ($valid) + ' = false; j = itemIndices[item]; break; } itemIndices[item] = i; } ';
+      }
+      out += ' } ';
+      if ($isData) {
+        out += '  }  ';
+      }
+      out += ' if (!' + ($valid) + ') {   ';
+      var $$outStack = $$outStack || [];
+      $$outStack.push(out);
+      out = ''; /* istanbul ignore else */
+      if (it.createErrors !== false) {
+        out += ' { keyword: \'' + ('uniqueItems') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { i: i, j: j } ';
+        if (it.opts.messages !== false) {
+          out += ' , message: \'should NOT have duplicate items (items ## \' + j + \' and \' + i + \' are identical)\' ';
+        }
+        if (it.opts.verbose) {
+          out += ' , schema:  ';
+          if ($isData) {
+            out += 'validate.schema' + ($schemaPath);
+          } else {
+            out += '' + ($schema);
+          }
+          out += '         , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+        }
+        out += ' } ';
+      } else {
+        out += ' {} ';
+      }
+      var __err = out;
+      out = $$outStack.pop();
+      if (!it.compositeRule && $breakOnError) {
+        /* istanbul ignore if */
+        if (it.async) {
+          out += ' throw new ValidationError([' + (__err) + ']); ';
+        } else {
+          out += ' validate.errors = [' + (__err) + ']; return false; ';
+        }
+      } else {
+        out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+      }
+      out += ' } ';
+      if ($breakOnError) {
+        out += ' else { ';
+      }
+    } else {
+      if ($breakOnError) {
+        out += ' if (true) { ';
+      }
+    }
+    return out;
+  }
+
+  },{}],39:[function(require,module,exports){
+  'use strict';
+  module.exports = function generate_validate(it, $keyword, $ruleType) {
+    var out = '';
+    var $async = it.schema.$async === true,
+      $refKeywords = it.util.schemaHasRulesExcept(it.schema, it.RULES.all, '$ref'),
+      $id = it.self._getId(it.schema);
+    if (it.opts.strictKeywords) {
+      var $unknownKwd = it.util.schemaUnknownRules(it.schema, it.RULES.keywords);
+      if ($unknownKwd) {
+        var $keywordsMsg = 'unknown keyword: ' + $unknownKwd;
+        if (it.opts.strictKeywords === 'log') it.logger.warn($keywordsMsg);
+        else throw new Error($keywordsMsg);
+      }
+    }
+    if (it.isTop) {
+      out += ' var validate = ';
+      if ($async) {
+        it.async = true;
+        out += 'async ';
+      }
+      out += 'function(data, dataPath, parentData, parentDataProperty, rootData) { \'use strict\'; ';
+      if ($id && (it.opts.sourceCode || it.opts.processCode)) {
+        out += ' ' + ('/\*# sourceURL=' + $id + ' */') + ' ';
+      }
+    }
+    if (typeof it.schema == 'boolean' || !($refKeywords || it.schema.$ref)) {
+      var $keyword = 'false schema';
+      var $lvl = it.level;
+      var $dataLvl = it.dataLevel;
+      var $schema = it.schema[$keyword];
+      var $schemaPath = it.schemaPath + it.util.getProperty($keyword);
+      var $errSchemaPath = it.errSchemaPath + '/' + $keyword;
+      var $breakOnError = !it.opts.allErrors;
+      var $errorKeyword;
+      var $data = 'data' + ($dataLvl || '');
+      var $valid = 'valid' + $lvl;
+      if (it.schema === false) {
+        if (it.isTop) {
+          $breakOnError = true;
+        } else {
+          out += ' var ' + ($valid) + ' = false; ';
+        }
+        var $$outStack = $$outStack || [];
+        $$outStack.push(out);
+        out = ''; /* istanbul ignore else */
+        if (it.createErrors !== false) {
+          out += ' { keyword: \'' + ($errorKeyword || 'false schema') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: {} ';
+          if (it.opts.messages !== false) {
+            out += ' , message: \'boolean schema is false\' ';
+          }
+          if (it.opts.verbose) {
+            out += ' , schema: false , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+          }
+          out += ' } ';
+        } else {
+          out += ' {} ';
+        }
+        var __err = out;
+        out = $$outStack.pop();
+        if (!it.compositeRule && $breakOnError) {
+          /* istanbul ignore if */
+          if (it.async) {
+            out += ' throw new ValidationError([' + (__err) + ']); ';
+          } else {
+            out += ' validate.errors = [' + (__err) + ']; return false; ';
+          }
+        } else {
+          out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+        }
+      } else {
+        if (it.isTop) {
+          if ($async) {
+            out += ' return data; ';
+          } else {
+            out += ' validate.errors = null; return true; ';
+          }
+        } else {
+          out += ' var ' + ($valid) + ' = true; ';
+        }
+      }
+      if (it.isTop) {
+        out += ' }; return validate; ';
+      }
+      return out;
+    }
+    if (it.isTop) {
+      var $top = it.isTop,
+        $lvl = it.level = 0,
+        $dataLvl = it.dataLevel = 0,
+        $data = 'data';
+      it.rootId = it.resolve.fullPath(it.self._getId(it.root.schema));
+      it.baseId = it.baseId || it.rootId;
+      delete it.isTop;
+      it.dataPathArr = [""];
+      if (it.schema.default !== undefined && it.opts.useDefaults && it.opts.strictDefaults) {
+        var $defaultMsg = 'default is ignored in the schema root';
+        if (it.opts.strictDefaults === 'log') it.logger.warn($defaultMsg);
+        else throw new Error($defaultMsg);
+      }
+      out += ' var vErrors = null; ';
+      out += ' var errors = 0;     ';
+      out += ' if (rootData === undefined) rootData = data; ';
+    } else {
+      var $lvl = it.level,
+        $dataLvl = it.dataLevel,
+        $data = 'data' + ($dataLvl || '');
+      if ($id) it.baseId = it.resolve.url(it.baseId, $id);
+      if ($async && !it.async) throw new Error('async schema in sync schema');
+      out += ' var errs_' + ($lvl) + ' = errors;';
+    }
+    var $valid = 'valid' + $lvl,
+      $breakOnError = !it.opts.allErrors,
+      $closingBraces1 = '',
+      $closingBraces2 = '';
+    var $errorKeyword;
+    var $typeSchema = it.schema.type,
+      $typeIsArray = Array.isArray($typeSchema);
+    if ($typeSchema && it.opts.nullable && it.schema.nullable === true) {
+      if ($typeIsArray) {
+        if ($typeSchema.indexOf('null') == -1) $typeSchema = $typeSchema.concat('null');
+      } else if ($typeSchema != 'null') {
+        $typeSchema = [$typeSchema, 'null'];
+        $typeIsArray = true;
+      }
+    }
+    if ($typeIsArray && $typeSchema.length == 1) {
+      $typeSchema = $typeSchema[0];
+      $typeIsArray = false;
+    }
+    if (it.schema.$ref && $refKeywords) {
+      if (it.opts.extendRefs == 'fail') {
+        throw new Error('$ref: validation keywords used in schema at path "' + it.errSchemaPath + '" (see option extendRefs)');
+      } else if (it.opts.extendRefs !== true) {
+        $refKeywords = false;
+        it.logger.warn('$ref: keywords ignored in schema at path "' + it.errSchemaPath + '"');
+      }
+    }
+    if (it.schema.$comment && it.opts.$comment) {
+      out += ' ' + (it.RULES.all.$comment.code(it, '$comment'));
+    }
+    if ($typeSchema) {
+      if (it.opts.coerceTypes) {
+        var $coerceToTypes = it.util.coerceToTypes(it.opts.coerceTypes, $typeSchema);
+      }
+      var $rulesGroup = it.RULES.types[$typeSchema];
+      if ($coerceToTypes || $typeIsArray || $rulesGroup === true || ($rulesGroup && !$shouldUseGroup($rulesGroup))) {
+        var $schemaPath = it.schemaPath + '.type',
+          $errSchemaPath = it.errSchemaPath + '/type';
+        var $schemaPath = it.schemaPath + '.type',
+          $errSchemaPath = it.errSchemaPath + '/type',
+          $method = $typeIsArray ? 'checkDataTypes' : 'checkDataType';
+        out += ' if (' + (it.util[$method]($typeSchema, $data, it.opts.strictNumbers, true)) + ') { ';
+        if ($coerceToTypes) {
+          var $dataType = 'dataType' + $lvl,
+            $coerced = 'coerced' + $lvl;
+          out += ' var ' + ($dataType) + ' = typeof ' + ($data) + '; var ' + ($coerced) + ' = undefined; ';
+          if (it.opts.coerceTypes == 'array') {
+            out += ' if (' + ($dataType) + ' == \'object\' && Array.isArray(' + ($data) + ') && ' + ($data) + '.length == 1) { ' + ($data) + ' = ' + ($data) + '[0]; ' + ($dataType) + ' = typeof ' + ($data) + '; if (' + (it.util.checkDataType(it.schema.type, $data, it.opts.strictNumbers)) + ') ' + ($coerced) + ' = ' + ($data) + '; } ';
+          }
+          out += ' if (' + ($coerced) + ' !== undefined) ; ';
+          var arr1 = $coerceToTypes;
+          if (arr1) {
+            var $type, $i = -1,
+              l1 = arr1.length - 1;
+            while ($i < l1) {
+              $type = arr1[$i += 1];
+              if ($type == 'string') {
+                out += ' else if (' + ($dataType) + ' == \'number\' || ' + ($dataType) + ' == \'boolean\') ' + ($coerced) + ' = \'\' + ' + ($data) + '; else if (' + ($data) + ' === null) ' + ($coerced) + ' = \'\'; ';
+              } else if ($type == 'number' || $type == 'integer') {
+                out += ' else if (' + ($dataType) + ' == \'boolean\' || ' + ($data) + ' === null || (' + ($dataType) + ' == \'string\' && ' + ($data) + ' && ' + ($data) + ' == +' + ($data) + ' ';
+                if ($type == 'integer') {
+                  out += ' && !(' + ($data) + ' % 1)';
+                }
+                out += ')) ' + ($coerced) + ' = +' + ($data) + '; ';
+              } else if ($type == 'boolean') {
+                out += ' else if (' + ($data) + ' === \'false\' || ' + ($data) + ' === 0 || ' + ($data) + ' === null) ' + ($coerced) + ' = false; else if (' + ($data) + ' === \'true\' || ' + ($data) + ' === 1) ' + ($coerced) + ' = true; ';
+              } else if ($type == 'null') {
+                out += ' else if (' + ($data) + ' === \'\' || ' + ($data) + ' === 0 || ' + ($data) + ' === false) ' + ($coerced) + ' = null; ';
+              } else if (it.opts.coerceTypes == 'array' && $type == 'array') {
+                out += ' else if (' + ($dataType) + ' == \'string\' || ' + ($dataType) + ' == \'number\' || ' + ($dataType) + ' == \'boolean\' || ' + ($data) + ' == null) ' + ($coerced) + ' = [' + ($data) + ']; ';
+              }
+            }
+          }
+          out += ' else {   ';
+          var $$outStack = $$outStack || [];
+          $$outStack.push(out);
+          out = ''; /* istanbul ignore else */
+          if (it.createErrors !== false) {
+            out += ' { keyword: \'' + ($errorKeyword || 'type') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { type: \'';
+            if ($typeIsArray) {
+              out += '' + ($typeSchema.join(","));
+            } else {
+              out += '' + ($typeSchema);
+            }
+            out += '\' } ';
+            if (it.opts.messages !== false) {
+              out += ' , message: \'should be ';
+              if ($typeIsArray) {
+                out += '' + ($typeSchema.join(","));
+              } else {
+                out += '' + ($typeSchema);
+              }
+              out += '\' ';
+            }
+            if (it.opts.verbose) {
+              out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+            }
+            out += ' } ';
+          } else {
+            out += ' {} ';
+          }
+          var __err = out;
+          out = $$outStack.pop();
+          if (!it.compositeRule && $breakOnError) {
+            /* istanbul ignore if */
+            if (it.async) {
+              out += ' throw new ValidationError([' + (__err) + ']); ';
+            } else {
+              out += ' validate.errors = [' + (__err) + ']; return false; ';
+            }
+          } else {
+            out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+          }
+          out += ' } if (' + ($coerced) + ' !== undefined) {  ';
+          var $parentData = $dataLvl ? 'data' + (($dataLvl - 1) || '') : 'parentData',
+            $parentDataProperty = $dataLvl ? it.dataPathArr[$dataLvl] : 'parentDataProperty';
+          out += ' ' + ($data) + ' = ' + ($coerced) + '; ';
+          if (!$dataLvl) {
+            out += 'if (' + ($parentData) + ' !== undefined)';
+          }
+          out += ' ' + ($parentData) + '[' + ($parentDataProperty) + '] = ' + ($coerced) + '; } ';
+        } else {
+          var $$outStack = $$outStack || [];
+          $$outStack.push(out);
+          out = ''; /* istanbul ignore else */
+          if (it.createErrors !== false) {
+            out += ' { keyword: \'' + ($errorKeyword || 'type') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { type: \'';
+            if ($typeIsArray) {
+              out += '' + ($typeSchema.join(","));
+            } else {
+              out += '' + ($typeSchema);
+            }
+            out += '\' } ';
+            if (it.opts.messages !== false) {
+              out += ' , message: \'should be ';
+              if ($typeIsArray) {
+                out += '' + ($typeSchema.join(","));
+              } else {
+                out += '' + ($typeSchema);
+              }
+              out += '\' ';
+            }
+            if (it.opts.verbose) {
+              out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+            }
+            out += ' } ';
+          } else {
+            out += ' {} ';
+          }
+          var __err = out;
+          out = $$outStack.pop();
+          if (!it.compositeRule && $breakOnError) {
+            /* istanbul ignore if */
+            if (it.async) {
+              out += ' throw new ValidationError([' + (__err) + ']); ';
+            } else {
+              out += ' validate.errors = [' + (__err) + ']; return false; ';
+            }
+          } else {
+            out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+          }
+        }
+        out += ' } ';
+      }
+    }
+    if (it.schema.$ref && !$refKeywords) {
+      out += ' ' + (it.RULES.all.$ref.code(it, '$ref')) + ' ';
+      if ($breakOnError) {
+        out += ' } if (errors === ';
+        if ($top) {
+          out += '0';
+        } else {
+          out += 'errs_' + ($lvl);
+        }
+        out += ') { ';
+        $closingBraces2 += '}';
+      }
+    } else {
+      var arr2 = it.RULES;
+      if (arr2) {
+        var $rulesGroup, i2 = -1,
+          l2 = arr2.length - 1;
+        while (i2 < l2) {
+          $rulesGroup = arr2[i2 += 1];
+          if ($shouldUseGroup($rulesGroup)) {
+            if ($rulesGroup.type) {
+              out += ' if (' + (it.util.checkDataType($rulesGroup.type, $data, it.opts.strictNumbers)) + ') { ';
+            }
+            if (it.opts.useDefaults) {
+              if ($rulesGroup.type == 'object' && it.schema.properties) {
+                var $schema = it.schema.properties,
+                  $schemaKeys = Object.keys($schema);
+                var arr3 = $schemaKeys;
+                if (arr3) {
+                  var $propertyKey, i3 = -1,
+                    l3 = arr3.length - 1;
+                  while (i3 < l3) {
+                    $propertyKey = arr3[i3 += 1];
+                    var $sch = $schema[$propertyKey];
+                    if ($sch.default !== undefined) {
+                      var $passData = $data + it.util.getProperty($propertyKey);
+                      if (it.compositeRule) {
+                        if (it.opts.strictDefaults) {
+                          var $defaultMsg = 'default is ignored for: ' + $passData;
+                          if (it.opts.strictDefaults === 'log') it.logger.warn($defaultMsg);
+                          else throw new Error($defaultMsg);
+                        }
+                      } else {
+                        out += ' if (' + ($passData) + ' === undefined ';
+                        if (it.opts.useDefaults == 'empty') {
+                          out += ' || ' + ($passData) + ' === null || ' + ($passData) + ' === \'\' ';
+                        }
+                        out += ' ) ' + ($passData) + ' = ';
+                        if (it.opts.useDefaults == 'shared') {
+                          out += ' ' + (it.useDefault($sch.default)) + ' ';
+                        } else {
+                          out += ' ' + (JSON.stringify($sch.default)) + ' ';
+                        }
+                        out += '; ';
+                      }
+                    }
+                  }
+                }
+              } else if ($rulesGroup.type == 'array' && Array.isArray(it.schema.items)) {
+                var arr4 = it.schema.items;
+                if (arr4) {
+                  var $sch, $i = -1,
+                    l4 = arr4.length - 1;
+                  while ($i < l4) {
+                    $sch = arr4[$i += 1];
+                    if ($sch.default !== undefined) {
+                      var $passData = $data + '[' + $i + ']';
+                      if (it.compositeRule) {
+                        if (it.opts.strictDefaults) {
+                          var $defaultMsg = 'default is ignored for: ' + $passData;
+                          if (it.opts.strictDefaults === 'log') it.logger.warn($defaultMsg);
+                          else throw new Error($defaultMsg);
+                        }
+                      } else {
+                        out += ' if (' + ($passData) + ' === undefined ';
+                        if (it.opts.useDefaults == 'empty') {
+                          out += ' || ' + ($passData) + ' === null || ' + ($passData) + ' === \'\' ';
+                        }
+                        out += ' ) ' + ($passData) + ' = ';
+                        if (it.opts.useDefaults == 'shared') {
+                          out += ' ' + (it.useDefault($sch.default)) + ' ';
+                        } else {
+                          out += ' ' + (JSON.stringify($sch.default)) + ' ';
+                        }
+                        out += '; ';
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            var arr5 = $rulesGroup.rules;
+            if (arr5) {
+              var $rule, i5 = -1,
+                l5 = arr5.length - 1;
+              while (i5 < l5) {
+                $rule = arr5[i5 += 1];
+                if ($shouldUseRule($rule)) {
+                  var $code = $rule.code(it, $rule.keyword, $rulesGroup.type);
+                  if ($code) {
+                    out += ' ' + ($code) + ' ';
+                    if ($breakOnError) {
+                      $closingBraces1 += '}';
+                    }
+                  }
+                }
+              }
+            }
+            if ($breakOnError) {
+              out += ' ' + ($closingBraces1) + ' ';
+              $closingBraces1 = '';
+            }
+            if ($rulesGroup.type) {
+              out += ' } ';
+              if ($typeSchema && $typeSchema === $rulesGroup.type && !$coerceToTypes) {
+                out += ' else { ';
+                var $schemaPath = it.schemaPath + '.type',
+                  $errSchemaPath = it.errSchemaPath + '/type';
+                var $$outStack = $$outStack || [];
+                $$outStack.push(out);
+                out = ''; /* istanbul ignore else */
+                if (it.createErrors !== false) {
+                  out += ' { keyword: \'' + ($errorKeyword || 'type') + '\' , dataPath: (dataPath || \'\') + ' + (it.errorPath) + ' , schemaPath: ' + (it.util.toQuotedString($errSchemaPath)) + ' , params: { type: \'';
+                  if ($typeIsArray) {
+                    out += '' + ($typeSchema.join(","));
+                  } else {
+                    out += '' + ($typeSchema);
+                  }
+                  out += '\' } ';
+                  if (it.opts.messages !== false) {
+                    out += ' , message: \'should be ';
+                    if ($typeIsArray) {
+                      out += '' + ($typeSchema.join(","));
+                    } else {
+                      out += '' + ($typeSchema);
+                    }
+                    out += '\' ';
+                  }
+                  if (it.opts.verbose) {
+                    out += ' , schema: validate.schema' + ($schemaPath) + ' , parentSchema: validate.schema' + (it.schemaPath) + ' , data: ' + ($data) + ' ';
+                  }
+                  out += ' } ';
+                } else {
+                  out += ' {} ';
+                }
+                var __err = out;
+                out = $$outStack.pop();
+                if (!it.compositeRule && $breakOnError) {
+                  /* istanbul ignore if */
+                  if (it.async) {
+                    out += ' throw new ValidationError([' + (__err) + ']); ';
+                  } else {
+                    out += ' validate.errors = [' + (__err) + ']; return false; ';
+                  }
+                } else {
+                  out += ' var err = ' + (__err) + ';  if (vErrors === null) vErrors = [err]; else vErrors.push(err); errors++; ';
+                }
+                out += ' } ';
+              }
+            }
+            if ($breakOnError) {
+              out += ' if (errors === ';
+              if ($top) {
+                out += '0';
+              } else {
+                out += 'errs_' + ($lvl);
+              }
+              out += ') { ';
+              $closingBraces2 += '}';
+            }
+          }
+        }
+      }
+    }
+    if ($breakOnError) {
+      out += ' ' + ($closingBraces2) + ' ';
+    }
+    if ($top) {
+      if ($async) {
+        out += ' if (errors === 0) return data;           ';
+        out += ' else throw new ValidationError(vErrors); ';
+      } else {
+        out += ' validate.errors = vErrors; ';
+        out += ' return errors === 0;       ';
+      }
+      out += ' }; return validate;';
+    } else {
+      out += ' var ' + ($valid) + ' = errors === errs_' + ($lvl) + ';';
+    }
+
+    function $shouldUseGroup($rulesGroup) {
+      var rules = $rulesGroup.rules;
+      for (var i = 0; i < rules.length; i++)
+        if ($shouldUseRule(rules[i])) return true;
+    }
+
+    function $shouldUseRule($rule) {
+      return it.schema[$rule.keyword] !== undefined || ($rule.implements && $ruleImplementsSomeKeyword($rule));
+    }
+
+    function $ruleImplementsSomeKeyword($rule) {
+      var impl = $rule.implements;
+      for (var i = 0; i < impl.length; i++)
+        if (it.schema[impl[i]] !== undefined) return true;
+    }
+    return out;
+  }
+
+  },{}],40:[function(require,module,exports){
+  'use strict';
+
+  var IDENTIFIER = /^[a-z_$][a-z0-9_$-]*$/i;
+  var customRuleCode = require('./dotjs/custom');
+  var definitionSchema = require('./definition_schema');
+
+  module.exports = {
+    add: addKeyword,
+    get: getKeyword,
+    remove: removeKeyword,
+    validate: validateKeyword
+  };
+
+
+  /**
+   * Define custom keyword
+   * @this  Ajv
+   * @param {String} keyword custom keyword, should be unique (including different from all standard, custom and macro keywords).
+   * @param {Object} definition keyword definition object with properties `type` (type(s) which the keyword applies to), `validate` or `compile`.
+   * @return {Ajv} this for method chaining
+   */
+  function addKeyword(keyword, definition) {
+    /* jshint validthis: true */
+    /* eslint no-shadow: 0 */
+    var RULES = this.RULES;
+    if (RULES.keywords[keyword])
+      throw new Error('Keyword ' + keyword + ' is already defined');
+
+    if (!IDENTIFIER.test(keyword))
+      throw new Error('Keyword ' + keyword + ' is not a valid identifier');
+
+    if (definition) {
+      this.validateKeyword(definition, true);
+
+      var dataType = definition.type;
+      if (Array.isArray(dataType)) {
+        for (var i=0; i<dataType.length; i++)
+          _addRule(keyword, dataType[i], definition);
+      } else {
+        _addRule(keyword, dataType, definition);
+      }
+
+      var metaSchema = definition.metaSchema;
+      if (metaSchema) {
+        if (definition.$data && this._opts.$data) {
+          metaSchema = {
+            anyOf: [
+              metaSchema,
+              { '$ref': 'https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#' }
+            ]
+          };
+        }
+        definition.validateSchema = this.compile(metaSchema, true);
+      }
+    }
+
+    RULES.keywords[keyword] = RULES.all[keyword] = true;
+
+
+    function _addRule(keyword, dataType, definition) {
+      var ruleGroup;
+      for (var i=0; i<RULES.length; i++) {
+        var rg = RULES[i];
+        if (rg.type == dataType) {
+          ruleGroup = rg;
+          break;
+        }
+      }
+
+      if (!ruleGroup) {
+        ruleGroup = { type: dataType, rules: [] };
+        RULES.push(ruleGroup);
+      }
+
+      var rule = {
+        keyword: keyword,
+        definition: definition,
+        custom: true,
+        code: customRuleCode,
+        implements: definition.implements
+      };
+      ruleGroup.rules.push(rule);
+      RULES.custom[keyword] = rule;
+    }
+
+    return this;
+  }
+
+
+  /**
+   * Get keyword
+   * @this  Ajv
+   * @param {String} keyword pre-defined or custom keyword.
+   * @return {Object|Boolean} custom keyword definition, `true` if it is a predefined keyword, `false` otherwise.
+   */
+  function getKeyword(keyword) {
+    /* jshint validthis: true */
+    var rule = this.RULES.custom[keyword];
+    return rule ? rule.definition : this.RULES.keywords[keyword] || false;
+  }
+
+
+  /**
+   * Remove keyword
+   * @this  Ajv
+   * @param {String} keyword pre-defined or custom keyword.
+   * @return {Ajv} this for method chaining
+   */
+  function removeKeyword(keyword) {
+    /* jshint validthis: true */
+    var RULES = this.RULES;
+    delete RULES.keywords[keyword];
+    delete RULES.all[keyword];
+    delete RULES.custom[keyword];
+    for (var i=0; i<RULES.length; i++) {
+      var rules = RULES[i].rules;
+      for (var j=0; j<rules.length; j++) {
+        if (rules[j].keyword == keyword) {
+          rules.splice(j, 1);
+          break;
+        }
+      }
+    }
+    return this;
+  }
+
+
+  /**
+   * Validate keyword definition
+   * @this  Ajv
+   * @param {Object} definition keyword definition object.
+   * @param {Boolean} throwError true to throw exception if definition is invalid
+   * @return {boolean} validation result
+   */
+  function validateKeyword(definition, throwError) {
+    validateKeyword.errors = null;
+    var v = this._validateKeyword = this._validateKeyword
+                                    || this.compile(definitionSchema, true);
+
+    if (v(definition)) return true;
+    validateKeyword.errors = v.errors;
+    if (throwError)
+      throw new Error('custom keyword definition is invalid: '  + this.errorsText(v.errors));
+    else
+      return false;
+  }
+
+  },{"./definition_schema":13,"./dotjs/custom":23}],41:[function(require,module,exports){
+  module.exports={
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#",
+      "description": "Meta-schema for $data reference (JSON Schema extension proposal)",
+      "type": "object",
+      "required": [ "$data" ],
+      "properties": {
+          "$data": {
+              "type": "string",
+              "anyOf": [
+                  { "format": "relative-json-pointer" },
+                  { "format": "json-pointer" }
+              ]
+          }
+      },
+      "additionalProperties": false
+  }
+
+  },{}],42:[function(require,module,exports){
+  module.exports={
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "http://json-schema.org/draft-07/schema#",
+      "title": "Core schema meta-schema",
+      "definitions": {
+          "schemaArray": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#" }
+          },
+          "nonNegativeInteger": {
+              "type": "integer",
+              "minimum": 0
+          },
+          "nonNegativeIntegerDefault0": {
+              "allOf": [
+                  { "$ref": "#/definitions/nonNegativeInteger" },
+                  { "default": 0 }
+              ]
+          },
+          "simpleTypes": {
+              "enum": [
+                  "array",
+                  "boolean",
+                  "integer",
+                  "null",
+                  "number",
+                  "object",
+                  "string"
+              ]
+          },
+          "stringArray": {
+              "type": "array",
+              "items": { "type": "string" },
+              "uniqueItems": true,
+              "default": []
+          }
+      },
+      "type": ["object", "boolean"],
+      "properties": {
+          "$id": {
+              "type": "string",
+              "format": "uri-reference"
+          },
+          "$schema": {
+              "type": "string",
+              "format": "uri"
+          },
+          "$ref": {
+              "type": "string",
+              "format": "uri-reference"
+          },
+          "$comment": {
+              "type": "string"
+          },
+          "title": {
+              "type": "string"
+          },
+          "description": {
+              "type": "string"
+          },
+          "default": true,
+          "readOnly": {
+              "type": "boolean",
+              "default": false
+          },
+          "examples": {
+              "type": "array",
+              "items": true
+          },
+          "multipleOf": {
+              "type": "number",
+              "exclusiveMinimum": 0
+          },
+          "maximum": {
+              "type": "number"
+          },
+          "exclusiveMaximum": {
+              "type": "number"
+          },
+          "minimum": {
+              "type": "number"
+          },
+          "exclusiveMinimum": {
+              "type": "number"
+          },
+          "maxLength": { "$ref": "#/definitions/nonNegativeInteger" },
+          "minLength": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+          "pattern": {
+              "type": "string",
+              "format": "regex"
+          },
+          "additionalItems": { "$ref": "#" },
+          "items": {
+              "anyOf": [
+                  { "$ref": "#" },
+                  { "$ref": "#/definitions/schemaArray" }
+              ],
+              "default": true
+          },
+          "maxItems": { "$ref": "#/definitions/nonNegativeInteger" },
+          "minItems": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+          "uniqueItems": {
+              "type": "boolean",
+              "default": false
+          },
+          "contains": { "$ref": "#" },
+          "maxProperties": { "$ref": "#/definitions/nonNegativeInteger" },
+          "minProperties": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+          "required": { "$ref": "#/definitions/stringArray" },
+          "additionalProperties": { "$ref": "#" },
+          "definitions": {
+              "type": "object",
+              "additionalProperties": { "$ref": "#" },
+              "default": {}
+          },
+          "properties": {
+              "type": "object",
+              "additionalProperties": { "$ref": "#" },
+              "default": {}
+          },
+          "patternProperties": {
+              "type": "object",
+              "additionalProperties": { "$ref": "#" },
+              "propertyNames": { "format": "regex" },
+              "default": {}
+          },
+          "dependencies": {
+              "type": "object",
+              "additionalProperties": {
+                  "anyOf": [
+                      { "$ref": "#" },
+                      { "$ref": "#/definitions/stringArray" }
+                  ]
+              }
+          },
+          "propertyNames": { "$ref": "#" },
+          "const": true,
+          "enum": {
+              "type": "array",
+              "items": true,
+              "minItems": 1,
+              "uniqueItems": true
+          },
+          "type": {
+              "anyOf": [
+                  { "$ref": "#/definitions/simpleTypes" },
+                  {
+                      "type": "array",
+                      "items": { "$ref": "#/definitions/simpleTypes" },
+                      "minItems": 1,
+                      "uniqueItems": true
+                  }
+              ]
+          },
+          "format": { "type": "string" },
+          "contentMediaType": { "type": "string" },
+          "contentEncoding": { "type": "string" },
+          "if": {"$ref": "#"},
+          "then": {"$ref": "#"},
+          "else": {"$ref": "#"},
+          "allOf": { "$ref": "#/definitions/schemaArray" },
+          "anyOf": { "$ref": "#/definitions/schemaArray" },
+          "oneOf": { "$ref": "#/definitions/schemaArray" },
+          "not": { "$ref": "#" }
+      },
+      "default": true
+  }
+
+  },{}],43:[function(require,module,exports){
+  'use strict';
+
+  // do not edit .js files directly - edit src/index.jst
+
+
+
+  module.exports = function equal(a, b) {
+    if (a === b) return true;
+
+    if (a && b && typeof a == 'object' && typeof b == 'object') {
+      if (a.constructor !== b.constructor) return false;
+
+      var length, i, keys;
+      if (Array.isArray(a)) {
+        length = a.length;
+        if (length != b.length) return false;
+        for (i = length; i-- !== 0;)
+          if (!equal(a[i], b[i])) return false;
+        return true;
+      }
+
+
+
+      if (a.constructor === RegExp) return a.source === b.source && a.flags === b.flags;
+      if (a.valueOf !== Object.prototype.valueOf) return a.valueOf() === b.valueOf();
+      if (a.toString !== Object.prototype.toString) return a.toString() === b.toString();
+
+      keys = Object.keys(a);
+      length = keys.length;
+      if (length !== Object.keys(b).length) return false;
+
+      for (i = length; i-- !== 0;)
+        if (!Object.prototype.hasOwnProperty.call(b, keys[i])) return false;
+
+      for (i = length; i-- !== 0;) {
+        var key = keys[i];
+
+        if (!equal(a[key], b[key])) return false;
+      }
+
+      return true;
+    }
+
+    // true if both NaN, false otherwise
+    return a!==a && b!==b;
+  };
+
+  },{}],44:[function(require,module,exports){
+  'use strict';
+
+  module.exports = function (data, opts) {
+      if (!opts) opts = {};
+      if (typeof opts === 'function') opts = { cmp: opts };
+      var cycles = (typeof opts.cycles === 'boolean') ? opts.cycles : false;
+
+      var cmp = opts.cmp && (function (f) {
+          return function (node) {
+              return function (a, b) {
+                  var aobj = { key: a, value: node[a] };
+                  var bobj = { key: b, value: node[b] };
+                  return f(aobj, bobj);
+              };
+          };
+      })(opts.cmp);
+
+      var seen = [];
+      return (function stringify (node) {
+          if (node && node.toJSON && typeof node.toJSON === 'function') {
+              node = node.toJSON();
+          }
+
+          if (node === undefined) return;
+          if (typeof node == 'number') return isFinite(node) ? '' + node : 'null';
+          if (typeof node !== 'object') return JSON.stringify(node);
+
+          var i, out;
+          if (Array.isArray(node)) {
+              out = '[';
+              for (i = 0; i < node.length; i++) {
+                  if (i) out += ',';
+                  out += stringify(node[i]) || 'null';
+              }
+              return out + ']';
+          }
+
+          if (node === null) return 'null';
+
+          if (seen.indexOf(node) !== -1) {
+              if (cycles) return JSON.stringify('__cycle__');
+              throw new TypeError('Converting circular structure to JSON');
+          }
+
+          var seenIndex = seen.push(node) - 1;
+          var keys = Object.keys(node).sort(cmp && cmp(node));
+          out = '';
+          for (i = 0; i < keys.length; i++) {
+              var key = keys[i];
+              var value = stringify(node[key]);
+
+              if (!value) continue;
+              if (out) out += ',';
+              out += JSON.stringify(key) + ':' + value;
+          }
+          seen.splice(seenIndex, 1);
+          return '{' + out + '}';
+      })(data);
+  };
+
+  },{}],45:[function(require,module,exports){
+  'use strict';
+
+  var traverse = module.exports = function (schema, opts, cb) {
+    // Legacy support for v0.3.1 and earlier.
+    if (typeof opts == 'function') {
+      cb = opts;
+      opts = {};
+    }
+
+    cb = opts.cb || cb;
+    var pre = (typeof cb == 'function') ? cb : cb.pre || function() {};
+    var post = cb.post || function() {};
+
+    _traverse(opts, pre, post, schema, '', schema);
+  };
+
+
+  traverse.keywords = {
+    additionalItems: true,
+    items: true,
+    contains: true,
+    additionalProperties: true,
+    propertyNames: true,
+    not: true
+  };
+
+  traverse.arrayKeywords = {
+    items: true,
+    allOf: true,
+    anyOf: true,
+    oneOf: true
+  };
+
+  traverse.propsKeywords = {
+    definitions: true,
+    properties: true,
+    patternProperties: true,
+    dependencies: true
+  };
+
+  traverse.skipKeywords = {
+    default: true,
+    enum: true,
+    const: true,
+    required: true,
+    maximum: true,
+    minimum: true,
+    exclusiveMaximum: true,
+    exclusiveMinimum: true,
+    multipleOf: true,
+    maxLength: true,
+    minLength: true,
+    pattern: true,
+    format: true,
+    maxItems: true,
+    minItems: true,
+    uniqueItems: true,
+    maxProperties: true,
+    minProperties: true
+  };
+
+
+  function _traverse(opts, pre, post, schema, jsonPtr, rootSchema, parentJsonPtr, parentKeyword, parentSchema, keyIndex) {
+    if (schema && typeof schema == 'object' && !Array.isArray(schema)) {
+      pre(schema, jsonPtr, rootSchema, parentJsonPtr, parentKeyword, parentSchema, keyIndex);
+      for (var key in schema) {
+        var sch = schema[key];
+        if (Array.isArray(sch)) {
+          if (key in traverse.arrayKeywords) {
+            for (var i=0; i<sch.length; i++)
+              _traverse(opts, pre, post, sch[i], jsonPtr + '/' + key + '/' + i, rootSchema, jsonPtr, key, schema, i);
+          }
+        } else if (key in traverse.propsKeywords) {
+          if (sch && typeof sch == 'object') {
+            for (var prop in sch)
+              _traverse(opts, pre, post, sch[prop], jsonPtr + '/' + key + '/' + escapeJsonPtr(prop), rootSchema, jsonPtr, key, schema, prop);
+          }
+        } else if (key in traverse.keywords || (opts.allKeys && !(key in traverse.skipKeywords))) {
+          _traverse(opts, pre, post, sch, jsonPtr + '/' + key, rootSchema, jsonPtr, key, schema);
+        }
+      }
+      post(schema, jsonPtr, rootSchema, parentJsonPtr, parentKeyword, parentSchema, keyIndex);
+    }
+  }
+
+
+  function escapeJsonPtr(str) {
+    return str.replace(/~/g, '~0').replace(/\//g, '~1');
+  }
+
+  },{}],46:[function(require,module,exports){
+  /** @license URI.js v4.4.1 (c) 2011 Gary Court. License: http://github.com/garycourt/uri-js */
+  (function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+    typeof define === 'function' && define.amd ? define(['exports'], factory) :
+    (factory((global.URI = global.URI || {})));
+  }(this, (function (exports) { 'use strict';
+
+  function merge() {
+      for (var _len = arguments.length, sets = Array(_len), _key = 0; _key < _len; _key++) {
+          sets[_key] = arguments[_key];
+      }
+
+      if (sets.length > 1) {
+          sets[0] = sets[0].slice(0, -1);
+          var xl = sets.length - 1;
+          for (var x = 1; x < xl; ++x) {
+              sets[x] = sets[x].slice(1, -1);
+          }
+          sets[xl] = sets[xl].slice(1);
+          return sets.join('');
+      } else {
+          return sets[0];
+      }
+  }
+  function subexp(str) {
+      return "(?:" + str + ")";
+  }
+  function typeOf(o) {
+      return o === undefined ? "undefined" : o === null ? "null" : Object.prototype.toString.call(o).split(" ").pop().split("]").shift().toLowerCase();
+  }
+  function toUpperCase(str) {
+      return str.toUpperCase();
+  }
+  function toArray(obj) {
+      return obj !== undefined && obj !== null ? obj instanceof Array ? obj : typeof obj.length !== "number" || obj.split || obj.setInterval || obj.call ? [obj] : Array.prototype.slice.call(obj) : [];
+  }
+  function assign(target, source) {
+      var obj = target;
+      if (source) {
+          for (var key in source) {
+              obj[key] = source[key];
+          }
+      }
+      return obj;
+  }
+
+  function buildExps(isIRI) {
+      var ALPHA$$ = "[A-Za-z]",
+          CR$ = "[\\x0D]",
+          DIGIT$$ = "[0-9]",
+          DQUOTE$$ = "[\\x22]",
+          HEXDIG$$ = merge(DIGIT$$, "[A-Fa-f]"),
+          //case-insensitive
+      LF$$ = "[\\x0A]",
+          SP$$ = "[\\x20]",
+          PCT_ENCODED$ = subexp(subexp("%[EFef]" + HEXDIG$$ + "%" + HEXDIG$$ + HEXDIG$$ + "%" + HEXDIG$$ + HEXDIG$$) + "|" + subexp("%[89A-Fa-f]" + HEXDIG$$ + "%" + HEXDIG$$ + HEXDIG$$) + "|" + subexp("%" + HEXDIG$$ + HEXDIG$$)),
+          //expanded
+      GEN_DELIMS$$ = "[\\:\\/\\?\\#\\[\\]\\@]",
+          SUB_DELIMS$$ = "[\\!\\$\\&\\'\\(\\)\\*\\+\\,\\;\\=]",
+          RESERVED$$ = merge(GEN_DELIMS$$, SUB_DELIMS$$),
+          UCSCHAR$$ = isIRI ? "[\\xA0-\\u200D\\u2010-\\u2029\\u202F-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFEF]" : "[]",
+          //subset, excludes bidi control characters
+      IPRIVATE$$ = isIRI ? "[\\uE000-\\uF8FF]" : "[]",
+          //subset
+      UNRESERVED$$ = merge(ALPHA$$, DIGIT$$, "[\\-\\.\\_\\~]", UCSCHAR$$),
+          SCHEME$ = subexp(ALPHA$$ + merge(ALPHA$$, DIGIT$$, "[\\+\\-\\.]") + "*"),
+          USERINFO$ = subexp(subexp(PCT_ENCODED$ + "|" + merge(UNRESERVED$$, SUB_DELIMS$$, "[\\:]")) + "*"),
+          DEC_OCTET$ = subexp(subexp("25[0-5]") + "|" + subexp("2[0-4]" + DIGIT$$) + "|" + subexp("1" + DIGIT$$ + DIGIT$$) + "|" + subexp("[1-9]" + DIGIT$$) + "|" + DIGIT$$),
+          DEC_OCTET_RELAXED$ = subexp(subexp("25[0-5]") + "|" + subexp("2[0-4]" + DIGIT$$) + "|" + subexp("1" + DIGIT$$ + DIGIT$$) + "|" + subexp("0?[1-9]" + DIGIT$$) + "|0?0?" + DIGIT$$),
+          //relaxed parsing rules
+      IPV4ADDRESS$ = subexp(DEC_OCTET_RELAXED$ + "\\." + DEC_OCTET_RELAXED$ + "\\." + DEC_OCTET_RELAXED$ + "\\." + DEC_OCTET_RELAXED$),
+          H16$ = subexp(HEXDIG$$ + "{1,4}"),
+          LS32$ = subexp(subexp(H16$ + "\\:" + H16$) + "|" + IPV4ADDRESS$),
+          IPV6ADDRESS1$ = subexp(subexp(H16$ + "\\:") + "{6}" + LS32$),
+          //                           6( h16 ":" ) ls32
+      IPV6ADDRESS2$ = subexp("\\:\\:" + subexp(H16$ + "\\:") + "{5}" + LS32$),
+          //                      "::" 5( h16 ":" ) ls32
+      IPV6ADDRESS3$ = subexp(subexp(H16$) + "?\\:\\:" + subexp(H16$ + "\\:") + "{4}" + LS32$),
+          //[               h16 ] "::" 4( h16 ":" ) ls32
+      IPV6ADDRESS4$ = subexp(subexp(subexp(H16$ + "\\:") + "{0,1}" + H16$) + "?\\:\\:" + subexp(H16$ + "\\:") + "{3}" + LS32$),
+          //[ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) ls32
+      IPV6ADDRESS5$ = subexp(subexp(subexp(H16$ + "\\:") + "{0,2}" + H16$) + "?\\:\\:" + subexp(H16$ + "\\:") + "{2}" + LS32$),
+          //[ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) ls32
+      IPV6ADDRESS6$ = subexp(subexp(subexp(H16$ + "\\:") + "{0,3}" + H16$) + "?\\:\\:" + H16$ + "\\:" + LS32$),
+          //[ *3( h16 ":" ) h16 ] "::"    h16 ":"   ls32
+      IPV6ADDRESS7$ = subexp(subexp(subexp(H16$ + "\\:") + "{0,4}" + H16$) + "?\\:\\:" + LS32$),
+          //[ *4( h16 ":" ) h16 ] "::"              ls32
+      IPV6ADDRESS8$ = subexp(subexp(subexp(H16$ + "\\:") + "{0,5}" + H16$) + "?\\:\\:" + H16$),
+          //[ *5( h16 ":" ) h16 ] "::"              h16
+      IPV6ADDRESS9$ = subexp(subexp(subexp(H16$ + "\\:") + "{0,6}" + H16$) + "?\\:\\:"),
+          //[ *6( h16 ":" ) h16 ] "::"
+      IPV6ADDRESS$ = subexp([IPV6ADDRESS1$, IPV6ADDRESS2$, IPV6ADDRESS3$, IPV6ADDRESS4$, IPV6ADDRESS5$, IPV6ADDRESS6$, IPV6ADDRESS7$, IPV6ADDRESS8$, IPV6ADDRESS9$].join("|")),
+          ZONEID$ = subexp(subexp(UNRESERVED$$ + "|" + PCT_ENCODED$) + "+"),
+          //RFC 6874
+      IPV6ADDRZ$ = subexp(IPV6ADDRESS$ + "\\%25" + ZONEID$),
+          //RFC 6874
+      IPV6ADDRZ_RELAXED$ = subexp(IPV6ADDRESS$ + subexp("\\%25|\\%(?!" + HEXDIG$$ + "{2})") + ZONEID$),
+          //RFC 6874, with relaxed parsing rules
+      IPVFUTURE$ = subexp("[vV]" + HEXDIG$$ + "+\\." + merge(UNRESERVED$$, SUB_DELIMS$$, "[\\:]") + "+"),
+          IP_LITERAL$ = subexp("\\[" + subexp(IPV6ADDRZ_RELAXED$ + "|" + IPV6ADDRESS$ + "|" + IPVFUTURE$) + "\\]"),
+          //RFC 6874
+      REG_NAME$ = subexp(subexp(PCT_ENCODED$ + "|" + merge(UNRESERVED$$, SUB_DELIMS$$)) + "*"),
+          HOST$ = subexp(IP_LITERAL$ + "|" + IPV4ADDRESS$ + "(?!" + REG_NAME$ + ")" + "|" + REG_NAME$),
+          PORT$ = subexp(DIGIT$$ + "*"),
+          AUTHORITY$ = subexp(subexp(USERINFO$ + "@") + "?" + HOST$ + subexp("\\:" + PORT$) + "?"),
+          PCHAR$ = subexp(PCT_ENCODED$ + "|" + merge(UNRESERVED$$, SUB_DELIMS$$, "[\\:\\@]")),
+          SEGMENT$ = subexp(PCHAR$ + "*"),
+          SEGMENT_NZ$ = subexp(PCHAR$ + "+"),
+          SEGMENT_NZ_NC$ = subexp(subexp(PCT_ENCODED$ + "|" + merge(UNRESERVED$$, SUB_DELIMS$$, "[\\@]")) + "+"),
+          PATH_ABEMPTY$ = subexp(subexp("\\/" + SEGMENT$) + "*"),
+          PATH_ABSOLUTE$ = subexp("\\/" + subexp(SEGMENT_NZ$ + PATH_ABEMPTY$) + "?"),
+          //simplified
+      PATH_NOSCHEME$ = subexp(SEGMENT_NZ_NC$ + PATH_ABEMPTY$),
+          //simplified
+      PATH_ROOTLESS$ = subexp(SEGMENT_NZ$ + PATH_ABEMPTY$),
+          //simplified
+      PATH_EMPTY$ = "(?!" + PCHAR$ + ")",
+          PATH$ = subexp(PATH_ABEMPTY$ + "|" + PATH_ABSOLUTE$ + "|" + PATH_NOSCHEME$ + "|" + PATH_ROOTLESS$ + "|" + PATH_EMPTY$),
+          QUERY$ = subexp(subexp(PCHAR$ + "|" + merge("[\\/\\?]", IPRIVATE$$)) + "*"),
+          FRAGMENT$ = subexp(subexp(PCHAR$ + "|[\\/\\?]") + "*"),
+          HIER_PART$ = subexp(subexp("\\/\\/" + AUTHORITY$ + PATH_ABEMPTY$) + "|" + PATH_ABSOLUTE$ + "|" + PATH_ROOTLESS$ + "|" + PATH_EMPTY$),
+          URI$ = subexp(SCHEME$ + "\\:" + HIER_PART$ + subexp("\\?" + QUERY$) + "?" + subexp("\\#" + FRAGMENT$) + "?"),
+          RELATIVE_PART$ = subexp(subexp("\\/\\/" + AUTHORITY$ + PATH_ABEMPTY$) + "|" + PATH_ABSOLUTE$ + "|" + PATH_NOSCHEME$ + "|" + PATH_EMPTY$),
+          RELATIVE$ = subexp(RELATIVE_PART$ + subexp("\\?" + QUERY$) + "?" + subexp("\\#" + FRAGMENT$) + "?"),
+          URI_REFERENCE$ = subexp(URI$ + "|" + RELATIVE$),
+          ABSOLUTE_URI$ = subexp(SCHEME$ + "\\:" + HIER_PART$ + subexp("\\?" + QUERY$) + "?"),
+          GENERIC_REF$ = "^(" + SCHEME$ + ")\\:" + subexp(subexp("\\/\\/(" + subexp("(" + USERINFO$ + ")@") + "?(" + HOST$ + ")" + subexp("\\:(" + PORT$ + ")") + "?)") + "?(" + PATH_ABEMPTY$ + "|" + PATH_ABSOLUTE$ + "|" + PATH_ROOTLESS$ + "|" + PATH_EMPTY$ + ")") + subexp("\\?(" + QUERY$ + ")") + "?" + subexp("\\#(" + FRAGMENT$ + ")") + "?$",
+          RELATIVE_REF$ = "^(){0}" + subexp(subexp("\\/\\/(" + subexp("(" + USERINFO$ + ")@") + "?(" + HOST$ + ")" + subexp("\\:(" + PORT$ + ")") + "?)") + "?(" + PATH_ABEMPTY$ + "|" + PATH_ABSOLUTE$ + "|" + PATH_NOSCHEME$ + "|" + PATH_EMPTY$ + ")") + subexp("\\?(" + QUERY$ + ")") + "?" + subexp("\\#(" + FRAGMENT$ + ")") + "?$",
+          ABSOLUTE_REF$ = "^(" + SCHEME$ + ")\\:" + subexp(subexp("\\/\\/(" + subexp("(" + USERINFO$ + ")@") + "?(" + HOST$ + ")" + subexp("\\:(" + PORT$ + ")") + "?)") + "?(" + PATH_ABEMPTY$ + "|" + PATH_ABSOLUTE$ + "|" + PATH_ROOTLESS$ + "|" + PATH_EMPTY$ + ")") + subexp("\\?(" + QUERY$ + ")") + "?$",
+          SAMEDOC_REF$ = "^" + subexp("\\#(" + FRAGMENT$ + ")") + "?$",
+          AUTHORITY_REF$ = "^" + subexp("(" + USERINFO$ + ")@") + "?(" + HOST$ + ")" + subexp("\\:(" + PORT$ + ")") + "?$";
+      return {
+          NOT_SCHEME: new RegExp(merge("[^]", ALPHA$$, DIGIT$$, "[\\+\\-\\.]"), "g"),
+          NOT_USERINFO: new RegExp(merge("[^\\%\\:]", UNRESERVED$$, SUB_DELIMS$$), "g"),
+          NOT_HOST: new RegExp(merge("[^\\%\\[\\]\\:]", UNRESERVED$$, SUB_DELIMS$$), "g"),
+          NOT_PATH: new RegExp(merge("[^\\%\\/\\:\\@]", UNRESERVED$$, SUB_DELIMS$$), "g"),
+          NOT_PATH_NOSCHEME: new RegExp(merge("[^\\%\\/\\@]", UNRESERVED$$, SUB_DELIMS$$), "g"),
+          NOT_QUERY: new RegExp(merge("[^\\%]", UNRESERVED$$, SUB_DELIMS$$, "[\\:\\@\\/\\?]", IPRIVATE$$), "g"),
+          NOT_FRAGMENT: new RegExp(merge("[^\\%]", UNRESERVED$$, SUB_DELIMS$$, "[\\:\\@\\/\\?]"), "g"),
+          ESCAPE: new RegExp(merge("[^]", UNRESERVED$$, SUB_DELIMS$$), "g"),
+          UNRESERVED: new RegExp(UNRESERVED$$, "g"),
+          OTHER_CHARS: new RegExp(merge("[^\\%]", UNRESERVED$$, RESERVED$$), "g"),
+          PCT_ENCODED: new RegExp(PCT_ENCODED$, "g"),
+          IPV4ADDRESS: new RegExp("^(" + IPV4ADDRESS$ + ")$"),
+          IPV6ADDRESS: new RegExp("^\\[?(" + IPV6ADDRESS$ + ")" + subexp(subexp("\\%25|\\%(?!" + HEXDIG$$ + "{2})") + "(" + ZONEID$ + ")") + "?\\]?$") //RFC 6874, with relaxed parsing rules
+      };
+  }
+  var URI_PROTOCOL = buildExps(false);
+
+  var IRI_PROTOCOL = buildExps(true);
+
+  var slicedToArray = function () {
+    function sliceIterator(arr, i) {
+      var _arr = [];
+      var _n = true;
+      var _d = false;
+      var _e = undefined;
+
+      try {
+        for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
+          _arr.push(_s.value);
+
+          if (i && _arr.length === i) break;
+        }
+      } catch (err) {
+        _d = true;
+        _e = err;
+      } finally {
+        try {
+          if (!_n && _i["return"]) _i["return"]();
+        } finally {
+          if (_d) throw _e;
+        }
+      }
+
+      return _arr;
+    }
+
+    return function (arr, i) {
+      if (Array.isArray(arr)) {
+        return arr;
+      } else if (Symbol.iterator in Object(arr)) {
+        return sliceIterator(arr, i);
+      } else {
+        throw new TypeError("Invalid attempt to destructure non-iterable instance");
+      }
+    };
+  }();
+
+
+
+
+
+
+
+
+
+
+
+
+
+  var toConsumableArray = function (arr) {
+    if (Array.isArray(arr)) {
+      for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i];
+
+      return arr2;
+    } else {
+      return Array.from(arr);
+    }
+  };
+
+  /** Highest positive signed 32-bit float value */
+
+  var maxInt = 2147483647; // aka. 0x7FFFFFFF or 2^31-1
+
+  /** Bootstring parameters */
+  var base = 36;
+  var tMin = 1;
+  var tMax = 26;
+  var skew = 38;
+  var damp = 700;
+  var initialBias = 72;
+  var initialN = 128; // 0x80
+  var delimiter = '-'; // '\x2D'
+
+  /** Regular expressions */
+  var regexPunycode = /^xn--/;
+  var regexNonASCII = /[^\0-\x7E]/; // non-ASCII chars
+  var regexSeparators = /[\x2E\u3002\uFF0E\uFF61]/g; // RFC 3490 separators
+
+  /** Error messages */
+  var errors = {
+    'overflow': 'Overflow: input needs wider integers to process',
+    'not-basic': 'Illegal input >= 0x80 (not a basic code point)',
+    'invalid-input': 'Invalid input'
+  };
+
+  /** Convenience shortcuts */
+  var baseMinusTMin = base - tMin;
+  var floor = Math.floor;
+  var stringFromCharCode = String.fromCharCode;
+
+  /*--------------------------------------------------------------------------*/
+
+  /**
+   * A generic error utility function.
+   * @private
+   * @param {String} type The error type.
+   * @returns {Error} Throws a `RangeError` with the applicable error message.
+   */
+  function error$1(type) {
+    throw new RangeError(errors[type]);
+  }
+
+  /**
+   * A generic `Array#map` utility function.
+   * @private
+   * @param {Array} array The array to iterate over.
+   * @param {Function} callback The function that gets called for every array
+   * item.
+   * @returns {Array} A new array of values returned by the callback function.
+   */
+  function map(array, fn) {
+    var result = [];
+    var length = array.length;
+    while (length--) {
+      result[length] = fn(array[length]);
+    }
+    return result;
+  }
+
+  /**
+   * A simple `Array#map`-like wrapper to work with domain name strings or email
+   * addresses.
+   * @private
+   * @param {String} domain The domain name or email address.
+   * @param {Function} callback The function that gets called for every
+   * character.
+   * @returns {Array} A new string of characters returned by the callback
+   * function.
+   */
+  function mapDomain(string, fn) {
+    var parts = string.split('@');
+    var result = '';
+    if (parts.length > 1) {
+      // In email addresses, only the domain name should be punycoded. Leave
+      // the local part (i.e. everything up to `@`) intact.
+      result = parts[0] + '@';
+      string = parts[1];
+    }
+    // Avoid `split(regex)` for IE8 compatibility. See #17.
+    string = string.replace(regexSeparators, '\x2E');
+    var labels = string.split('.');
+    var encoded = map(labels, fn).join('.');
+    return result + encoded;
+  }
+
+  /**
+   * Creates an array containing the numeric code points of each Unicode
+   * character in the string. While JavaScript uses UCS-2 internally,
+   * this function will convert a pair of surrogate halves (each of which
+   * UCS-2 exposes as separate characters) into a single code point,
+   * matching UTF-16.
+   * @see `punycode.ucs2.encode`
+   * @see <https://mathiasbynens.be/notes/javascript-encoding>
+   * @memberOf punycode.ucs2
+   * @name decode
+   * @param {String} string The Unicode input string (UCS-2).
+   * @returns {Array} The new array of code points.
+   */
+  function ucs2decode(string) {
+    var output = [];
+    var counter = 0;
+    var length = string.length;
+    while (counter < length) {
+      var value = string.charCodeAt(counter++);
+      if (value >= 0xD800 && value <= 0xDBFF && counter < length) {
+        // It's a high surrogate, and there is a next character.
+        var extra = string.charCodeAt(counter++);
+        if ((extra & 0xFC00) == 0xDC00) {
+          // Low surrogate.
+          output.push(((value & 0x3FF) << 10) + (extra & 0x3FF) + 0x10000);
+        } else {
+          // It's an unmatched surrogate; only append this code unit, in case the
+          // next code unit is the high surrogate of a surrogate pair.
+          output.push(value);
+          counter--;
+        }
+      } else {
+        output.push(value);
+      }
+    }
+    return output;
+  }
+
+  /**
+   * Creates a string based on an array of numeric code points.
+   * @see `punycode.ucs2.decode`
+   * @memberOf punycode.ucs2
+   * @name encode
+   * @param {Array} codePoints The array of numeric code points.
+   * @returns {String} The new Unicode string (UCS-2).
+   */
+  var ucs2encode = function ucs2encode(array) {
+    return String.fromCodePoint.apply(String, toConsumableArray(array));
+  };
+
+  /**
+   * Converts a basic code point into a digit/integer.
+   * @see `digitToBasic()`
+   * @private
+   * @param {Number} codePoint The basic numeric code point value.
+   * @returns {Number} The numeric value of a basic code point (for use in
+   * representing integers) in the range `0` to `base - 1`, or `base` if
+   * the code point does not represent a value.
+   */
+  var basicToDigit = function basicToDigit(codePoint) {
+    if (codePoint - 0x30 < 0x0A) {
+      return codePoint - 0x16;
+    }
+    if (codePoint - 0x41 < 0x1A) {
+      return codePoint - 0x41;
+    }
+    if (codePoint - 0x61 < 0x1A) {
+      return codePoint - 0x61;
+    }
+    return base;
+  };
+
+  /**
+   * Converts a digit/integer into a basic code point.
+   * @see `basicToDigit()`
+   * @private
+   * @param {Number} digit The numeric value of a basic code point.
+   * @returns {Number} The basic code point whose value (when used for
+   * representing integers) is `digit`, which needs to be in the range
+   * `0` to `base - 1`. If `flag` is non-zero, the uppercase form is
+   * used; else, the lowercase form is used. The behavior is undefined
+   * if `flag` is non-zero and `digit` has no uppercase form.
+   */
+  var digitToBasic = function digitToBasic(digit, flag) {
+    //  0..25 map to ASCII a..z or A..Z
+    // 26..35 map to ASCII 0..9
+    return digit + 22 + 75 * (digit < 26) - ((flag != 0) << 5);
+  };
+
+  /**
+   * Bias adaptation function as per section 3.4 of RFC 3492.
+   * https://tools.ietf.org/html/rfc3492#section-3.4
+   * @private
+   */
+  var adapt = function adapt(delta, numPoints, firstTime) {
+    var k = 0;
+    delta = firstTime ? floor(delta / damp) : delta >> 1;
+    delta += floor(delta / numPoints);
+    for (; /* no initialization */delta > baseMinusTMin * tMax >> 1; k += base) {
+      delta = floor(delta / baseMinusTMin);
+    }
+    return floor(k + (baseMinusTMin + 1) * delta / (delta + skew));
+  };
+
+  /**
+   * Converts a Punycode string of ASCII-only symbols to a string of Unicode
+   * symbols.
+   * @memberOf punycode
+   * @param {String} input The Punycode string of ASCII-only symbols.
+   * @returns {String} The resulting string of Unicode symbols.
+   */
+  var decode = function decode(input) {
+    // Don't use UCS-2.
+    var output = [];
+    var inputLength = input.length;
+    var i = 0;
+    var n = initialN;
+    var bias = initialBias;
+
+    // Handle the basic code points: let `basic` be the number of input code
+    // points before the last delimiter, or `0` if there is none, then copy
+    // the first basic code points to the output.
+
+    var basic = input.lastIndexOf(delimiter);
+    if (basic < 0) {
+      basic = 0;
+    }
+
+    for (var j = 0; j < basic; ++j) {
+      // if it's not a basic code point
+      if (input.charCodeAt(j) >= 0x80) {
+        error$1('not-basic');
+      }
+      output.push(input.charCodeAt(j));
+    }
+
+    // Main decoding loop: start just after the last delimiter if any basic code
+    // points were copied; start at the beginning otherwise.
+
+    for (var index = basic > 0 ? basic + 1 : 0; index < inputLength;) /* no final expression */{
+
+      // `index` is the index of the next character to be consumed.
+      // Decode a generalized variable-length integer into `delta`,
+      // which gets added to `i`. The overflow checking is easier
+      // if we increase `i` as we go, then subtract off its starting
+      // value at the end to obtain `delta`.
+      var oldi = i;
+      for (var w = 1, k = base;; /* no condition */k += base) {
+
+        if (index >= inputLength) {
+          error$1('invalid-input');
+        }
+
+        var digit = basicToDigit(input.charCodeAt(index++));
+
+        if (digit >= base || digit > floor((maxInt - i) / w)) {
+          error$1('overflow');
+        }
+
+        i += digit * w;
+        var t = k <= bias ? tMin : k >= bias + tMax ? tMax : k - bias;
+
+        if (digit < t) {
+          break;
+        }
+
+        var baseMinusT = base - t;
+        if (w > floor(maxInt / baseMinusT)) {
+          error$1('overflow');
+        }
+
+        w *= baseMinusT;
+      }
+
+      var out = output.length + 1;
+      bias = adapt(i - oldi, out, oldi == 0);
+
+      // `i` was supposed to wrap around from `out` to `0`,
+      // incrementing `n` each time, so we'll fix that now:
+      if (floor(i / out) > maxInt - n) {
+        error$1('overflow');
+      }
+
+      n += floor(i / out);
+      i %= out;
+
+      // Insert `n` at position `i` of the output.
+      output.splice(i++, 0, n);
+    }
+
+    return String.fromCodePoint.apply(String, output);
+  };
+
+  /**
+   * Converts a string of Unicode symbols (e.g. a domain name label) to a
+   * Punycode string of ASCII-only symbols.
+   * @memberOf punycode
+   * @param {String} input The string of Unicode symbols.
+   * @returns {String} The resulting Punycode string of ASCII-only symbols.
+   */
+  var encode = function encode(input) {
+    var output = [];
+
+    // Convert the input in UCS-2 to an array of Unicode code points.
+    input = ucs2decode(input);
+
+    // Cache the length.
+    var inputLength = input.length;
+
+    // Initialize the state.
+    var n = initialN;
+    var delta = 0;
+    var bias = initialBias;
+
+    // Handle the basic code points.
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
+
+    try {
+      for (var _iterator = input[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+        var _currentValue2 = _step.value;
+
+        if (_currentValue2 < 0x80) {
+          output.push(stringFromCharCode(_currentValue2));
+        }
+      }
+    } catch (err) {
+      _didIteratorError = true;
+      _iteratorError = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion && _iterator.return) {
+          _iterator.return();
+        }
+      } finally {
+        if (_didIteratorError) {
+          throw _iteratorError;
+        }
+      }
+    }
+
+    var basicLength = output.length;
+    var handledCPCount = basicLength;
+
+    // `handledCPCount` is the number of code points that have been handled;
+    // `basicLength` is the number of basic code points.
+
+    // Finish the basic string with a delimiter unless it's empty.
+    if (basicLength) {
+      output.push(delimiter);
+    }
+
+    // Main encoding loop:
+    while (handledCPCount < inputLength) {
+
+      // All non-basic code points < n have been handled already. Find the next
+      // larger one:
+      var m = maxInt;
+      var _iteratorNormalCompletion2 = true;
+      var _didIteratorError2 = false;
+      var _iteratorError2 = undefined;
+
+      try {
+        for (var _iterator2 = input[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+          var currentValue = _step2.value;
+
+          if (currentValue >= n && currentValue < m) {
+            m = currentValue;
+          }
+        }
+
+        // Increase `delta` enough to advance the decoder's <n,i> state to <m,0>,
+        // but guard against overflow.
+      } catch (err) {
+        _didIteratorError2 = true;
+        _iteratorError2 = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion2 && _iterator2.return) {
+            _iterator2.return();
+          }
+        } finally {
+          if (_didIteratorError2) {
+            throw _iteratorError2;
+          }
+        }
+      }
+
+      var handledCPCountPlusOne = handledCPCount + 1;
+      if (m - n > floor((maxInt - delta) / handledCPCountPlusOne)) {
+        error$1('overflow');
+      }
+
+      delta += (m - n) * handledCPCountPlusOne;
+      n = m;
+
+      var _iteratorNormalCompletion3 = true;
+      var _didIteratorError3 = false;
+      var _iteratorError3 = undefined;
+
+      try {
+        for (var _iterator3 = input[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+          var _currentValue = _step3.value;
+
+          if (_currentValue < n && ++delta > maxInt) {
+            error$1('overflow');
+          }
+          if (_currentValue == n) {
+            // Represent delta as a generalized variable-length integer.
+            var q = delta;
+            for (var k = base;; /* no condition */k += base) {
+              var t = k <= bias ? tMin : k >= bias + tMax ? tMax : k - bias;
+              if (q < t) {
+                break;
+              }
+              var qMinusT = q - t;
+              var baseMinusT = base - t;
+              output.push(stringFromCharCode(digitToBasic(t + qMinusT % baseMinusT, 0)));
+              q = floor(qMinusT / baseMinusT);
+            }
+
+            output.push(stringFromCharCode(digitToBasic(q, 0)));
+            bias = adapt(delta, handledCPCountPlusOne, handledCPCount == basicLength);
+            delta = 0;
+            ++handledCPCount;
+          }
+        }
+      } catch (err) {
+        _didIteratorError3 = true;
+        _iteratorError3 = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion3 && _iterator3.return) {
+            _iterator3.return();
+          }
+        } finally {
+          if (_didIteratorError3) {
+            throw _iteratorError3;
+          }
+        }
+      }
+
+      ++delta;
+      ++n;
+    }
+    return output.join('');
+  };
+
+  /**
+   * Converts a Punycode string representing a domain name or an email address
+   * to Unicode. Only the Punycoded parts of the input will be converted, i.e.
+   * it doesn't matter if you call it on a string that has already been
+   * converted to Unicode.
+   * @memberOf punycode
+   * @param {String} input The Punycoded domain name or email address to
+   * convert to Unicode.
+   * @returns {String} The Unicode representation of the given Punycode
+   * string.
+   */
+  var toUnicode = function toUnicode(input) {
+    return mapDomain(input, function (string) {
+      return regexPunycode.test(string) ? decode(string.slice(4).toLowerCase()) : string;
+    });
+  };
+
+  /**
+   * Converts a Unicode string representing a domain name or an email address to
+   * Punycode. Only the non-ASCII parts of the domain name will be converted,
+   * i.e. it doesn't matter if you call it with a domain that's already in
+   * ASCII.
+   * @memberOf punycode
+   * @param {String} input The domain name or email address to convert, as a
+   * Unicode string.
+   * @returns {String} The Punycode representation of the given domain name or
+   * email address.
+   */
+  var toASCII = function toASCII(input) {
+    return mapDomain(input, function (string) {
+      return regexNonASCII.test(string) ? 'xn--' + encode(string) : string;
+    });
+  };
+
+  /*--------------------------------------------------------------------------*/
+
+  /** Define the public API */
+  var punycode = {
+    /**
+    * A string representing the current Punycode.js version number.
+    * @memberOf punycode
+    * @type String
+    */
+    'version': '2.1.0',
+    /**
+    * An object of methods to convert from JavaScript's internal character
+    * representation (UCS-2) to Unicode code points, and back.
+    * @see <https://mathiasbynens.be/notes/javascript-encoding>
+    * @memberOf punycode
+    * @type Object
+    */
+    'ucs2': {
+      'decode': ucs2decode,
+      'encode': ucs2encode
+    },
+    'decode': decode,
+    'encode': encode,
+    'toASCII': toASCII,
+    'toUnicode': toUnicode
+  };
+
+  /**
+   * URI.js
+   *
+   * @fileoverview An RFC 3986 compliant, scheme extendable URI parsing/validating/resolving library for JavaScript.
+   * @author <a href="mailto:gary.court@gmail.com">Gary Court</a>
+   * @see http://github.com/garycourt/uri-js
+   */
+  /**
+   * Copyright 2011 Gary Court. All rights reserved.
+   *
+   * Redistribution and use in source and binary forms, with or without modification, are
+   * permitted provided that the following conditions are met:
+   *
+   *    1. Redistributions of source code must retain the above copyright notice, this list of
+   *       conditions and the following disclaimer.
+   *
+   *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+   *       of conditions and the following disclaimer in the documentation and/or other materials
+   *       provided with the distribution.
+   *
+   * THIS SOFTWARE IS PROVIDED BY GARY COURT ``AS IS'' AND ANY EXPRESS OR IMPLIED
+   * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+   * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL GARY COURT OR
+   * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+   * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+   * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   *
+   * The views and conclusions contained in the software and documentation are those of the
+   * authors and should not be interpreted as representing official policies, either expressed
+   * or implied, of Gary Court.
+   */
+  var SCHEMES = {};
+  function pctEncChar(chr) {
+      var c = chr.charCodeAt(0);
+      var e = void 0;
+      if (c < 16) e = "%0" + c.toString(16).toUpperCase();else if (c < 128) e = "%" + c.toString(16).toUpperCase();else if (c < 2048) e = "%" + (c >> 6 | 192).toString(16).toUpperCase() + "%" + (c & 63 | 128).toString(16).toUpperCase();else e = "%" + (c >> 12 | 224).toString(16).toUpperCase() + "%" + (c >> 6 & 63 | 128).toString(16).toUpperCase() + "%" + (c & 63 | 128).toString(16).toUpperCase();
+      return e;
+  }
+  function pctDecChars(str) {
+      var newStr = "";
+      var i = 0;
+      var il = str.length;
+      while (i < il) {
+          var c = parseInt(str.substr(i + 1, 2), 16);
+          if (c < 128) {
+              newStr += String.fromCharCode(c);
+              i += 3;
+          } else if (c >= 194 && c < 224) {
+              if (il - i >= 6) {
+                  var c2 = parseInt(str.substr(i + 4, 2), 16);
+                  newStr += String.fromCharCode((c & 31) << 6 | c2 & 63);
+              } else {
+                  newStr += str.substr(i, 6);
+              }
+              i += 6;
+          } else if (c >= 224) {
+              if (il - i >= 9) {
+                  var _c = parseInt(str.substr(i + 4, 2), 16);
+                  var c3 = parseInt(str.substr(i + 7, 2), 16);
+                  newStr += String.fromCharCode((c & 15) << 12 | (_c & 63) << 6 | c3 & 63);
+              } else {
+                  newStr += str.substr(i, 9);
+              }
+              i += 9;
+          } else {
+              newStr += str.substr(i, 3);
+              i += 3;
+          }
+      }
+      return newStr;
+  }
+  function _normalizeComponentEncoding(components, protocol) {
+      function decodeUnreserved(str) {
+          var decStr = pctDecChars(str);
+          return !decStr.match(protocol.UNRESERVED) ? str : decStr;
+      }
+      if (components.scheme) components.scheme = String(components.scheme).replace(protocol.PCT_ENCODED, decodeUnreserved).toLowerCase().replace(protocol.NOT_SCHEME, "");
+      if (components.userinfo !== undefined) components.userinfo = String(components.userinfo).replace(protocol.PCT_ENCODED, decodeUnreserved).replace(protocol.NOT_USERINFO, pctEncChar).replace(protocol.PCT_ENCODED, toUpperCase);
+      if (components.host !== undefined) components.host = String(components.host).replace(protocol.PCT_ENCODED, decodeUnreserved).toLowerCase().replace(protocol.NOT_HOST, pctEncChar).replace(protocol.PCT_ENCODED, toUpperCase);
+      if (components.path !== undefined) components.path = String(components.path).replace(protocol.PCT_ENCODED, decodeUnreserved).replace(components.scheme ? protocol.NOT_PATH : protocol.NOT_PATH_NOSCHEME, pctEncChar).replace(protocol.PCT_ENCODED, toUpperCase);
+      if (components.query !== undefined) components.query = String(components.query).replace(protocol.PCT_ENCODED, decodeUnreserved).replace(protocol.NOT_QUERY, pctEncChar).replace(protocol.PCT_ENCODED, toUpperCase);
+      if (components.fragment !== undefined) components.fragment = String(components.fragment).replace(protocol.PCT_ENCODED, decodeUnreserved).replace(protocol.NOT_FRAGMENT, pctEncChar).replace(protocol.PCT_ENCODED, toUpperCase);
+      return components;
+  }
+
+  function _stripLeadingZeros(str) {
+      return str.replace(/^0*(.*)/, "$1") || "0";
+  }
+  function _normalizeIPv4(host, protocol) {
+      var matches = host.match(protocol.IPV4ADDRESS) || [];
+
+      var _matches = slicedToArray(matches, 2),
+          address = _matches[1];
+
+      if (address) {
+          return address.split(".").map(_stripLeadingZeros).join(".");
+      } else {
+          return host;
+      }
+  }
+  function _normalizeIPv6(host, protocol) {
+      var matches = host.match(protocol.IPV6ADDRESS) || [];
+
+      var _matches2 = slicedToArray(matches, 3),
+          address = _matches2[1],
+          zone = _matches2[2];
+
+      if (address) {
+          var _address$toLowerCase$ = address.toLowerCase().split('::').reverse(),
+              _address$toLowerCase$2 = slicedToArray(_address$toLowerCase$, 2),
+              last = _address$toLowerCase$2[0],
+              first = _address$toLowerCase$2[1];
+
+          var firstFields = first ? first.split(":").map(_stripLeadingZeros) : [];
+          var lastFields = last.split(":").map(_stripLeadingZeros);
+          var isLastFieldIPv4Address = protocol.IPV4ADDRESS.test(lastFields[lastFields.length - 1]);
+          var fieldCount = isLastFieldIPv4Address ? 7 : 8;
+          var lastFieldsStart = lastFields.length - fieldCount;
+          var fields = Array(fieldCount);
+          for (var x = 0; x < fieldCount; ++x) {
+              fields[x] = firstFields[x] || lastFields[lastFieldsStart + x] || '';
+          }
+          if (isLastFieldIPv4Address) {
+              fields[fieldCount - 1] = _normalizeIPv4(fields[fieldCount - 1], protocol);
+          }
+          var allZeroFields = fields.reduce(function (acc, field, index) {
+              if (!field || field === "0") {
+                  var lastLongest = acc[acc.length - 1];
+                  if (lastLongest && lastLongest.index + lastLongest.length === index) {
+                      lastLongest.length++;
+                  } else {
+                      acc.push({ index: index, length: 1 });
+                  }
+              }
+              return acc;
+          }, []);
+          var longestZeroFields = allZeroFields.sort(function (a, b) {
+              return b.length - a.length;
+          })[0];
+          var newHost = void 0;
+          if (longestZeroFields && longestZeroFields.length > 1) {
+              var newFirst = fields.slice(0, longestZeroFields.index);
+              var newLast = fields.slice(longestZeroFields.index + longestZeroFields.length);
+              newHost = newFirst.join(":") + "::" + newLast.join(":");
+          } else {
+              newHost = fields.join(":");
+          }
+          if (zone) {
+              newHost += "%" + zone;
+          }
+          return newHost;
+      } else {
+          return host;
+      }
+  }
+  var URI_PARSE = /^(?:([^:\/?#]+):)?(?:\/\/((?:([^\/?#@]*)@)?(\[[^\/?#\]]+\]|[^\/?#:]*)(?:\:(\d*))?))?([^?#]*)(?:\?([^#]*))?(?:#((?:.|\n|\r)*))?/i;
+  var NO_MATCH_IS_UNDEFINED = "".match(/(){0}/)[1] === undefined;
+  function parse(uriString) {
+      var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+      var components = {};
+      var protocol = options.iri !== false ? IRI_PROTOCOL : URI_PROTOCOL;
+      if (options.reference === "suffix") uriString = (options.scheme ? options.scheme + ":" : "") + "//" + uriString;
+      var matches = uriString.match(URI_PARSE);
+      if (matches) {
+          if (NO_MATCH_IS_UNDEFINED) {
+              //store each component
+              components.scheme = matches[1];
+              components.userinfo = matches[3];
+              components.host = matches[4];
+              components.port = parseInt(matches[5], 10);
+              components.path = matches[6] || "";
+              components.query = matches[7];
+              components.fragment = matches[8];
+              //fix port number
+              if (isNaN(components.port)) {
+                  components.port = matches[5];
+              }
+          } else {
+              //IE FIX for improper RegExp matching
+              //store each component
+              components.scheme = matches[1] || undefined;
+              components.userinfo = uriString.indexOf("@") !== -1 ? matches[3] : undefined;
+              components.host = uriString.indexOf("//") !== -1 ? matches[4] : undefined;
+              components.port = parseInt(matches[5], 10);
+              components.path = matches[6] || "";
+              components.query = uriString.indexOf("?") !== -1 ? matches[7] : undefined;
+              components.fragment = uriString.indexOf("#") !== -1 ? matches[8] : undefined;
+              //fix port number
+              if (isNaN(components.port)) {
+                  components.port = uriString.match(/\/\/(?:.|\n)*\:(?:\/|\?|\#|$)/) ? matches[4] : undefined;
+              }
+          }
+          if (components.host) {
+              //normalize IP hosts
+              components.host = _normalizeIPv6(_normalizeIPv4(components.host, protocol), protocol);
+          }
+          //determine reference type
+          if (components.scheme === undefined && components.userinfo === undefined && components.host === undefined && components.port === undefined && !components.path && components.query === undefined) {
+              components.reference = "same-document";
+          } else if (components.scheme === undefined) {
+              components.reference = "relative";
+          } else if (components.fragment === undefined) {
+              components.reference = "absolute";
+          } else {
+              components.reference = "uri";
+          }
+          //check for reference errors
+          if (options.reference && options.reference !== "suffix" && options.reference !== components.reference) {
+              components.error = components.error || "URI is not a " + options.reference + " reference.";
+          }
+          //find scheme handler
+          var schemeHandler = SCHEMES[(options.scheme || components.scheme || "").toLowerCase()];
+          //check if scheme can't handle IRIs
+          if (!options.unicodeSupport && (!schemeHandler || !schemeHandler.unicodeSupport)) {
+              //if host component is a domain name
+              if (components.host && (options.domainHost || schemeHandler && schemeHandler.domainHost)) {
+                  //convert Unicode IDN -> ASCII IDN
+                  try {
+                      components.host = punycode.toASCII(components.host.replace(protocol.PCT_ENCODED, pctDecChars).toLowerCase());
+                  } catch (e) {
+                      components.error = components.error || "Host's domain name can not be converted to ASCII via punycode: " + e;
+                  }
+              }
+              //convert IRI -> URI
+              _normalizeComponentEncoding(components, URI_PROTOCOL);
+          } else {
+              //normalize encodings
+              _normalizeComponentEncoding(components, protocol);
+          }
+          //perform scheme specific parsing
+          if (schemeHandler && schemeHandler.parse) {
+              schemeHandler.parse(components, options);
+          }
+      } else {
+          components.error = components.error || "URI can not be parsed.";
+      }
+      return components;
+  }
+
+  function _recomposeAuthority(components, options) {
+      var protocol = options.iri !== false ? IRI_PROTOCOL : URI_PROTOCOL;
+      var uriTokens = [];
+      if (components.userinfo !== undefined) {
+          uriTokens.push(components.userinfo);
+          uriTokens.push("@");
+      }
+      if (components.host !== undefined) {
+          //normalize IP hosts, add brackets and escape zone separator for IPv6
+          uriTokens.push(_normalizeIPv6(_normalizeIPv4(String(components.host), protocol), protocol).replace(protocol.IPV6ADDRESS, function (_, $1, $2) {
+              return "[" + $1 + ($2 ? "%25" + $2 : "") + "]";
+          }));
+      }
+      if (typeof components.port === "number" || typeof components.port === "string") {
+          uriTokens.push(":");
+          uriTokens.push(String(components.port));
+      }
+      return uriTokens.length ? uriTokens.join("") : undefined;
+  }
+
+  var RDS1 = /^\.\.?\//;
+  var RDS2 = /^\/\.(\/|$)/;
+  var RDS3 = /^\/\.\.(\/|$)/;
+  var RDS5 = /^\/?(?:.|\n)*?(?=\/|$)/;
+  function removeDotSegments(input) {
+      var output = [];
+      while (input.length) {
+          if (input.match(RDS1)) {
+              input = input.replace(RDS1, "");
+          } else if (input.match(RDS2)) {
+              input = input.replace(RDS2, "/");
+          } else if (input.match(RDS3)) {
+              input = input.replace(RDS3, "/");
+              output.pop();
+          } else if (input === "." || input === "..") {
+              input = "";
+          } else {
+              var im = input.match(RDS5);
+              if (im) {
+                  var s = im[0];
+                  input = input.slice(s.length);
+                  output.push(s);
+              } else {
+                  throw new Error("Unexpected dot segment condition");
+              }
+          }
+      }
+      return output.join("");
+  }
+
+  function serialize(components) {
+      var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+      var protocol = options.iri ? IRI_PROTOCOL : URI_PROTOCOL;
+      var uriTokens = [];
+      //find scheme handler
+      var schemeHandler = SCHEMES[(options.scheme || components.scheme || "").toLowerCase()];
+      //perform scheme specific serialization
+      if (schemeHandler && schemeHandler.serialize) schemeHandler.serialize(components, options);
+      if (components.host) {
+          //if host component is an IPv6 address
+          if (protocol.IPV6ADDRESS.test(components.host)) {}
+          //TODO: normalize IPv6 address as per RFC 5952
+
+          //if host component is a domain name
+          else if (options.domainHost || schemeHandler && schemeHandler.domainHost) {
+                  //convert IDN via punycode
+                  try {
+                      components.host = !options.iri ? punycode.toASCII(components.host.replace(protocol.PCT_ENCODED, pctDecChars).toLowerCase()) : punycode.toUnicode(components.host);
+                  } catch (e) {
+                      components.error = components.error || "Host's domain name can not be converted to " + (!options.iri ? "ASCII" : "Unicode") + " via punycode: " + e;
+                  }
+              }
+      }
+      //normalize encoding
+      _normalizeComponentEncoding(components, protocol);
+      if (options.reference !== "suffix" && components.scheme) {
+          uriTokens.push(components.scheme);
+          uriTokens.push(":");
+      }
+      var authority = _recomposeAuthority(components, options);
+      if (authority !== undefined) {
+          if (options.reference !== "suffix") {
+              uriTokens.push("//");
+          }
+          uriTokens.push(authority);
+          if (components.path && components.path.charAt(0) !== "/") {
+              uriTokens.push("/");
+          }
+      }
+      if (components.path !== undefined) {
+          var s = components.path;
+          if (!options.absolutePath && (!schemeHandler || !schemeHandler.absolutePath)) {
+              s = removeDotSegments(s);
+          }
+          if (authority === undefined) {
+              s = s.replace(/^\/\//, "/%2F"); //don't allow the path to start with "//"
+          }
+          uriTokens.push(s);
+      }
+      if (components.query !== undefined) {
+          uriTokens.push("?");
+          uriTokens.push(components.query);
+      }
+      if (components.fragment !== undefined) {
+          uriTokens.push("#");
+          uriTokens.push(components.fragment);
+      }
+      return uriTokens.join(""); //merge tokens into a string
+  }
+
+  function resolveComponents(base, relative) {
+      var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+      var skipNormalization = arguments[3];
+
+      var target = {};
+      if (!skipNormalization) {
+          base = parse(serialize(base, options), options); //normalize base components
+          relative = parse(serialize(relative, options), options); //normalize relative components
+      }
+      options = options || {};
+      if (!options.tolerant && relative.scheme) {
+          target.scheme = relative.scheme;
+          //target.authority = relative.authority;
+          target.userinfo = relative.userinfo;
+          target.host = relative.host;
+          target.port = relative.port;
+          target.path = removeDotSegments(relative.path || "");
+          target.query = relative.query;
+      } else {
+          if (relative.userinfo !== undefined || relative.host !== undefined || relative.port !== undefined) {
+              //target.authority = relative.authority;
+              target.userinfo = relative.userinfo;
+              target.host = relative.host;
+              target.port = relative.port;
+              target.path = removeDotSegments(relative.path || "");
+              target.query = relative.query;
+          } else {
+              if (!relative.path) {
+                  target.path = base.path;
+                  if (relative.query !== undefined) {
+                      target.query = relative.query;
+                  } else {
+                      target.query = base.query;
+                  }
+              } else {
+                  if (relative.path.charAt(0) === "/") {
+                      target.path = removeDotSegments(relative.path);
+                  } else {
+                      if ((base.userinfo !== undefined || base.host !== undefined || base.port !== undefined) && !base.path) {
+                          target.path = "/" + relative.path;
+                      } else if (!base.path) {
+                          target.path = relative.path;
+                      } else {
+                          target.path = base.path.slice(0, base.path.lastIndexOf("/") + 1) + relative.path;
+                      }
+                      target.path = removeDotSegments(target.path);
+                  }
+                  target.query = relative.query;
+              }
+              //target.authority = base.authority;
+              target.userinfo = base.userinfo;
+              target.host = base.host;
+              target.port = base.port;
+          }
+          target.scheme = base.scheme;
+      }
+      target.fragment = relative.fragment;
+      return target;
+  }
+
+  function resolve(baseURI, relativeURI, options) {
+      var schemelessOptions = assign({ scheme: 'null' }, options);
+      return serialize(resolveComponents(parse(baseURI, schemelessOptions), parse(relativeURI, schemelessOptions), schemelessOptions, true), schemelessOptions);
+  }
+
+  function normalize(uri, options) {
+      if (typeof uri === "string") {
+          uri = serialize(parse(uri, options), options);
+      } else if (typeOf(uri) === "object") {
+          uri = parse(serialize(uri, options), options);
+      }
+      return uri;
+  }
+
+  function equal(uriA, uriB, options) {
+      if (typeof uriA === "string") {
+          uriA = serialize(parse(uriA, options), options);
+      } else if (typeOf(uriA) === "object") {
+          uriA = serialize(uriA, options);
+      }
+      if (typeof uriB === "string") {
+          uriB = serialize(parse(uriB, options), options);
+      } else if (typeOf(uriB) === "object") {
+          uriB = serialize(uriB, options);
+      }
+      return uriA === uriB;
+  }
+
+  function escapeComponent(str, options) {
+      return str && str.toString().replace(!options || !options.iri ? URI_PROTOCOL.ESCAPE : IRI_PROTOCOL.ESCAPE, pctEncChar);
+  }
+
+  function unescapeComponent(str, options) {
+      return str && str.toString().replace(!options || !options.iri ? URI_PROTOCOL.PCT_ENCODED : IRI_PROTOCOL.PCT_ENCODED, pctDecChars);
+  }
+
+  var handler = {
+      scheme: "http",
+      domainHost: true,
+      parse: function parse(components, options) {
+          //report missing host
+          if (!components.host) {
+              components.error = components.error || "HTTP URIs must have a host.";
+          }
+          return components;
+      },
+      serialize: function serialize(components, options) {
+          var secure = String(components.scheme).toLowerCase() === "https";
+          //normalize the default port
+          if (components.port === (secure ? 443 : 80) || components.port === "") {
+              components.port = undefined;
+          }
+          //normalize the empty path
+          if (!components.path) {
+              components.path = "/";
+          }
+          //NOTE: We do not parse query strings for HTTP URIs
+          //as WWW Form Url Encoded query strings are part of the HTML4+ spec,
+          //and not the HTTP spec.
+          return components;
+      }
+  };
+
+  var handler$1 = {
+      scheme: "https",
+      domainHost: handler.domainHost,
+      parse: handler.parse,
+      serialize: handler.serialize
+  };
+
+  function isSecure(wsComponents) {
+      return typeof wsComponents.secure === 'boolean' ? wsComponents.secure : String(wsComponents.scheme).toLowerCase() === "wss";
+  }
+  //RFC 6455
+  var handler$2 = {
+      scheme: "ws",
+      domainHost: true,
+      parse: function parse(components, options) {
+          var wsComponents = components;
+          //indicate if the secure flag is set
+          wsComponents.secure = isSecure(wsComponents);
+          //construct resouce name
+          wsComponents.resourceName = (wsComponents.path || '/') + (wsComponents.query ? '?' + wsComponents.query : '');
+          wsComponents.path = undefined;
+          wsComponents.query = undefined;
+          return wsComponents;
+      },
+      serialize: function serialize(wsComponents, options) {
+          //normalize the default port
+          if (wsComponents.port === (isSecure(wsComponents) ? 443 : 80) || wsComponents.port === "") {
+              wsComponents.port = undefined;
+          }
+          //ensure scheme matches secure flag
+          if (typeof wsComponents.secure === 'boolean') {
+              wsComponents.scheme = wsComponents.secure ? 'wss' : 'ws';
+              wsComponents.secure = undefined;
+          }
+          //reconstruct path from resource name
+          if (wsComponents.resourceName) {
+              var _wsComponents$resourc = wsComponents.resourceName.split('?'),
+                  _wsComponents$resourc2 = slicedToArray(_wsComponents$resourc, 2),
+                  path = _wsComponents$resourc2[0],
+                  query = _wsComponents$resourc2[1];
+
+              wsComponents.path = path && path !== '/' ? path : undefined;
+              wsComponents.query = query;
+              wsComponents.resourceName = undefined;
+          }
+          //forbid fragment component
+          wsComponents.fragment = undefined;
+          return wsComponents;
+      }
+  };
+
+  var handler$3 = {
+      scheme: "wss",
+      domainHost: handler$2.domainHost,
+      parse: handler$2.parse,
+      serialize: handler$2.serialize
+  };
+
+  var O = {};
+  var isIRI = true;
+  //RFC 3986
+  var UNRESERVED$$ = "[A-Za-z0-9\\-\\.\\_\\~" + (isIRI ? "\\xA0-\\u200D\\u2010-\\u2029\\u202F-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFEF" : "") + "]";
+  var HEXDIG$$ = "[0-9A-Fa-f]"; //case-insensitive
+  var PCT_ENCODED$ = subexp(subexp("%[EFef]" + HEXDIG$$ + "%" + HEXDIG$$ + HEXDIG$$ + "%" + HEXDIG$$ + HEXDIG$$) + "|" + subexp("%[89A-Fa-f]" + HEXDIG$$ + "%" + HEXDIG$$ + HEXDIG$$) + "|" + subexp("%" + HEXDIG$$ + HEXDIG$$)); //expanded
+  //RFC 5322, except these symbols as per RFC 6068: @ : / ? # [ ] & ; =
+  //const ATEXT$$ = "[A-Za-z0-9\\!\\#\\$\\%\\&\\'\\*\\+\\-\\/\\=\\?\\^\\_\\`\\{\\|\\}\\~]";
+  //const WSP$$ = "[\\x20\\x09]";
+  //const OBS_QTEXT$$ = "[\\x01-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F]";  //(%d1-8 / %d11-12 / %d14-31 / %d127)
+  //const QTEXT$$ = merge("[\\x21\\x23-\\x5B\\x5D-\\x7E]", OBS_QTEXT$$);  //%d33 / %d35-91 / %d93-126 / obs-qtext
+  //const VCHAR$$ = "[\\x21-\\x7E]";
+  //const WSP$$ = "[\\x20\\x09]";
+  //const OBS_QP$ = subexp("\\\\" + merge("[\\x00\\x0D\\x0A]", OBS_QTEXT$$));  //%d0 / CR / LF / obs-qtext
+  //const FWS$ = subexp(subexp(WSP$$ + "*" + "\\x0D\\x0A") + "?" + WSP$$ + "+");
+  //const QUOTED_PAIR$ = subexp(subexp("\\\\" + subexp(VCHAR$$ + "|" + WSP$$)) + "|" + OBS_QP$);
+  //const QUOTED_STRING$ = subexp('\\"' + subexp(FWS$ + "?" + QCONTENT$) + "*" + FWS$ + "?" + '\\"');
+  var ATEXT$$ = "[A-Za-z0-9\\!\\$\\%\\'\\*\\+\\-\\^\\_\\`\\{\\|\\}\\~]";
+  var QTEXT$$ = "[\\!\\$\\%\\'\\(\\)\\*\\+\\,\\-\\.0-9\\<\\>A-Z\\x5E-\\x7E]";
+  var VCHAR$$ = merge(QTEXT$$, "[\\\"\\\\]");
+  var SOME_DELIMS$$ = "[\\!\\$\\'\\(\\)\\*\\+\\,\\;\\:\\@]";
+  var UNRESERVED = new RegExp(UNRESERVED$$, "g");
+  var PCT_ENCODED = new RegExp(PCT_ENCODED$, "g");
+  var NOT_LOCAL_PART = new RegExp(merge("[^]", ATEXT$$, "[\\.]", '[\\"]', VCHAR$$), "g");
+  var NOT_HFNAME = new RegExp(merge("[^]", UNRESERVED$$, SOME_DELIMS$$), "g");
+  var NOT_HFVALUE = NOT_HFNAME;
+  function decodeUnreserved(str) {
+      var decStr = pctDecChars(str);
+      return !decStr.match(UNRESERVED) ? str : decStr;
+  }
+  var handler$4 = {
+      scheme: "mailto",
+      parse: function parse$$1(components, options) {
+          var mailtoComponents = components;
+          var to = mailtoComponents.to = mailtoComponents.path ? mailtoComponents.path.split(",") : [];
+          mailtoComponents.path = undefined;
+          if (mailtoComponents.query) {
+              var unknownHeaders = false;
+              var headers = {};
+              var hfields = mailtoComponents.query.split("&");
+              for (var x = 0, xl = hfields.length; x < xl; ++x) {
+                  var hfield = hfields[x].split("=");
+                  switch (hfield[0]) {
+                      case "to":
+                          var toAddrs = hfield[1].split(",");
+                          for (var _x = 0, _xl = toAddrs.length; _x < _xl; ++_x) {
+                              to.push(toAddrs[_x]);
+                          }
+                          break;
+                      case "subject":
+                          mailtoComponents.subject = unescapeComponent(hfield[1], options);
+                          break;
+                      case "body":
+                          mailtoComponents.body = unescapeComponent(hfield[1], options);
+                          break;
+                      default:
+                          unknownHeaders = true;
+                          headers[unescapeComponent(hfield[0], options)] = unescapeComponent(hfield[1], options);
+                          break;
+                  }
+              }
+              if (unknownHeaders) mailtoComponents.headers = headers;
+          }
+          mailtoComponents.query = undefined;
+          for (var _x2 = 0, _xl2 = to.length; _x2 < _xl2; ++_x2) {
+              var addr = to[_x2].split("@");
+              addr[0] = unescapeComponent(addr[0]);
+              if (!options.unicodeSupport) {
+                  //convert Unicode IDN -> ASCII IDN
+                  try {
+                      addr[1] = punycode.toASCII(unescapeComponent(addr[1], options).toLowerCase());
+                  } catch (e) {
+                      mailtoComponents.error = mailtoComponents.error || "Email address's domain name can not be converted to ASCII via punycode: " + e;
+                  }
+              } else {
+                  addr[1] = unescapeComponent(addr[1], options).toLowerCase();
+              }
+              to[_x2] = addr.join("@");
+          }
+          return mailtoComponents;
+      },
+      serialize: function serialize$$1(mailtoComponents, options) {
+          var components = mailtoComponents;
+          var to = toArray(mailtoComponents.to);
+          if (to) {
+              for (var x = 0, xl = to.length; x < xl; ++x) {
+                  var toAddr = String(to[x]);
+                  var atIdx = toAddr.lastIndexOf("@");
+                  var localPart = toAddr.slice(0, atIdx).replace(PCT_ENCODED, decodeUnreserved).replace(PCT_ENCODED, toUpperCase).replace(NOT_LOCAL_PART, pctEncChar);
+                  var domain = toAddr.slice(atIdx + 1);
+                  //convert IDN via punycode
+                  try {
+                      domain = !options.iri ? punycode.toASCII(unescapeComponent(domain, options).toLowerCase()) : punycode.toUnicode(domain);
+                  } catch (e) {
+                      components.error = components.error || "Email address's domain name can not be converted to " + (!options.iri ? "ASCII" : "Unicode") + " via punycode: " + e;
+                  }
+                  to[x] = localPart + "@" + domain;
+              }
+              components.path = to.join(",");
+          }
+          var headers = mailtoComponents.headers = mailtoComponents.headers || {};
+          if (mailtoComponents.subject) headers["subject"] = mailtoComponents.subject;
+          if (mailtoComponents.body) headers["body"] = mailtoComponents.body;
+          var fields = [];
+          for (var name in headers) {
+              if (headers[name] !== O[name]) {
+                  fields.push(name.replace(PCT_ENCODED, decodeUnreserved).replace(PCT_ENCODED, toUpperCase).replace(NOT_HFNAME, pctEncChar) + "=" + headers[name].replace(PCT_ENCODED, decodeUnreserved).replace(PCT_ENCODED, toUpperCase).replace(NOT_HFVALUE, pctEncChar));
+              }
+          }
+          if (fields.length) {
+              components.query = fields.join("&");
+          }
+          return components;
+      }
+  };
+
+  var URN_PARSE = /^([^\:]+)\:(.*)/;
+  //RFC 2141
+  var handler$5 = {
+      scheme: "urn",
+      parse: function parse$$1(components, options) {
+          var matches = components.path && components.path.match(URN_PARSE);
+          var urnComponents = components;
+          if (matches) {
+              var scheme = options.scheme || urnComponents.scheme || "urn";
+              var nid = matches[1].toLowerCase();
+              var nss = matches[2];
+              var urnScheme = scheme + ":" + (options.nid || nid);
+              var schemeHandler = SCHEMES[urnScheme];
+              urnComponents.nid = nid;
+              urnComponents.nss = nss;
+              urnComponents.path = undefined;
+              if (schemeHandler) {
+                  urnComponents = schemeHandler.parse(urnComponents, options);
+              }
+          } else {
+              urnComponents.error = urnComponents.error || "URN can not be parsed.";
+          }
+          return urnComponents;
+      },
+      serialize: function serialize$$1(urnComponents, options) {
+          var scheme = options.scheme || urnComponents.scheme || "urn";
+          var nid = urnComponents.nid;
+          var urnScheme = scheme + ":" + (options.nid || nid);
+          var schemeHandler = SCHEMES[urnScheme];
+          if (schemeHandler) {
+              urnComponents = schemeHandler.serialize(urnComponents, options);
+          }
+          var uriComponents = urnComponents;
+          var nss = urnComponents.nss;
+          uriComponents.path = (nid || options.nid) + ":" + nss;
+          return uriComponents;
+      }
+  };
+
+  var UUID = /^[0-9A-Fa-f]{8}(?:\-[0-9A-Fa-f]{4}){3}\-[0-9A-Fa-f]{12}$/;
+  //RFC 4122
+  var handler$6 = {
+      scheme: "urn:uuid",
+      parse: function parse(urnComponents, options) {
+          var uuidComponents = urnComponents;
+          uuidComponents.uuid = uuidComponents.nss;
+          uuidComponents.nss = undefined;
+          if (!options.tolerant && (!uuidComponents.uuid || !uuidComponents.uuid.match(UUID))) {
+              uuidComponents.error = uuidComponents.error || "UUID is not valid.";
+          }
+          return uuidComponents;
+      },
+      serialize: function serialize(uuidComponents, options) {
+          var urnComponents = uuidComponents;
+          //normalize UUID
+          urnComponents.nss = (uuidComponents.uuid || "").toLowerCase();
+          return urnComponents;
+      }
+  };
+
+  SCHEMES[handler.scheme] = handler;
+  SCHEMES[handler$1.scheme] = handler$1;
+  SCHEMES[handler$2.scheme] = handler$2;
+  SCHEMES[handler$3.scheme] = handler$3;
+  SCHEMES[handler$4.scheme] = handler$4;
+  SCHEMES[handler$5.scheme] = handler$5;
+  SCHEMES[handler$6.scheme] = handler$6;
+
+  exports.SCHEMES = SCHEMES;
+  exports.pctEncChar = pctEncChar;
+  exports.pctDecChars = pctDecChars;
+  exports.parse = parse;
+  exports.removeDotSegments = removeDotSegments;
+  exports.serialize = serialize;
+  exports.resolveComponents = resolveComponents;
+  exports.resolve = resolve;
+  exports.normalize = normalize;
+  exports.equal = equal;
+  exports.escapeComponent = escapeComponent;
+  exports.unescapeComponent = unescapeComponent;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
+
+  })));
+
+
+  },{}]},{},[1])(1)
+  });

--- a/assets/json-schema-draft-04.json
+++ b/assets/json-schema-draft-04.json
@@ -1,0 +1,149 @@
+{
+  "id": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Core schema meta-schema",
+  "definitions": {
+      "schemaArray": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#" }
+      },
+      "positiveInteger": {
+          "type": "integer",
+          "minimum": 0
+      },
+      "positiveIntegerDefault0": {
+          "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
+      },
+      "simpleTypes": {
+          "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
+      },
+      "stringArray": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1,
+          "uniqueItems": true
+      }
+  },
+  "type": "object",
+  "properties": {
+      "id": {
+          "type": "string"
+      },
+      "$schema": {
+          "type": "string"
+      },
+      "title": {
+          "type": "string"
+      },
+      "description": {
+          "type": "string"
+      },
+      "default": {},
+      "multipleOf": {
+          "type": "number",
+          "minimum": 0,
+          "exclusiveMinimum": true
+      },
+      "maximum": {
+          "type": "number"
+      },
+      "exclusiveMaximum": {
+          "type": "boolean",
+          "default": false
+      },
+      "minimum": {
+          "type": "number"
+      },
+      "exclusiveMinimum": {
+          "type": "boolean",
+          "default": false
+      },
+      "maxLength": { "$ref": "#/definitions/positiveInteger" },
+      "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
+      "pattern": {
+          "type": "string",
+          "format": "regex"
+      },
+      "additionalItems": {
+          "anyOf": [
+              { "type": "boolean" },
+              { "$ref": "#" }
+          ],
+          "default": {}
+      },
+      "items": {
+          "anyOf": [
+              { "$ref": "#" },
+              { "$ref": "#/definitions/schemaArray" }
+          ],
+          "default": {}
+      },
+      "maxItems": { "$ref": "#/definitions/positiveInteger" },
+      "minItems": { "$ref": "#/definitions/positiveIntegerDefault0" },
+      "uniqueItems": {
+          "type": "boolean",
+          "default": false
+      },
+      "maxProperties": { "$ref": "#/definitions/positiveInteger" },
+      "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
+      "required": { "$ref": "#/definitions/stringArray" },
+      "additionalProperties": {
+          "anyOf": [
+              { "type": "boolean" },
+              { "$ref": "#" }
+          ],
+          "default": {}
+      },
+      "definitions": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#" },
+          "default": {}
+      },
+      "properties": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#" },
+          "default": {}
+      },
+      "patternProperties": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#" },
+          "default": {}
+      },
+      "dependencies": {
+          "type": "object",
+          "additionalProperties": {
+              "anyOf": [
+                  { "$ref": "#" },
+                  { "$ref": "#/definitions/stringArray" }
+              ]
+          }
+      },
+      "enum": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true
+      },
+      "type": {
+          "anyOf": [
+              { "$ref": "#/definitions/simpleTypes" },
+              {
+                  "type": "array",
+                  "items": { "$ref": "#/definitions/simpleTypes" },
+                  "minItems": 1,
+                  "uniqueItems": true
+              }
+          ]
+      },
+      "format": { "type": "string" },
+      "allOf": { "$ref": "#/definitions/schemaArray" },
+      "anyOf": { "$ref": "#/definitions/schemaArray" },
+      "oneOf": { "$ref": "#/definitions/schemaArray" },
+      "not": { "$ref": "#" }
+  },
+  "dependencies": {
+      "exclusiveMaximum": [ "maximum" ],
+      "exclusiveMinimum": [ "minimum" ]
+  },
+  "default": {}
+}

--- a/lib/ajValidation/ajvValidatorDraft04.js
+++ b/lib/ajValidation/ajvValidatorDraft04.js
@@ -21,7 +21,9 @@ function validateSchemaAJVDraft04 (schema, valueToUse) {
       // check all rules collecting all errors. instead returning after the first error.
       allErrors: true,
       strict: false,
-      schemaId: 'id'
+      schemaId: 'id',
+      unknownFormats: ['int32', 'int64'],
+      nullable: true
     });
     ajv.addMetaSchema(draft4MetaSchema);
     validate = ajv.compile(schema);

--- a/lib/ajValidation/ajvValidatorDraft04.js
+++ b/lib/ajValidation/ajvValidatorDraft04.js
@@ -1,5 +1,5 @@
-const Ajv = require('ajv-06'),
-  draft4MetaSchema = require('ajv-06/lib/refs/json-schema-draft-04.json');
+const Ajv = require('../../assets/ajv6faker'),
+  draft4MetaSchema = require('../../assets/json-schema-draft-04.json');
 
 /**
  * Used to validate schema against a value.

--- a/lib/ajValidation/ajvValidatorDraft04.js
+++ b/lib/ajValidation/ajvValidatorDraft04.js
@@ -1,5 +1,5 @@
-const Ajv = require('ajv-draft-04'),
-  addFormats = require('ajv-formats');
+const Ajv = require('ajv-06'),
+  draft4MetaSchema = require('ajv-06/lib/refs/json-schema-draft-04.json');
 
 /**
  * Used to validate schema against a value.
@@ -20,9 +20,10 @@ function validateSchemaAJVDraft04 (schema, valueToUse) {
     ajv = new Ajv({
       // check all rules collecting all errors. instead returning after the first error.
       allErrors: true,
-      strict: false
+      strict: false,
+      schemaId: 'id'
     });
-    addFormats(ajv);
+    ajv.addMetaSchema(draft4MetaSchema);
     validate = ajv.compile(schema);
     validate(valueToUse);
   }
@@ -30,6 +31,19 @@ function validateSchemaAJVDraft04 (schema, valueToUse) {
     // something went wrong validating the schema
     // input was invalid. Don't throw mismatch
     return { filteredValidationError };
+  }
+
+  if (validate.errors && validate.errors.length > 0) {
+    let mapped = validate.errors.map(((error) => {
+      return {
+        instancePath: error.dataPath,
+        keyword: error.keyword,
+        message: error.message,
+        params: error.params,
+        schemaPath: error.schemaPath
+      };
+    }));
+    validate.errors = mapped;
   }
   return { filteredValidationError, validate };
 }

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -3190,7 +3190,7 @@ module.exports = {
 
                 mismatchObj = _.assign({
                   property: property,
-                  transactionJsonPath: jsonPathPrefix + ajvError.instancePath,
+                  transactionJsonPath: jsonPathPrefix + formatDataPath(ajvError.instancePath),
                   schemaJsonPath: schemaPathPrefix + '.' + localSchemaPath
                 }, ajvValidationError(ajvError, { property, humanPropName }));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -389,10 +389,23 @@
         "uri-js": "^4.2.2"
       }
     },
-    "ajv-draft-04": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="
+    "ajv-06": {
+      "version": "npm:ajv@6.12.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "dependencies": {
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        }
+      }
     },
     "ajv-formats": {
       "version": "2.1.1",
@@ -1197,8 +1210,7 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,4582 @@
 {
   "name": "openapi-to-postmanv2",
   "version": "2.12.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "openapi-to-postmanv2",
+      "version": "2.12.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "8.1.0",
+        "ajv-formats": "2.1.1",
+        "async": "3.2.1",
+        "commander": "2.20.3",
+        "js-yaml": "3.14.1",
+        "json-schema-merge-allof": "0.8.1",
+        "lodash": "4.17.21",
+        "oas-resolver-browser": "2.5.2",
+        "path-browserify": "1.0.1",
+        "postman-collection": "4.0.0",
+        "yaml": "1.10.2"
+      },
+      "bin": {
+        "openapi2postmanv2": "bin/openapi2postmanv2.js"
+      },
+      "devDependencies": {
+        "chai": "4.3.4",
+        "editorconfig": "0.15.3",
+        "eslint": "5.16.0",
+        "eslint-plugin-jsdoc": "3.8.0",
+        "eslint-plugin-mocha": "5.3.0",
+        "eslint-plugin-security": "1.4.0",
+        "expect.js": "0.3.1",
+        "mocha": "7.2.0",
+        "nyc": "15.1.0",
+        "parse-gitignore": "0.5.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.0.tgz",
+      "integrity": "sha512-vu9V3uMM/1o5Hl5OekMUowo3FqXLJSw+s+66nt0fSWVWTtmosdzn45JHOB3cPtZoe6CTBDzvSw0RdOY85Q37+Q==",
+      "dev": true
+    },
+    "node_modules/@babel/core": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.0.tgz",
+      "integrity": "sha512-8YqpRig5NmIHlMLw09zMlPTvUVMILjqCOtVgu+TVNWEBvy9b5I3RRyhqnrV4hjgEK7n8P9OqvkWJAFmEL6Wwfw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.14.0",
+        "@babel/helper-compilation-targets": "^7.13.16",
+        "@babel/helper-module-transforms": "^7.14.0",
+        "@babel/helpers": "^7.14.0",
+        "@babel/parser": "^7.14.0",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.14.0",
+        "@babel/types": "^7.14.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/code-frame": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/highlight": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+      "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.0",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/core/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.1.tgz",
+      "integrity": "sha512-TMGhsXMXCP/O1WtQmZjpEYDhCYC9vFhayWZPJSZCGkPJgUqX0rF0wwtrYvnzVxIjcF80tkUertXVk5cwqi5cAQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.14.1",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz",
+      "integrity": "sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.13.15",
+        "@babel/helper-validator-option": "^7.12.17",
+        "browserslist": "^4.14.5",
+        "semver": "^6.3.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-get-function-arity": "^7.12.13",
+        "@babel/template": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-get-function-arity": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+      "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.13.12"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+      "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.13.12"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.0.tgz",
+      "integrity": "sha512-L40t9bxIuGOfpIGA3HNkJhU9qYrf4y5A5LUSw7rGMSn+pcG8dfJ0g6Zval6YJGd2nEjI7oP00fRdnhLKndx6bw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.13.12",
+        "@babel/helper-replace-supers": "^7.13.12",
+        "@babel/helper-simple-access": "^7.13.12",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/helper-validator-identifier": "^7.14.0",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.14.0",
+        "@babel/types": "^7.14.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+      "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+      "integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.13.12",
+        "@babel/helper-optimise-call-expression": "^7.12.13",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.12"
+      }
+    },
+    "node_modules/@babel/helper-simple-access": {
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+      "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.13.12"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+      "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+      "dev": true
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+      "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+      "dev": true
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
+      "integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.14.0",
+        "@babel/types": "^7.14.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.1.tgz",
+      "integrity": "sha512-muUGEKu8E/ftMTPlNp+mc6zL3E9zKWmF5sDHZ5MSsoTP9Wyz64AhEf9kD08xYJ7w6Hdcu8H550ircnPyWSIF0Q==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+      "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/parser": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/code-frame": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/highlight": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+      "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.0",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.0.tgz",
+      "integrity": "sha512-dZ/a371EE5XNhTHomvtuLTUyx6UEoJmYX+DT5zBCQN3McHemsuIaKKYqsc/fs26BEkHs/lBZy0J571LP5z9kQA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.14.0",
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/parser": "^7.14.0",
+        "@babel/types": "^7.14.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/highlight": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+      "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.0",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.1.tgz",
+      "integrity": "sha512-S13Qe85fzLs3gYRUnrpyeIrBJIMYv33qSTg1qoBwiG6nPKwUWAD9odSzWhEedpwOIzSEI6gbdQIWEMiCI42iBA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.0",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.1.0.tgz",
+      "integrity": "sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+      "integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.5.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/append-transform": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+      "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
+      "dev": true,
+      "dependencies": {
+        "default-require-extensions": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
+      "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg=="
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "node_modules/browserslist": {
+      "version": "4.16.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+      "dev": true,
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001219",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.723",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.71"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/caching-transform": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+      "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+      "dev": true,
+      "dependencies": {
+        "hasha": "^5.0.0",
+        "make-dir": "^3.0.0",
+        "package-hash": "^4.0.0",
+        "write-file-atomic": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001228",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
+      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha1-tV5lWzHh6scJm+TAjCGWT84ubEk=",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "node_modules/charset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/charset/-/charset-1.0.1.tgz",
+      "integrity": "sha512-6dVyOOYjpfFcL1Y4qChrAoQLRHvj2ziyhcm0QJlhOcAhykL/k1kTUPbeo+87MNRTRdk2OIIsIXbuF3x2wi5EXg==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.2.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.1.1"
+      }
+    },
+    "node_modules/chokidar/node_modules/is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/colorette": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+      "dev": true
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/comment-parser": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.4.2.tgz",
+      "integrity": "sha1-+lo/eAEwcBFIZtx7jpzzF6ljX3Q=",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "^2.0.4"
+      }
+    },
+    "node_modules/comment-parser/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/comment-parser/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
+    "node_modules/compute-gcd": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
+      "integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
+      "dependencies": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
+    "node_modules/compute-lcm": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
+      "integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
+      "dependencies": {
+        "compute-gcd": "^1.2.1",
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "node_modules/default-require-extensions": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
+      "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
+      "dev": true,
+      "dependencies": {
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "dependencies": {
+        "object-keys": "^1.0.12"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/editorconfig": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.19.0",
+        "lru-cache": "^4.1.5",
+        "semver": "^5.6.0",
+        "sigmund": "^1.0.1"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true
+    },
+    "node_modules/editorconfig/node_modules/semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.3.727",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.727.tgz",
+      "integrity": "sha512-Mfz4FIB4FSvEwBpDfdipRIrwd6uo8gUDoRDF4QEYb4h4tSuI3ov594OrjU6on042UlFHouIJpClDODGkPcBSbg==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/es-abstract": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+      "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.2",
+        "is-callable": "^1.2.3",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.2",
+        "is-string": "^1.0.5",
+        "object-inspect": "^1.9.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-abstract/node_modules/object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
+      "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.9.1",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^4.0.3",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^5.0.1",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.2.2",
+        "js-yaml": "^3.13.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.11",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^6.14.0 || ^8.10.0 || >=9.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.8.0.tgz",
+      "integrity": "sha512-Fp5BwwQGCA6w/00+rp+6Dr/l2f8i1d8XsorT9qZZn+9UJQHqywPCxJ7nb5ZY50FqhDz8nY5gl/jPJ5j0elD1XQ==",
+      "dev": true,
+      "dependencies": {
+        "comment-parser": "^0.4.2",
+        "jsdoctypeparser": "^2.0.0-alpha-8",
+        "lodash": "^4.17.4"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.14.0"
+      }
+    },
+    "node_modules/eslint-plugin-mocha": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-5.3.0.tgz",
+      "integrity": "sha512-3uwlJVLijjEmBeNyH60nzqgA1gacUWLUmcKV8PIGNvj1kwP/CTgAWQHn2ayyJVwziX+KETkr9opNwT1qD/RZ5A==",
+      "dev": true,
+      "dependencies": {
+        "ramda": "^0.26.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">= 4.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-security": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-1.4.0.tgz",
+      "integrity": "sha512-xlS7P2PLMXeqfhyf3NpqbvbnW04kN8M9NtmhpR3XGyOvt/vNKS7XPXT5EDbwKW9vCjWH4PpfQvgD/+JgN0VJKA==",
+      "dev": true,
+      "dependencies": {
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/eslint/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/espree": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+      "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^6.0.7",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect.js": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz",
+      "integrity": "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s=",
+      "dev": true
+    },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/faker": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
+      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g=="
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
+    "node_modules/figures": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
+      "integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+      "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "dev": true,
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/flat": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
+      "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "~2.0.3"
+      },
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "dev": true
+    },
+    "node_modules/foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/foreground-child/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fromentries": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glob-parent/node_modules/is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
+    },
+    "node_modules/growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.x"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasha": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+      "dev": true,
+      "dependencies": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hasha/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/http-reasons": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/http-reasons/-/http-reasons-0.1.0.tgz",
+      "integrity": "sha1-qVPKZwB4Zp3eFCzomUAbnW6F07Q="
+    },
+    "node_modules/http2-client": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.3.tgz",
+      "integrity": "sha512-nUxLymWQ9pzkzTmir24p2RtsgruLmhje7lH3hLX1IpwvyTg77fW+1brenPPP3USAR+rQ36p5sTA/x7sjCJVkAA=="
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+      "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "node_modules/inquirer": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.1.tgz",
+      "integrity": "sha512-uxNHBeQhRXIoHWTSNYUFhQVrHYFThIt6IVo2fFmSe8aBwdR3/w6b58hJpiL/fMukFkvGzjg+hSxFtwvVmKZmXw==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "node_modules/inquirer/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+      "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+      "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+      "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+      "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "node_modules/is-regex": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+      "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+      "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-hook": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+      "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
+      "dev": true,
+      "dependencies": {
+        "append-transform": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.7.5",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.0.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
+      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "dev": true,
+      "dependencies": {
+        "archy": "^1.0.0",
+        "cross-spawn": "^7.0.0",
+        "istanbul-lib-coverage": "^3.0.0-alpha.1",
+        "make-dir": "^3.0.0",
+        "p-map": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "uuid": "^3.3.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdoctypeparser": {
+      "version": "2.0.0-alpha-8",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-2.0.0-alpha-8.tgz",
+      "integrity": "sha1-uvE3+44qVYgQrc8Z0tKi9oDpCl8=",
+      "dev": true
+    },
+    "node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/json-schema-compare": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
+      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+      "dependencies": {
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/json-schema-merge-allof": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.8.1.tgz",
+      "integrity": "sha1-7SgozdlYYW/3T5MoMKJikXieqvI=",
+      "dependencies": {
+        "compute-lcm": "^1.1.2",
+        "json-schema-compare": "^0.2.2",
+        "lodash": "^4.17.20"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5/node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/liquid-json": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/liquid-json/-/liquid-json-0.3.1.tgz",
+      "integrity": "sha1-kVWhgTbYprJhXl8W+aJEira1Duo=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw="
+    },
+    "node_modules/lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "node_modules/log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
+      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-format": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mime-format/-/mime-format-2.0.1.tgz",
+      "integrity": "sha512-XxU3ngPbEnrYnNbIX+lYSaYg0M01v6p2ntd2YaFksTu0vayaw5OJvbdRyWs07EYRlLED5qadUZ+xo+XhOvFhwg==",
+      "dependencies": {
+        "charset": "^1.0.0"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.31",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
+      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
+      "dependencies": {
+        "mime-db": "1.48.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
+      "integrity": "sha1-AcwiewDYdase7QOnUQZonP7VpgQ=",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.3.0",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "3.0.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.5",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.6",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
+        "yargs-unparser": "1.6.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/mocha/node_modules/cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/mocha/node_modules/debug": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/mocha/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mocha/node_modules/js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/mocha/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mocha/node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mocha/node_modules/ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mocha/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mocha/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mocha/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+      "integrity": "sha1-ds/nQs8fQbubHCmtAwaMBbTA5Ao=",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mocha/node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mocha/node_modules/yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      }
+    },
+    "node_modules/mocha/node_modules/yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha1-Ew8JcC667vJlDVTObj5XBvek+zg=",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node_modules/node-environment-flags": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
+      "dev": true,
+      "dependencies": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      }
+    },
+    "node_modules/node-environment-flags/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/node-fetch-h2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
+      "integrity": "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==",
+      "dependencies": {
+        "http2-client": "^1.2.5"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/node-preload": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+      "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+      "dev": true,
+      "dependencies": {
+        "process-on-spawn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "1.1.71",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
+      "dev": true
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nyc": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
+      "integrity": "sha1-EzXa4S3ch7biSdWhmUykva6nXwI=",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "caching-transform": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "decamelize": "^1.2.0",
+        "find-cache-dir": "^3.2.0",
+        "find-up": "^4.1.0",
+        "foreground-child": "^2.0.0",
+        "get-package-type": "^0.1.0",
+        "glob": "^7.1.6",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-hook": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.0",
+        "istanbul-lib-processinfo": "^2.0.2",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.2",
+        "make-dir": "^3.0.0",
+        "node-preload": "^0.2.1",
+        "p-map": "^3.0.0",
+        "process-on-spawn": "^1.0.0",
+        "resolve-from": "^5.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^2.0.0",
+        "test-exclude": "^6.0.0",
+        "yargs": "^15.0.2"
+      },
+      "bin": {
+        "nyc": "bin/nyc.js"
+      },
+      "engines": {
+        "node": ">=8.9"
+      }
+    },
+    "node_modules/nyc/node_modules/glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha1-Oxk+kjPwHULQs/eClLvutBj5SpA=",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/nyc/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/oas-kit-common": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
+      "integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
+      "dependencies": {
+        "fast-safe-stringify": "^2.0.7"
+      }
+    },
+    "node_modules/oas-resolver-browser": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/oas-resolver-browser/-/oas-resolver-browser-2.5.2.tgz",
+      "integrity": "sha512-L3ugWyBHOpKLT+lb+pFXCOpk3byh6usis5T9u9mfu92jH5bR6YK8MA2bebUTIjY7I4415PzDeZcmcc+i7X05MA==",
+      "dependencies": {
+        "node-fetch-h2": "^2.3.0",
+        "oas-kit-common": "^1.0.8",
+        "path-browserify": "^1.0.1",
+        "reftools": "^1.1.6",
+        "yaml": "^1.10.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "resolve": "resolve.js"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+      "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.getownpropertydescriptors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz",
+      "integrity": "sha512-WtxeKSzfBjlzL+F9b7M7hewDzMwy+C8NRssHd1YrNlzHzIDrXcXiNOMrezdAEM4UXixgV+vvnyBeN7Rygl2ttQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "dev": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-hash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+      "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.15",
+        "hasha": "^5.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "release-zalgo": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-gitignore": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-0.5.1.tgz",
+      "integrity": "sha512-Ls8RQQrYC0HqaIugZ0lwKl+dcIeuaV+8iQwrsQFNHCEnodTXaEAM2+RxQFFv2xDaJ1gM4C05eY4u6KzIHvNayQ==",
+      "dev": true,
+      "dependencies": {
+        "array-unique": "^0.3.2",
+        "is-glob": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+      "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/postman-collection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.0.0.tgz",
+      "integrity": "sha512-vDrXG/dclSu6RMqPqBz4ZqoQBwcj/a80sJYsQZmzWJ6dWgXiudPhwu6Vm3C1Hy7zX5W8A6am1Z6vb/TB4eyURA==",
+      "dependencies": {
+        "faker": "5.5.3",
+        "file-type": "3.9.0",
+        "http-reasons": "0.1.0",
+        "iconv-lite": "0.6.3",
+        "liquid-json": "0.3.1",
+        "lodash": "4.17.21",
+        "mime-format": "2.0.1",
+        "mime-types": "2.1.31",
+        "postman-url-encoder": "3.0.1",
+        "semver": "7.3.5",
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/postman-collection/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postman-collection/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/postman-url-encoder": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/postman-url-encoder/-/postman-url-encoder-3.0.1.tgz",
+      "integrity": "sha512-dMPqXnkDlstM2Eya+Gw4MIGWEan8TzldDcUKZIhZUsJ/G5JjubfQPhFhVWKzuATDMvwvrWbSjF+8VmAvbu6giw==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "node_modules/process-on-spawn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
+      "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
+      "dev": true,
+      "dependencies": {
+        "fromentries": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ramda": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
+      "dev": true
+    },
+    "node_modules/readdirp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/reftools": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.8.tgz",
+      "integrity": "sha1-zAj9Z+uRPXef0zBlfQEMwIDH1kM=",
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.5.0"
+      }
+    },
+    "node_modules/release-zalgo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "dev": true,
+      "dependencies": {
+        "es6-error": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "dependencies": {
+        "is-promise": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "dependencies": {
+        "ret": "~0.1.10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "node_modules/slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spawn-wrap": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "make-dir": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/spawn-wrap/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/spawn-wrap/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "node_modules/string-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
+      "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/table": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.5.tgz",
+      "integrity": "sha512-oGa2Hl7CQjfoaogtrOHEJroOcYILTx7BZWLGsJIlzoWmB2zmguhNfPJZsWPKYek/MgCxfco54gEi31d1uN2hFA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/table/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "node_modules/table/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/table/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/table/node_modules/lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
+    },
+    "node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+      "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00="
+    },
+    "node_modules/validate.io-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
+      "integrity": "sha1-NDoZgC7TsZaCaceA5VjpNBHAutc="
+    },
+    "node_modules/validate.io-integer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+      "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
+      "dependencies": {
+        "validate.io-number": "^1.0.3"
+      }
+    },
+    "node_modules/validate.io-integer-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
+      "integrity": "sha1-LKveAzKTpry+Bj/q/pHq9GsToIk=",
+      "dependencies": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-integer": "^1.0.4"
+      }
+    },
+    "node_modules/validate.io-number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg="
+    },
+    "node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "node_modules/wide-align/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/wide-align/node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "dependencies": {
+        "mkdirp": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
+    },
+    "node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha1-IwHF/78StGfejaIzOkWeKeeSDks=",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
+      "dependencies": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "node_modules/yargs-unparser/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  },
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.5.5",
@@ -366,7 +4940,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
       "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "aggregate-error": {
       "version": "3.1.0",
@@ -387,24 +4962,6 @@
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
-      }
-    },
-    "ajv-06": {
-      "version": "npm:ajv@6.12.5",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
-      "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "dependencies": {
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        }
       }
     },
     "ajv-formats": {
@@ -1210,7 +5767,8 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
   },
   "dependencies": {
     "ajv": "8.1.0",
-    "ajv-06": "npm:ajv@6.12.5",
     "ajv-formats": "2.1.1",
     "async": "3.2.1",
     "commander": "2.20.3",
@@ -139,15 +138,15 @@
     "eslint-plugin-mocha": "5.3.0",
     "eslint-plugin-security": "1.4.0",
     "expect.js": "0.3.1",
-    "nyc": "15.1.0",
     "mocha": "7.2.0",
+    "nyc": "15.1.0",
     "parse-gitignore": "0.5.1"
   },
   "scripts": {
     "test": "./scripts/test.sh",
-    "test-unit": "nyc --reporter=text ./node_modules/mocha/bin/mocha \"test/unit/**/**.test.js\"",
+    "test-unit": "nyc --reporter=text -x **/assets/** ./node_modules/mocha/bin/mocha \"test/unit/**/**.test.js\"",
     "test-lint": "./scripts/test-lint.sh",
-    "test-system": "./node_modules/mocha/bin/mocha \"test/system/**.test.js\"",
+    "test-system": "./node_modules/mocha/bin/mocha -x **/assets/** \"test/system/**.test.js\"",
     "test-regression": "./node_modules/mocha/bin/mocha test/integration/integration.test.js test/unit/sanity.test.js",
     "release": "./scripts/release.sh",
     "coverage": "nyc report --reporter=html --reporter=text mocha"

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
   },
   "dependencies": {
     "ajv": "8.1.0",
-    "ajv-draft-04": "1.0.0",
+    "ajv-06": "npm:ajv@6.12.5",
     "ajv-formats": "2.1.1",
     "async": "3.2.1",
     "commander": "2.20.3",

--- a/test/system/repository.test.js
+++ b/test/system/repository.test.js
@@ -80,8 +80,9 @@ describe('project repository', function () {
       // Unskip before merging
       it('must point to a valid and precise (no * or ^) semver', function () {
         json.dependencies && Object.keys(json.dependencies).forEach(function (item) {
-          expect(json.dependencies[item]).to.match(new RegExp('^((\\d+)\\.(\\d+)\\.(\\d+))(?:-' +
-                        '([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?(?:\\+([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?$'));
+          expect(json.dependencies[item]).to.match(new RegExp('(^((\\d+)\\.(\\d+)\\.(\\d+)|' +
+          '(^npm:[\\dA-Za-z\\-]+@(\\d+)\\.(\\d+)\\.(\\d+)))(?:-([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?' +
+                      '(?:\\+([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?)$'));
         });
       });
     });
@@ -93,8 +94,9 @@ describe('project repository', function () {
 
       it('must point to a valid and precise (no * or ^) semver', function () {
         json.devDependencies && Object.keys(json.devDependencies).forEach(function (item) {
-          expect(json.devDependencies[item]).to.match(new RegExp('^((\\d+)\\.(\\d+)\\.(\\d+))(?:-' +
-                        '([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?(?:\\+([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?$'));
+          expect(json.devDependencies[item]).to.match(new RegExp('(^((\\d+)\\.(\\d+)\\.(\\d+)|' +
+            '(^npm:[\\dA-Za-z\\-]+@(\\d+)\\.(\\d+)\\.(\\d+)))(?:-([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?' +
+                        '(?:\\+([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?)$'));
         });
       });
 

--- a/test/unit/schemaUtilsCommon.test.js
+++ b/test/unit/schemaUtilsCommon.test.js
@@ -16,6 +16,21 @@ describe('formatData method', function() {
       formattedDataPath = formatDataPath(instancePath);
     expect(formattedDataPath).to.be.equal(expectedDataPath);
   });
+
+  it('Should return the same string when input is a data path ".id" ', function() {
+    const inputAlreadyDataPath = '.id',
+      expectedDataPath = '.id',
+      formattedDataPath = formatDataPath(inputAlreadyDataPath);
+    expect(formattedDataPath).to.be.equal(expectedDataPath);
+  });
+
+  it('Should return the same string when input is a data path ".test[3]" ', function() {
+    const inputAlreadyDataPath = '.test[3]',
+      expectedDataPath = '.test[3]',
+      formattedDataPath = formatDataPath(inputAlreadyDataPath);
+    expect(formattedDataPath).to.be.equal(expectedDataPath);
+  });
+
 });
 
 describe('handleExclusiveMaximum method', function() {

--- a/test/unit/xajvValidation.test.js
+++ b/test/unit/xajvValidation.test.js
@@ -227,7 +227,7 @@ describe('validateSchema', function () {
         name: 'dolor consectetur Excepteur'
       },
       result = validateSchema(schema, valueToUse);
-    expect(result[0].instancePath).equal('/id');
+    expect(result[0].instancePath).equal('.id');
   });
 
   it('should return no errors correct schema value $schema pointing to draft 06', function () {


### PR DESCRIPTION
change AJV draft 4 to AJV 6 and validate using schema for 04
Changed the facade to AJV 4 validations using AJV 6 installed with alias and adding metaSchema for 04
This changed is aim to test if installing both versions independently instead of ajv-draft-04 will work after packaging the library

Update:

for solving building issues we are now trying to consume ajv6 as an asset