### PR TITLE
Adding descriptions as fallback in webhooks name, Avoid webhooks fold…

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -660,6 +660,10 @@ module.exports = {
       variableStore = {},
       webhooksVariables = [];
 
+    if (Object.keys(webhooksTree.root.children).length === 0) {
+      return;
+    }
+
     for (let child in webhooksTree.root.children) {
       if (
         webhooksTree.root.children.hasOwnProperty(child) &&
@@ -2232,10 +2236,10 @@ module.exports = {
       pmBody,
       authMeta,
       swagResponse,
-      localServers = _.get(operationItem, 'properties.servers'),
+      localServers = fromWebhooks ? '' : _.get(operationItem, 'properties.servers'),
       exampleRequestBody,
       sanitizeResult,
-      globalServers = _.get(operationItem, 'servers'),
+      globalServers = fromWebhooks ? '' : _.get(operationItem, 'servers'),
       responseMediaTypes,
       acceptHeader;
 
@@ -2341,7 +2345,7 @@ module.exports = {
         if (fromWebhooks) {
           reqName = utils.insertSpacesInName(operation.operationId) ||
             operation.summary ||
-            `${this.cleanWebhookName(operationItem.path)} - ${operationItem.method}`;
+            operation.description;
         }
         else {
           reqName = operation.summary || utils.insertSpacesInName(operation.operationId) || reqUrl;

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2345,7 +2345,8 @@ module.exports = {
         if (fromWebhooks) {
           reqName = utils.insertSpacesInName(operation.operationId) ||
             operation.summary ||
-            operation.description;
+            operation.description ||
+            `${this.cleanWebhookName(operationItem.path)} - ${operationItem.method}`;
         }
         else {
           reqName = operation.summary || utils.insertSpacesInName(operation.operationId) || reqUrl;

--- a/test/data/valid_openapi31X/webhooks/only-paths.yaml
+++ b/test/data/valid_openapi31X/webhooks/only-paths.yaml
@@ -1,0 +1,2334 @@
+openapi: 3.1.0
+info:
+  contact:
+    email: developer-experience@adyen.com
+    name: Adyen Developer Experience team
+    url: https://www.adyen.help/hc/en-us/community/topics
+    x-twitter: Adyen
+  description: |-
+    The Notification API sends notifications to the endpoints specified in a given subscription. Subscriptions are managed through the Notification Configuration API. The API specifications listed here detail the format of each notification.
+
+    For more information, refer to our [documentation](https://docs.adyen.com/platforms/notifications).
+  termsOfService: https://www.adyen.com/legal/terms-and-conditions
+  title: "Webhooks test - Two webhooks and paths"
+  version: "3"
+  x-apisguru-categories:
+    - payment
+  x-logo:
+    url: https://twitter.com/Adyen/profile_image?size=original
+  x-origin:
+    - converter:
+        url: https://github.com/mermade/oas-kit
+        version: 7.0.4
+      format: openapi
+      url: https://raw.githubusercontent.com/Adyen/adyen-openapi/master/json/MarketPayNotificationService-v3.json
+      version: "3.1"
+  x-preferred: false
+  x-providerName: adyen.com
+  x-publicVersion: true
+  x-serviceName: MarketPayNotificationService
+components:
+  examples:
+    WebhookAck:
+      summary: Acknowledge Webhook
+      value:
+        notificationResponse: "[accepted]"
+    post-ACCOUNT_CLOSED-accountClosed:
+      summary: ACCOUNT CLOSED example
+      value:
+        content:
+          invalidFields:
+            - errorCode: 1
+              errorDescription: Field is missing
+              fieldType:
+                field: AccountHolderDetails.BusinessDetails.Shareholders.unknown
+                fieldName: unknown
+                shareholderCode: SH00001
+          pspReference: TSTPSPR0001
+          resultCode: Success
+          status: Closed
+        error:
+          errorCode: "000"
+          message: test error message
+        eventDate: 2019-01-01T01:00:00+01:00
+        eventType: ACCOUNT_CLOSED
+        executingUserKey: executing-user-key
+        live: false
+        pspReference: TSTPSPR0001
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: '#/components/schemas/Pet'
+    Error:
+      required:
+        - code
+        - mesage
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+    AccountCloseNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/CloseAccountResponse"
+          description: The details of the Account update.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    AccountCreateNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/CreateAccountResponse"
+          description: The details of the account creation.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    AccountEvent:
+      properties:
+        event:
+          description: |-
+            The event.
+            >Permitted values: `InactivateAccount`, `RefundNotPaidOutTransfers`.
+            For more information, refer to [Verification checks](https://docs.adyen.com/platforms/verification-checks).
+          enum:
+            - InactivateAccount
+            - RefundNotPaidOutTransfers
+          type: string
+        executionDate:
+          description: The date on which the event will take place.
+          format: date-time
+          type: string
+        reason:
+          description: The reason why this event has been created.
+          type: string
+      required:
+        - event
+        - executionDate
+        - reason
+    AccountFundsBelowThresholdNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/AccountFundsBelowThresholdNotificationContent"
+          description: Details of the liable account with funds under threshold.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+    AccountFundsBelowThresholdNotificationContent:
+      properties:
+        accountCode:
+          description: The code of the account with funds under threshold
+          type: string
+        balanceDate:
+          $ref: "#/components/schemas/LocalDate"
+          description: The date of the funds were found to be below threshold.
+        currentFunds:
+          $ref: "#/components/schemas/Amount"
+          description: The current funds in the liable account.
+        fundThreshold:
+          $ref: "#/components/schemas/Amount"
+          description: The configured fund threshold for the liable account
+        merchantAccountCode:
+          description: The code of the merchant account.
+          type: string
+      required:
+        - accountCode
+        - merchantAccountCode
+        - fundThreshold
+    AccountHolderCreateNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/CreateAccountHolderResponse"
+          description: The details of the account holder creation.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    AccountHolderDetails:
+      properties:
+        address:
+          $ref: "#/components/schemas/ViasAddress"
+          description: The address of the account holder.
+        bankAccountDetails:
+          description: Array of bank accounts associated with the account holder. For details about the required `BankAccountDetail` fields, refer to [Bank account check](https://docs.adyen.com/platforms/verification-checks/bank-account-check).
+          items:
+            $ref: "#/components/schemas/BankAccountDetail"
+          type: array
+        businessDetails:
+          $ref: "#/components/schemas/BusinessDetails"
+          description: |-
+            Details about the business or nonprofit account holder.
+            Required when creating an account holder with `legalEntity` **Business** or **NonProfit**.
+        email:
+          description: The email address of the account holder.
+          type: string
+        fullPhoneNumber:
+          description: |-
+            The phone number of the account holder provided as a single string. It will be handled as a landline phone.
+            **Examples:** "0031 6 11 22 33 44", "+316/1122-3344", "(0031) 611223344"
+          type: string
+        individualDetails:
+          $ref: "#/components/schemas/IndividualDetails"
+          description: |
+            Details about the individual account holder.
+            Required when creating an account holder with `legalEntity` **Individual**.
+        merchantCategoryCode:
+          description: |-
+            The Merchant Category Code of the account holder.
+            > If not specified in the request, this will be derived from the platform account (which is configured by Adyen).
+          type: string
+        metadata:
+          additionalProperties:
+            type: string
+          description: |-
+            A set of key and value pairs for general use by the account holder or merchant.
+            The keys do not have specific names and may be used for storing miscellaneous data as desired.
+            > The values being stored have a maximum length of eighty (80) characters and will be truncated if necessary.
+            > Note that during an update of metadata, the omission of existing key-value pairs will result in the deletion of those key-value pairs.
+          type: object
+        principalBusinessAddress:
+          $ref: "#/components/schemas/ViasAddress"
+          description: The principal business address of the account holder.
+        webAddress:
+          description: The URL of the website of the account holder.
+          type: string
+      required:
+        - fullPhoneNumber
+        - email
+        - webAddress
+    AccountHolderPayoutNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/AccountHolderPayoutNotificationContent"
+          description: Details of the payout to the Account Holder.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    AccountHolderPayoutNotificationContent:
+      properties:
+        accountCode:
+          description: The code of the account from which the payout was made.
+          type: string
+        accountHolderCode:
+          description: The code of the Account Holder to which the payout was made.
+          type: string
+        amount:
+          $ref: "#/components/schemas/Amount"
+          description: The payout amount.
+        amounts:
+          description: The payout amounts (per currency).
+          items:
+            $ref: "#/components/schemas/Amount"
+          type: array
+        bankAccountDetail:
+          $ref: "#/components/schemas/BankAccountDetail"
+          description: Details of the Bank Account to which the payout was made.
+        description:
+          description: A description of the payout.
+          type: string
+        merchantReference:
+          description: The merchant reference.
+          type: string
+          x-addedInVersion: "2"
+        status:
+          $ref: "#/components/schemas/OperationStatus"
+          description: The payout status.
+      required:
+        - accountHolderCode
+        - accountCode
+    AccountHolderStatus:
+      properties:
+        events:
+          description: A list of events scheduled for the account holder.
+          items:
+            $ref: "#/components/schemas/AccountEvent"
+          type: array
+        payoutState:
+          $ref: "#/components/schemas/AccountPayoutState"
+          description: The payout state of the account holder.
+        processingState:
+          $ref: "#/components/schemas/AccountProcessingState"
+          description: The processing state of the account holder.
+        status:
+          description: |-
+            The status of the account holder.
+            >Permitted values: `Active`, `Inactive`, `Suspended`, `Closed`.
+          enum:
+            - Active
+            - Closed
+            - Inactive
+            - Suspended
+          type: string
+        statusReason:
+          description: The reason why the status was assigned to the account holder.
+          type: string
+      required:
+        - status
+    AccountHolderStatusChangeNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/AccountHolderStatusChangeNotificationContent"
+          description: The details of the Account Holder status change.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+    AccountHolderStatusChangeNotificationContent:
+      properties:
+        accountHolderCode:
+          description: The code of the account holder.
+          type: string
+        newStatus:
+          $ref: "#/components/schemas/AccountHolderStatus"
+          description: The new status of the account holder.
+          x-addedInVersion: "2"
+        oldStatus:
+          $ref: "#/components/schemas/AccountHolderStatus"
+          description: The former status of the account holder.
+          x-addedInVersion: "2"
+        reason:
+          description: The reason for the status change.
+          type: string
+      required:
+        - accountHolderCode
+        - oldStatus
+        - newStatus
+    AccountHolderStoreStatusChangeNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/AccountHolderStoreStatusChangeNotificationContent"
+          description: The details of the Account Holder Store status change.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+    AccountHolderStoreStatusChangeNotificationContent: {}
+    AccountHolderUpcomingDeadlineNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/AccountHolderUpcomingDeadlineNotificationContent"
+          description: The details of the upcoming event.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+    AccountHolderUpcomingDeadlineNotificationContent:
+      properties:
+        accountHolderCode:
+          description: The code of the account holder whom the event refers to.
+          type: string
+        event:
+          description: The event name that will be trigger if no action is taken.
+          enum:
+            - AccessPii
+            - ApiTierUpdate
+            - CloseAccount
+            - CloseStores
+            - DeleteBankAccounts
+            - DeletePayoutMethods
+            - DeleteShareholders
+            - DeleteSignatories
+            - InactivateAccount
+            - KYCDeadlineExtension
+            - RecalculateAccountStatusAndProcessingTier
+            - RefundNotPaidOutTransfers
+            - ResolveEvents
+            - SaveAccountHolder
+            - SaveCriminalityAndPEPChecks
+            - SaveKYCCheckStatus
+            - SuspendAccount
+            - UnSuspendAccount
+            - UpdateAccountHolderState
+            - Verification
+          type: string
+        executionDate:
+          description: The execution date scheduled for the event.
+          format: date-time
+          type: string
+        reason:
+          description: The reason that leads to scheduling of the event.
+          type: string
+    AccountHolderUpdateNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/UpdateAccountHolderResponse"
+          description: The details of the Account Holder update.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    AccountHolderVerificationNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/AccountHolderVerificationNotificationContent"
+          description: The details of the Account Holder verification.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    AccountHolderVerificationNotificationContent:
+      properties:
+        accountHolderCode:
+          description: The code of the account holder.
+          type: string
+        bankAccountUUID:
+          description: The unique ID of the bank account that has been verified.
+          type: string
+        shareholderCode:
+          description: The code of the shareholder that has been verified.
+          type: string
+        signatoryCode:
+          description: The code of the signatory that has been verified.
+          type: string
+        statusSummaryItems:
+          deprecated: true
+          description: A summary of the verification status.
+          items:
+            $ref: "#/components/schemas/KYCCheckDataSummaryItem"
+          type: array
+        verificationStatus:
+          description: The status of verification.
+          enum:
+            - AWAITING_DATA
+            - DATA_PROVIDED
+            - FAILED
+            - INVALID_DATA
+            - PASSED
+            - PENDING
+            - PENDING_REVIEW
+            - RETRY_LIMIT_REACHED
+            - UNCHECKED
+          type: string
+        verificationType:
+          description: The type of validation performed.
+          enum:
+            - BANK_ACCOUNT_VERIFICATION
+            - CARD_VERIFICATION
+            - COMPANY_VERIFICATION
+            - IDENTITY_VERIFICATION
+            - LEGAL_ARRANGEMENT_VERIFICATION
+            - NONPROFIT_VERIFICATION
+            - PASSPORT_VERIFICATION
+            - PAYOUT_METHOD_VERIFICATION
+            - PCI_VERIFICATION
+          type: string
+      required:
+        - accountHolderCode
+    AccountPayoutState:
+      properties:
+        allowPayout:
+          description: Indicates whether payouts are allowed. This field is the overarching payout status, and is the aggregate of multiple conditions (e.g., KYC status, disabled flag, etc). If this field is false, no payouts will be permitted for any of the account holder's accounts. If this field is true, payouts will be permitted for any of the account holder's accounts.
+          type: boolean
+        disableReason:
+          description: The reason why payouts (to all of the account holder's accounts) have been disabled (by the platform). If the `disabled` field is true, this field can be used to explain why.
+          type: string
+        disabled:
+          description: Indicates whether payouts have been disabled (by the platform) for all of the account holder's accounts. A platform may enable and disable this field at their discretion. If this field is true, `allowPayout` will be false and no payouts will be permitted for any of the account holder's accounts. If this field is false, `allowPayout` may or may not be enabled, depending on other factors.
+          type: boolean
+        payoutLimit:
+          $ref: "#/components/schemas/Amount"
+          description: The maximum amount that payouts are limited to. Only applies if payouts are allowed but limited.
+        tierNumber:
+          description: The payout tier that the account holder occupies.
+          format: int32
+          type: integer
+          x-addedInVersion: "3"
+    AccountProcessingState:
+      properties:
+        disableReason:
+          description: The reason why processing has been disabled.
+          type: string
+        disabled:
+          description: Indicates whether the processing of payments is allowed.
+          type: boolean
+        processedFrom:
+          $ref: "#/components/schemas/Amount"
+          description: The lower bound of the processing tier (i.e., an account holder must have processed at least this amount of money in order to be placed into this tier).
+        processedTo:
+          $ref: "#/components/schemas/Amount"
+          description: The upper bound of the processing tier (i.e., an account holder must have processed less than this amount of money in order to be placed into this tier).
+        tierNumber:
+          description: The processing tier that the account holder occupies.
+          format: int32
+          type: integer
+          x-addedInVersion: "3"
+    AccountUpdateNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/UpdateAccountResponse"
+          description: The details of the Account update.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    Amount:
+      properties:
+        currency:
+          description: The three-character [ISO currency code](https://docs.adyen.com/development-resources/currency-codes).
+          maxLength: 3
+          minLength: 3
+          type: string
+        value:
+          description: The amount of the transaction, in [minor units](https://docs.adyen.com/development-resources/currency-codes).
+          format: int64
+          type: integer
+      required:
+        - value
+        - currency
+    BankAccountDetail:
+      properties:
+        accountNumber:
+          description: |-
+            The bank account number (without separators).
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        accountType:
+          description: |-
+            The type of bank account.
+            Only applicable to bank accounts held in the USA.
+            The permitted values are: `checking`, `savings`.
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        bankAccountName:
+          description: The name of the bank account.
+          type: string
+        bankAccountUUID:
+          description: |
+            The unique identifier (UUID) of the Bank Account.
+            >If, during an account holder create or update request, this field is left blank (but other fields provided), a new Bank Account will be created with a procedurally-generated UUID.
+
+            >If, during an account holder create request, a UUID is provided, the creation of the Bank Account will fail while the creation of the account holder will continue.
+
+            >If, during an account holder update request, a UUID that is not correlated with an existing Bank Account is provided, the update of the account holder will fail.
+
+            >If, during an account holder update request, a UUID that is correlated with an existing Bank Account is provided, the existing Bank Account will be updated.
+          type: string
+        bankBicSwift:
+          description: |-
+            The bank identifier code.
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        bankCity:
+          description: |-
+            The city in which the bank branch is located.
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        bankCode:
+          description: |-
+            The bank code of the banking institution with which the bank account is registered.
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        bankName:
+          description: |-
+            The name of the banking institution with which the bank account is held.
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        branchCode:
+          description: |-
+            The branch code of the branch under which the bank account is registered. The value to be specified in this parameter depends on the country of the bank account:
+            * United States - Routing number
+            * United Kingdom - Sort code
+            * Germany - Bankleitzahl
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        checkCode:
+          description: |-
+            The check code of the bank account.
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        countryCode:
+          description: |-
+            The two-letter country code in which the bank account is registered.
+            >The permitted country codes are defined in ISO-3166-1 alpha-2 (e.g. 'NL').
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        currencyCode:
+          description: |-
+            The currency in which the bank account deals.
+            >The permitted currency codes are defined in ISO-4217 (e.g. 'EUR').
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        iban:
+          description: |-
+            The international bank account number.
+            >The IBAN standard is defined in ISO-13616.
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        ownerCity:
+          description: |-
+            The city of residence of the bank account owner.
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        ownerCountryCode:
+          description: |-
+            The country code of the country of residence of the bank account owner.
+            >The permitted country codes are defined in ISO-3166-1 alpha-2 (e.g. 'NL').
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        ownerDateOfBirth:
+          description: |
+            The date of birth of the bank account owner.
+          type: string
+        ownerHouseNumberOrName:
+          description: |-
+            The house name or number of the residence of the bank account owner.
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        ownerName:
+          description: |-
+            The name of the bank account owner.
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        ownerNationality:
+          description: |-
+            The country code of the country of nationality of the bank account owner.
+            >The permitted country codes are defined in ISO-3166-1 alpha-2 (e.g. 'NL').
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        ownerPostalCode:
+          description: |-
+            The postal code of the residence of the bank account owner.
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        ownerState:
+          description: |-
+            The state of residence of the bank account owner.
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        ownerStreet:
+          description: |-
+            The street name of the residence of the bank account owner.
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        primaryAccount:
+          description: If set to true, the bank account is a primary account.
+          type: boolean
+        taxId:
+          description: |-
+            The tax ID number.
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        urlForVerification:
+          description: |-
+            The URL to be used for bank account verification.
+            This may be generated on bank account creation.
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+    BeneficiarySetupNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/BeneficiarySetupNotificationContent"
+          description: Details of the beneficiary setup.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    BeneficiarySetupNotificationContent:
+      properties:
+        destinationAccountCode:
+          description: The code of the beneficiary account.
+          type: string
+        destinationAccountHolderCode:
+          description: The code of the beneficiary Account Holder.
+          type: string
+        merchantReference:
+          description: The reference provided by the merchant.
+          type: string
+        sourceAccountCode:
+          description: The code of the benefactor account.
+          type: string
+        sourceAccountHolderCode:
+          description: The code of the benefactor Account Holder.
+          type: string
+        transferDate:
+          description: The date on which the beneficiary was set up and funds transferred from benefactor to beneficiary.
+          format: date-time
+          type: string
+        transferredTransactionCount:
+          description: The number of transactions transferred upon the setup of the beneficiary.
+          format: int32
+          type: integer
+      required:
+        - sourceAccountHolderCode
+        - sourceAccountCode
+        - destinationAccountHolderCode
+        - destinationAccountCode
+        - transferDate
+        - transferredTransactionCount
+    BusinessDetails:
+      properties:
+        doingBusinessAs:
+          description: The registered name of the company (if it differs from the legal name of the company).
+          type: string
+        legalBusinessName:
+          description: The legal name of the company.
+          type: string
+        listedUltimateParentCompany:
+          description: Information about the parent public company. Required if the account holder is 100% owned by a publicly listed company.
+          items:
+            $ref: "#/components/schemas/UltimateParentCompany"
+          type: array
+        shareholders:
+          description: Array containing information about individuals associated with the account holder either through ownership or control. For details about how you can identify them, refer to [Identity check](https://docs.adyen.com/platforms/verification-checks/identity-check).
+          items:
+            $ref: "#/components/schemas/ShareholderContact"
+          type: array
+        signatories:
+          description: |-
+            Signatories associated with the company.
+            Each array entry should represent one signatory.
+          items:
+            $ref: "#/components/schemas/SignatoryContact"
+          type: array
+        taxId:
+          description: The tax ID of the company.
+          type: string
+    CloseAccountResponse:
+      properties:
+        pspReference:
+          description: The reference of a request. Can be used to uniquely identify the request.
+          type: string
+        resultCode:
+          description: The result code.
+          type: string
+        status:
+          description: |-
+            The new status of the account.
+            >Permitted values: `Active`, `Inactive`, `Suspended`, `Closed`.
+          enum:
+            - Active
+            - Closed
+            - Inactive
+            - Suspended
+          type: string
+          x-addedInVersion: "2"
+        submittedAsync:
+          description: |-
+            Indicates whether the request is processed asynchronously. Depending on the request's platform settings, the following scenarios may be applied:
+            * **true**: The request is queued and will be executed when the providing service is available in the order in which the requests are received.
+            * **false**: The processing of the request is immediately attempted; it may result in an error if the providing service is unavailable.
+          type: boolean
+      required:
+        - status
+    CompensateNegativeBalanceNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/CompensateNegativeBalanceNotificationContent"
+          description: Details of the negative balance compensation.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+    CompensateNegativeBalanceNotificationContent:
+      properties:
+        records:
+          description: A list of the negative balances compensated.
+          items:
+            $ref: "#/components/schemas/CompensateNegativeBalanceNotificationRecord"
+          type: array
+      required:
+        - records
+    CompensateNegativeBalanceNotificationRecord:
+      properties:
+        accountCode:
+          description: The code of the account whose negative balance has been compensated.
+          type: string
+        amount:
+          $ref: "#/components/schemas/Amount"
+          description: The amount compensated.
+        transferDate:
+          description: The date on which the compensation took place.
+          format: date-time
+          type: string
+      required:
+        - accountCode
+        - transferDate
+        - amount
+    CreateAccountHolderResponse:
+      properties:
+        accountCode:
+          description: The code of a new account created for the account holder.
+          type: string
+        accountHolderCode:
+          description: The code of the new account holder.
+          type: string
+        accountHolderDetails:
+          $ref: "#/components/schemas/AccountHolderDetails"
+          description: Details of the new account holder.
+        accountHolderStatus:
+          $ref: "#/components/schemas/AccountHolderStatus"
+          description: The status of the new account holder.
+          x-addedInVersion: "2"
+        invalidFields:
+          description: A list of fields that caused the `/createAccountHolder` request to fail.
+          items:
+            $ref: "#/components/schemas/ErrorFieldType"
+          type: array
+          x-addedInVersion: "5"
+        pspReference:
+          description: The reference of a request. Can be used to uniquely identify the request.
+          type: string
+        resultCode:
+          description: The result code.
+          type: string
+        submittedAsync:
+          description: |-
+            Indicates whether the request is processed asynchronously. Depending on the request's platform settings, the following scenarios may be applied:
+            * **true**: The request is queued and will be executed when the providing service is available in the order in which the requests are received.
+            * **false**: The processing of the request is immediately attempted; it may result in an error if the providing service is unavailable.
+          type: boolean
+        verification:
+          $ref: "#/components/schemas/KYCVerificationResult2"
+          description: The details of KYC Verification of the account holder.
+          x-addedInVersion: "2"
+      required:
+        - accountHolderCode
+        - accountHolderStatus
+        - accountHolderDetails
+        - verification
+    CreateAccountResponse:
+      properties:
+        accountCode:
+          description: The code of the new account.
+          type: string
+        accountHolderCode:
+          description: The code of the account holder.
+          type: string
+        payoutSchedule:
+          $ref: "#/components/schemas/PayoutScheduleResponse"
+          description: The payout schedule of the account.
+        pspReference:
+          description: The reference of a request. Can be used to uniquely identify the request.
+          type: string
+        resultCode:
+          description: The result code.
+          type: string
+        status:
+          description: |-
+            The status of the account.
+            >Permitted values: `Active`.
+          enum:
+            - Active
+            - Closed
+            - Inactive
+            - Suspended
+          type: string
+          x-addedInVersion: "2"
+        submittedAsync:
+          description: |-
+            Indicates whether the request is processed asynchronously. Depending on the request's platform settings, the following scenarios may be applied:
+            * **true**: The request is queued and will be executed when the providing service is available in the order in which the requests are received.
+            * **false**: The processing of the request is immediately attempted; it may result in an error if the providing service is unavailable.
+          type: boolean
+      required:
+        - accountHolderCode
+        - accountCode
+        - status
+    DirectDebitInitiatedNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/DirectDebitInitiatedNotificationContent"
+          description: Details of the direct debit.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+    DirectDebitInitiatedNotificationContent:
+      properties:
+        accountCode:
+          description: The code of the account.
+          type: string
+        amount:
+          $ref: "#/components/schemas/Amount"
+          description: The amount to be debited from the funding account.
+        debitInitiationDate:
+          $ref: "#/components/schemas/LocalDate"
+          description: The date of the debit initiation.
+        invalidFields:
+          description: Invalid fields list.
+          items:
+            $ref: "#/components/schemas/ErrorFieldType"
+          type: array
+        merchantAccountCode:
+          description: The code of the merchant account.
+          type: string
+        splits:
+          description: The split data for the debit request
+          items:
+            $ref: "#/components/schemas/Split"
+          type: array
+        status:
+          $ref: "#/components/schemas/OperationStatus"
+          description: Direct debit status.
+      required:
+        - amount
+        - accountCode
+        - merchantAccountCode
+    ErrorFieldType:
+      properties:
+        errorCode:
+          description: The validation error code.
+          format: int32
+          type: integer
+        errorDescription:
+          description: A description of the validation error.
+          type: string
+        fieldType:
+          $ref: "#/components/schemas/FieldType"
+          description: The type of error field.
+    FieldType:
+      properties:
+        field:
+          description: The full name of the property.
+          type: string
+        fieldName:
+          description: The type of the field.
+          enum:
+            - accountCode
+            - accountHolderCode
+            - accountHolderDetails
+            - accountNumber
+            - accountStateType
+            - accountStatus
+            - accountType
+            - address
+            - bankAccount
+            - bankAccountCode
+            - bankAccountName
+            - bankAccountUUID
+            - bankBicSwift
+            - bankCity
+            - bankCode
+            - bankName
+            - bankStatement
+            - branchCode
+            - businessContact
+            - cardToken
+            - checkCode
+            - city
+            - companyRegistration
+            - constitutionalDocument
+            - country
+            - countryCode
+            - currency
+            - currencyCode
+            - dateOfBirth
+            - destinationAccountCode
+            - document
+            - documentExpirationDate
+            - documentIssuerCountry
+            - documentIssuerState
+            - documentName
+            - documentNumber
+            - documentType
+            - doingBusinessAs
+            - drivingLicence
+            - drivingLicenceBack
+            - drivingLicense
+            - email
+            - firstName
+            - formType
+            - fullPhoneNumber
+            - gender
+            - hopWebserviceUser
+            - houseNumberOrName
+            - iban
+            - idCard
+            - idNumber
+            - identityDocument
+            - individualDetails
+            - jobTitle
+            - lastName
+            - legalArrangement
+            - legalArrangementCode
+            - legalArrangementEntity
+            - legalArrangementEntityCode
+            - legalArrangementLegalForm
+            - legalArrangementMember
+            - legalArrangementMembers
+            - legalArrangementName
+            - legalArrangementReference
+            - legalArrangementRegistrationNumber
+            - legalArrangementTaxNumber
+            - legalArrangementType
+            - legalBusinessName
+            - legalEntity
+            - legalEntityType
+            - merchantAccount
+            - merchantCategoryCode
+            - merchantReference
+            - microDeposit
+            - name
+            - nationality
+            - originalReference
+            - ownerCity
+            - ownerCountryCode
+            - ownerHouseNumberOrName
+            - ownerName
+            - ownerPostalCode
+            - ownerState
+            - ownerStreet
+            - passport
+            - passportNumber
+            - payoutMethodCode
+            - payoutSchedule
+            - pciSelfAssessment
+            - personalData
+            - phoneCountryCode
+            - phoneNumber
+            - postalCode
+            - primaryCurrency
+            - reason
+            - returnUrl
+            - schedule
+            - shareholder
+            - shareholderCode
+            - shareholderCodeAndSignatoryCode
+            - shareholderCodeOrSignatoryCode
+            - shareholderType
+            - shopperInteraction
+            - signatory
+            - signatoryCode
+            - socialSecurityNumber
+            - sourceAccountCode
+            - splitAccount
+            - splitConfigurationUUID
+            - splitCurrency
+            - splitValue
+            - splits
+            - stateOrProvince
+            - status
+            - stockExchange
+            - stockNumber
+            - stockTicker
+            - store
+            - storeDetail
+            - storeName
+            - storeReference
+            - street
+            - taxId
+            - tier
+            - tierNumber
+            - transferCode
+            - ultimateParentCompany
+            - ultimateParentCompanyAddressDetails
+            - ultimateParentCompanyAddressDetailsCountry
+            - ultimateParentCompanyBusinessDetails
+            - ultimateParentCompanyBusinessDetailsLegalBusinessName
+            - ultimateParentCompanyBusinessDetailsRegistrationNumber
+            - ultimateParentCompanyCode
+            - ultimateParentCompanyStockExchange
+            - ultimateParentCompanyStockNumber
+            - ultimateParentCompanyStockNumberOrStockTicker
+            - ultimateParentCompanyStockTicker
+            - unknown
+            - value
+            - verificationType
+            - virtualAccount
+            - visaNumber
+            - webAddress
+            - year
+          type: string
+        shareholderCode:
+          description: The code of the shareholder that the field belongs to. If empty, the field belongs to an account holder.
+          type: string
+    IndividualDetails:
+      properties:
+        name:
+          $ref: "#/components/schemas/ViasName"
+          description: |-
+            The name of the individual.
+            >Make sure your account holder registers using the name shown on their Photo ID.
+        personalData:
+          $ref: "#/components/schemas/ViasPersonalData"
+          description: Personal information of the individual.
+    KYCBankAccountCheckResult:
+      properties:
+        bankAccountUUID:
+          description: The unique ID of the bank account to which the check applies.
+          type: string
+        checks:
+          description: A list of the checks and their statuses.
+          items:
+            $ref: "#/components/schemas/KYCCheckStatusData"
+          type: array
+    KYCCheckDataSummaryItem:
+      properties:
+        itemCode:
+          description: The code of the item reviewed.
+          format: int32
+          type: integer
+        itemDescription:
+          description: A description of the item reviewed.
+          type: string
+    KYCCheckResult2:
+      properties:
+        checks:
+          description: A list of the checks and their statuses.
+          items:
+            $ref: "#/components/schemas/KYCCheckStatusData"
+          type: array
+    KYCCheckStatusData:
+      properties:
+        requiredFields:
+          description: A list of the fields required for execution of the check.
+          items:
+            type: string
+          type: array
+        status:
+          description: |-
+            The status of the check.
+
+            Possible values: **AWAITING_DATA** , **DATA_PROVIDED**, **FAILED**, **INVALID_DATA**, **PASSED**, **PENDING**, **RETRY_LIMIT_REACHED**.
+          enum:
+            - AWAITING_DATA
+            - DATA_PROVIDED
+            - FAILED
+            - INVALID_DATA
+            - PASSED
+            - PENDING
+            - PENDING_REVIEW
+            - RETRY_LIMIT_REACHED
+            - UNCHECKED
+          type: string
+        summary:
+          $ref: "#/components/schemas/KYCCheckSummary"
+          description: A summary of the execution of the check.
+        type:
+          description: |-
+            The type of check.
+
+            Possible values:
+
+             * **BANK_ACCOUNT_VERIFICATION**: Used in v5 and earlier. Replaced by **PAYOUT_METHOD_VERIFICATION** in v6 and later.
+
+             * **COMPANY_VERIFICATION**
+
+              * **CARD_VERIFICATION**
+
+            * **IDENTITY_VERIFICATION**
+
+            * **LEGAL_ARRANGEMENT_VERIFICATION**
+
+            * **NONPROFIT_VERIFICATION**
+
+             * **PASSPORT_VERIFICATION**
+
+            * **PAYOUT_METHOD_VERIFICATION**: Used in v6 and later.
+
+            * **PCI_VERIFICATION**
+          enum:
+            - BANK_ACCOUNT_VERIFICATION
+            - CARD_VERIFICATION
+            - COMPANY_VERIFICATION
+            - IDENTITY_VERIFICATION
+            - LEGAL_ARRANGEMENT_VERIFICATION
+            - NONPROFIT_VERIFICATION
+            - PASSPORT_VERIFICATION
+            - PAYOUT_METHOD_VERIFICATION
+            - PCI_VERIFICATION
+          type: string
+      required:
+        - type
+        - status
+    KYCCheckSummary:
+      properties:
+        code:
+          description: The code of the check.
+          format: int32
+          type: integer
+        description:
+          description: A description of the check.
+          type: string
+      required:
+        - code
+    KYCShareholderCheckResult:
+      properties:
+        checks:
+          description: A list of the checks and their statuses.
+          items:
+            $ref: "#/components/schemas/KYCCheckStatusData"
+          type: array
+        shareholderCode:
+          description: The code of the shareholder to which the check applies.
+          type: string
+    KYCSignatoryCheckResult:
+      properties:
+        checks:
+          description: A list of the checks and their statuses.
+          items:
+            $ref: "#/components/schemas/KYCCheckStatusData"
+          type: array
+        signatoryCode:
+          description: The code of the signatory to which the check applies.
+          type: string
+    KYCVerificationResult2:
+      properties:
+        accountHolder:
+          $ref: "#/components/schemas/KYCCheckResult2"
+          description: The results of the checks on the account holder.
+        bankAccounts:
+          description: The results of the checks on the bank accounts.
+          items:
+            $ref: "#/components/schemas/KYCBankAccountCheckResult"
+          type: array
+        shareholders:
+          description: The results of the checks on the shareholders.
+          items:
+            $ref: "#/components/schemas/KYCShareholderCheckResult"
+          type: array
+        signatories:
+          description: The results of the checks on the signatories.
+          items:
+            $ref: "#/components/schemas/KYCSignatoryCheckResult"
+          type: array
+    LocalDate:
+      properties:
+        month:
+          format: int32
+          type: integer
+        year:
+          format: int32
+          type: integer
+    Message:
+      properties:
+        code:
+          description: The message code.
+          type: string
+        text:
+          description: The message text.
+          type: string
+    NotificationResponse:
+      properties:
+        notificationResponse:
+          description: Set this parameter to **[accepted]** to acknowledge that you received a notification from Adyen.
+          type: string
+    OperationStatus:
+      properties:
+        message:
+          $ref: "#/components/schemas/Message"
+          description: The message regarding the operation status.
+        statusCode:
+          description: The status code.
+          type: string
+    PaymentFailureNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/PaymentFailureNotificationContent"
+          description: The details of the payment failure.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    PaymentFailureNotificationContent:
+      properties:
+        errorFields:
+          description: Missing or invalid fields that caused the payment error.
+          items:
+            $ref: "#/components/schemas/ErrorFieldType"
+          type: array
+        errorMessage:
+          $ref: "#/components/schemas/Message"
+          description: The error message.
+        modificationMerchantReference:
+          description: The `reference` of the capture or refund.
+          type: string
+        modificationPspReference:
+          description: The `pspReference` of the capture or refund.
+          type: string
+        paymentMerchantReference:
+          description: The `reference` of the payment.
+          type: string
+        paymentPspReference:
+          description: The `pspReference` of the payment.
+          type: string
+      required:
+        - errorMessage
+        - errorFields
+    PayoutScheduleResponse:
+      properties:
+        nextScheduledPayout:
+          description: The date of the next scheduled payout.
+          format: date-time
+          type: string
+        schedule:
+          description: |-
+            The payout schedule of the account.
+            >Permitted values: `DEFAULT`, `HOLD`, `DAILY`, `WEEKLY`, `MONTHLY`.
+          enum:
+            - BIWEEKLY_ON_1ST_AND_15TH_AT_MIDNIGHT
+            - BIWEEKLY_ON_1ST_AND_15TH_AT_NOON
+            - BI_DAILY_AU
+            - BI_DAILY_EU
+            - BI_DAILY_US
+            - DAILY
+            - DAILY_6PM
+            - DAILY_AU
+            - DAILY_EU
+            - DAILY_SG
+            - DAILY_US
+            - DEFAULT
+            - EVERY_6_HOURS_FROM_MIDNIGHT
+            - HOLD
+            - MONTHLY
+            - MONTHLY_ON_15TH_AT_MIDNIGHT
+            - WEEKLY
+            - WEEKLY_MON_TO_FRI_AU
+            - WEEKLY_MON_TO_FRI_EU
+            - WEEKLY_MON_TO_FRI_US
+            - WEEKLY_ON_TUE_FRI_MIDNIGHT
+            - YEARLY
+          type: string
+      required:
+        - schedule
+    PersonalDocumentData:
+      properties:
+        expirationDate:
+          description: |-
+            The expiry date of the document, 
+             in ISO-8601 YYYY-MM-DD format. For example, **2000-01-31**.
+          type: string
+        issuerCountry:
+          description: |-
+            The country where the document was issued, in the two-character 
+            [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) format. For example, **NL**.
+          maxLength: 2
+          minLength: 2
+          type: string
+        issuerState:
+          description: The state where the document was issued (if applicable).
+          type: string
+        number:
+          description: The number in the document.
+          type: string
+        type:
+          description: |-
+            The type of the document. Possible values: **ID**, **DRIVINGLICENSE**, **PASSPORT**, **SOCIALSECURITY**, **VISA**.
+
+            To delete an existing entry for a document `type`, send only the `type` field in your request. 
+          enum:
+            - DRIVINGLICENSE
+            - ID
+            - PASSPORT
+            - SOCIALSECURITY
+            - VISA
+          type: string
+      required:
+        - type
+    RefundFundsTransferNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/RefundFundsTransferNotificationContent"
+          description: Details of the fund transfer refund.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    RefundFundsTransferNotificationContent:
+      properties:
+        amount:
+          $ref: "#/components/schemas/Amount"
+          description: The amount to be refunded.
+        merchantReference:
+          description: A value that can be supplied at the discretion of the executing user in order to link multiple transactions to one another.
+          type: string
+        originalReference:
+          description: A PSP reference of the original fund transfer.
+          type: string
+        status:
+          $ref: "#/components/schemas/OperationStatus"
+          description: The status of the fund transfer refund.
+      required:
+        - originalReference
+        - amount
+    RefundResult:
+      properties:
+        originalTransaction:
+          $ref: "#/components/schemas/Transaction"
+          description: The transaction that has been refunded.
+        pspReference:
+          description: The reference of the refund.
+          type: string
+        response:
+          description: The response indicating if the refund has been received for processing.
+          type: string
+      required:
+        - pspReference
+        - originalTransaction
+    ReportAvailableNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/ReportAvailableNotificationContent"
+          description: Details of the report.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    ReportAvailableNotificationContent:
+      properties:
+        accountCode:
+          description: The code of the Account to which the report applies.
+          type: string
+        accountType:
+          description: The type of Account to which the report applies.
+          type: string
+        eventDate:
+          description: The date of the event to which the report applies.
+          format: date-time
+          type: string
+        remoteAccessUrl:
+          description: The URL at which the report can be accessed.
+          type: string
+        success:
+          description: Indicates whether the event resulted in a success.
+          type: boolean
+    ScheduledRefundsNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/ScheduledRefundsNotificationContent"
+          description: Details of the scheduling of the refunds.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    ScheduledRefundsNotificationContent:
+      properties:
+        accountCode:
+          description: The code of the account.
+          type: string
+        accountHolderCode:
+          description: The code of the Account Holder.
+          type: string
+        lastPayout:
+          $ref: "#/components/schemas/Transaction"
+          description: The most recent payout (after which all transactions were scheduled to be refunded).
+        refundResults:
+          description: A list of the refunds that have been scheduled and their results.
+          items:
+            $ref: "#/components/schemas/RefundResult"
+          type: array
+      required:
+        - accountHolderCode
+        - accountCode
+        - refundResults
+    ShareholderContact:
+      properties:
+        address:
+          $ref: "#/components/schemas/ViasAddress"
+          description: The address of the person.
+        email:
+          description: The e-mail address of the person.
+          type: string
+        fullPhoneNumber:
+          description: |-
+            The phone number of the person provided as a single string.  It will be handled as a landline phone.
+            Examples: "0031 6 11 22 33 44", "+316/1122-3344", "(0031) 611223344"
+          type: string
+        jobTitle:
+          description: |-
+            Job title of the person. Required when the `shareholderType` is **Controller**.
+
+            Example values: **Chief Executive Officer**, **Chief Financial Officer**, **Chief Operating Officer**, **President**, **Vice President**, **Executive President**, **Managing Member**, **Partner**, **Treasurer**, **Director**, or **Other**.
+          type: string
+        name:
+          $ref: "#/components/schemas/ViasName"
+          description: The name of the person.
+        personalData:
+          $ref: "#/components/schemas/ViasPersonalData"
+          description: Contains information about the person.
+        phoneNumber:
+          $ref: "#/components/schemas/ViasPhoneNumber"
+          description: The phone number of the person.
+        shareholderCode:
+          description: |
+            The unique identifier (UUID) of the shareholder entry.
+            >**If, during an Account Holder create or update request, this field is left blank (but other fields provided), a new Shareholder will be created with a procedurally-generated UUID.**
+
+            >**If, during an Account Holder create request, a UUID is provided, the creation of the Shareholder will fail while the creation of the Account Holder will continue.**
+
+            >**If, during an Account Holder update request, a UUID that is not correlated with an existing Shareholder is provided, the update of the Shareholder will fail.**
+
+            >**If, during an Account Holder update request, a UUID that is correlated with an existing Shareholder is provided, the existing Shareholder will be updated.**
+          type: string
+        shareholderType:
+          description: |-
+            Specifies how the person is associated with the account holder. 
+
+            Possible values: 
+
+            * **Owner**: Individuals who directly or indirectly own 25% or more of a company.
+
+            * **Controller**: Individuals who are members of senior management staff responsible for managing a company or organization.
+          enum:
+            - Controller
+            - Owner
+            - Signatory
+          type: string
+        webAddress:
+          description: The URL of the person's website.
+          type: string
+    SignatoryContact:
+      properties:
+        address:
+          $ref: "#/components/schemas/ViasAddress"
+          description: The address of the person.
+        email:
+          description: The e-mail address of the person.
+          type: string
+        fullPhoneNumber:
+          description: |-
+            The phone number of the person provided as a single string.  It will be handled as a landline phone.
+            Examples: "0031 6 11 22 33 44", "+316/1122-3344", "(0031) 611223344"
+          type: string
+        jobTitle:
+          description: |-
+            Job title of the signatory.
+
+            Example values: **Chief Executive Officer**, **Chief Financial Officer**, **Chief Operating Officer**, **President**, **Vice President**, **Executive President**, **Managing Member**, **Partner**, **Treasurer**, **Director**, or **Other**.
+          type: string
+        name:
+          $ref: "#/components/schemas/ViasName"
+          description: The name of the person.
+        personalData:
+          $ref: "#/components/schemas/ViasPersonalData"
+          description: Contains information about the person.
+        phoneNumber:
+          $ref: "#/components/schemas/ViasPhoneNumber"
+          description: The phone number of the person.
+        signatoryCode:
+          description: |
+            The unique identifier (UUID) of the signatory.
+            >**If, during an Account Holder create or update request, this field is left blank (but other fields provided), a new Signatory will be created with a procedurally-generated UUID.**
+
+            >**If, during an Account Holder create request, a UUID is provided, the creation of the Signatory will fail while the creation of the Account Holder will continue.**
+
+            >**If, during an Account Holder update request, a UUID that is not correlated with an existing Signatory is provided, the update of the Signatory will fail.**
+
+            >**If, during an Account Holder update request, a UUID that is correlated with an existing Signatory is provided, the existing Signatory will be updated.**
+          type: string
+        signatoryReference:
+          description: Your reference for the signatory.
+          type: string
+        webAddress:
+          description: The URL of the person's website.
+          type: string
+    Split:
+      properties:
+        account:
+          description: |+
+            Unique identifier of the account where the split amount should be sent. This is required if `type` is **MarketPlace** or **BalanceAccount**.
+
+          type: string
+        amount:
+          $ref: "#/components/schemas/SplitAmount"
+          description: The amount of this split.
+        description:
+          description: A description of this split.
+          type: string
+        reference:
+          description: |-
+            Your reference for the split, which you can use to link the split to other operations such as captures and refunds.
+
+            This is required if `type` is **MarketPlace** or **BalanceAccount**. For the other types, we also recommend sending a reference so you can reconcile the split and the associated payment in the transaction overview and in the reports. If the reference is not provided, the split is reported as part of the aggregated [TransferBalance record type](https://docs.adyen.com/reporting/marketpay-payments-accounting-report) in Adyen for Platforms.
+          type: string
+        type:
+          description: |-
+            The type of split.
+            Possible values: **Default**, **PaymentFee**, **VAT**, **Commission**, **MarketPlace**, **BalanceAccount**.
+          enum:
+            - BalanceAccount
+            - Commission
+            - Default
+            - MarketPlace
+            - PaymentFee
+            - VAT
+            - Verification
+          type: string
+      required:
+        - amount
+        - type
+    SplitAmount:
+      properties:
+        currency:
+          description: |-
+            The three-character [ISO currency code](https://docs.adyen.com/development-resources/currency-codes).
+
+            If this value is not provided, the currency in which the payment is made will be used.
+          maxLength: 3
+          minLength: 3
+          type: string
+        value:
+          description: The amount in [minor units](https://docs.adyen.com/development-resources/currency-codes).
+          format: int64
+          type: integer
+      required:
+        - value
+    Transaction:
+      properties:
+        amount:
+          $ref: "#/components/schemas/Amount"
+          description: The amount of the transaction.
+        bankAccountDetail:
+          $ref: "#/components/schemas/BankAccountDetail"
+          description: The details of the bank account to where a payout was made.
+        captureMerchantReference:
+          description: The merchant reference of a related capture.
+          type: string
+        capturePspReference:
+          description: The psp reference of a related capture.
+          type: string
+        creationDate:
+          description: The date on which the transaction was performed.
+          format: date-time
+          type: string
+        description:
+          description: A description of the transaction.
+          type: string
+        destinationAccountCode:
+          description: The code of the account to which funds were credited during an outgoing fund transfer.
+          type: string
+        disputePspReference:
+          description: The psp reference of the related dispute.
+          type: string
+        disputeReasonCode:
+          description: The reason code of a dispute.
+          type: string
+        merchantReference:
+          description: The merchant reference of a transaction.
+          type: string
+        paymentPspReference:
+          description: The psp reference of the related authorisation or transfer.
+          type: string
+          x-addedInVersion: "3"
+        payoutPspReference:
+          description: The psp reference of the related payout.
+          type: string
+          x-addedInVersion: "3"
+        pspReference:
+          description: The psp reference of a transaction.
+          type: string
+        sourceAccountCode:
+          description: The code of the account from which funds were debited during an incoming fund transfer.
+          type: string
+        transactionStatus:
+          description: |-
+            The status of the transaction.
+            >Permitted values: `PendingCredit`, `CreditFailed`, `CreditClosed`, `CreditSuspended`, `Credited`, `Converted`, `PendingDebit`, `DebitFailed`, `Debited`, `DebitReversedReceived`, `DebitedReversed`, `ChargebackReceived`, `Chargeback`, `ChargebackReversedReceived`, `ChargebackReversed`, `Payout`, `PayoutReversed`, `FundTransfer`, `PendingFundTransfer`, `ManualCorrected`.
+          enum:
+            - BalanceNotPaidOutTransfer
+            - Chargeback
+            - ChargebackCorrection
+            - ChargebackCorrectionReceived
+            - ChargebackReceived
+            - ChargebackReversed
+            - ChargebackReversedCorrection
+            - ChargebackReversedCorrectionReceived
+            - ChargebackReversedReceived
+            - Converted
+            - CreditClosed
+            - CreditFailed
+            - CreditReversed
+            - CreditReversedReceived
+            - CreditSuspended
+            - Credited
+            - DebitFailed
+            - DebitReversedReceived
+            - Debited
+            - DebitedReversed
+            - DepositCorrectionCredited
+            - DepositCorrectionDebited
+            - Fee
+            - FundTransfer
+            - FundTransferReversed
+            - InvoiceDeductionCredited
+            - InvoiceDeductionDebited
+            - ManualCorrected
+            - ManualCorrectionCredited
+            - ManualCorrectionDebited
+            - MerchantPayin
+            - MerchantPayinReversed
+            - Payout
+            - PayoutReversed
+            - PendingCredit
+            - PendingDebit
+            - PendingFundTransfer
+            - SecondChargeback
+            - SecondChargebackCorrection
+            - SecondChargebackCorrectionReceived
+            - SecondChargebackReceived
+          type: string
+        transferCode:
+          description: The transfer code of the transaction.
+          type: string
+    TransferFundsNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/TransferFundsNotificationContent"
+          description: Details of the fund transfer.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    TransferFundsNotificationContent:
+      properties:
+        amount:
+          $ref: "#/components/schemas/Amount"
+          description: The amount transferred.
+        destinationAccountCode:
+          description: The code of the Account to which funds were credited.
+          type: string
+        merchantReference:
+          description: The reference provided by the merchant.
+          type: string
+          x-addedInVersion: "2"
+        sourceAccountCode:
+          description: The code of the Account from which funds were debited.
+          type: string
+        status:
+          $ref: "#/components/schemas/OperationStatus"
+          description: The status of the fund transfer.
+        transferCode:
+          description: The transfer code.
+          type: string
+      required:
+        - sourceAccountCode
+        - destinationAccountCode
+        - amount
+        - transferCode
+    UltimateParentCompany:
+      properties:
+        address:
+          $ref: "#/components/schemas/ViasAddress"
+          description: Address of the ultimate parent company.
+        businessDetails:
+          $ref: "#/components/schemas/UltimateParentCompanyBusinessDetails"
+          description: Details about the ultimate parent company's business.
+        ultimateParentCompanyCode:
+          description: Adyen-generated unique alphanumeric identifier (UUID) for the entry, returned in the response when you create an ultimate parent company. Required when updating an existing entry in an `/updateAccountHolder` request.
+          type: string
+    UltimateParentCompanyBusinessDetails:
+      properties:
+        legalBusinessName:
+          description: The legal name of the company.
+          type: string
+        registrationNumber:
+          description: The registration number of the company.
+          type: string
+        stockExchange:
+          description: Market Identifier Code (MIC).
+          type: string
+        stockNumber:
+          description: International Securities Identification Number (ISIN).
+          type: string
+        stockTicker:
+          description: Stock Ticker symbol.
+          type: string
+    UpdateAccountHolderResponse:
+      properties:
+        accountHolderCode:
+          description: The code of the account holder.
+          type: string
+        accountHolderDetails:
+          $ref: "#/components/schemas/AccountHolderDetails"
+          description: Details of the account holder.
+        accountHolderStatus:
+          $ref: "#/components/schemas/AccountHolderStatus"
+          description: The new status of the account holder.
+          x-addedInVersion: "2"
+        invalidFields:
+          description: in case the account holder has not been updated, contains account holder fields, that did not pass the validation.
+          items:
+            $ref: "#/components/schemas/ErrorFieldType"
+          type: array
+          x-addedInVersion: "5"
+        pspReference:
+          description: The reference of a request. Can be used to uniquely identify the request.
+          type: string
+        resultCode:
+          description: The result code.
+          type: string
+        submittedAsync:
+          description: |-
+            Indicates whether the request is processed asynchronously. Depending on the request's platform settings, the following scenarios may be applied:
+            * **true**: The request is queued and will be executed when the providing service is available in the order in which the requests are received.
+            * **false**: The processing of the request is immediately attempted; it may result in an error if the providing service is unavailable.
+          type: boolean
+        updatedFields:
+          description: A list of the fields updated through the request.
+          items:
+            $ref: "#/components/schemas/FieldType"
+          type: array
+        verification:
+          $ref: "#/components/schemas/KYCVerificationResult2"
+          description: The details of KYC Verification of the account holder.
+          x-addedInVersion: "2"
+      required:
+        - accountHolderStatus
+        - verification
+    UpdateAccountResponse:
+      properties:
+        accountCode:
+          description: The code of the account.
+          type: string
+        payoutSchedule:
+          $ref: "#/components/schemas/PayoutScheduleResponse"
+          description: The payout schedule of the account.
+        pspReference:
+          description: The reference of a request. Can be used to uniquely identify the request.
+          type: string
+        resultCode:
+          description: The result code.
+          type: string
+        submittedAsync:
+          description: |-
+            Indicates whether the request is processed asynchronously. Depending on the request's platform settings, the following scenarios may be applied:
+            * **true**: The request is queued and will be executed when the providing service is available in the order in which the requests are received.
+            * **false**: The processing of the request is immediately attempted; it may result in an error if the providing service is unavailable.
+          type: boolean
+      required:
+        - accountCode
+    ViasAddress:
+      properties:
+        city:
+          description: The name of the city. Required if the `houseNumberOrName`, `street`, `postalCode`, or `stateOrProvince` are provided.
+          type: string
+        country:
+          description: The two-character country code of the address in ISO-3166-1 alpha-2 format. For example, **NL**.
+          type: string
+        houseNumberOrName:
+          description: The number or name of the house.
+          type: string
+        postalCode:
+          description: |-
+            The postal code. Required if the `houseNumberOrName`, `street`, `city`, or `stateOrProvince` are provided.
+
+            Maximum length:
+
+            * 5 digits for addresses in the US.
+
+            * 10 characters for all other countries.
+          type: string
+        stateOrProvince:
+          description: |
+            The abbreviation of the state or province. Required if the `houseNumberOrName`, `street`, `city`, or `postalCode` are provided. 
+
+            Maximum length:
+
+            * 2 characters for addresses in the US or Canada.
+
+            * 3 characters for all other countries.
+          type: string
+        street:
+          description: The name of the street. Required if the `houseNumberOrName`, `city`, `postalCode`, or `stateOrProvince` are provided.
+          type: string
+      required:
+        - country
+    ViasName:
+      properties:
+        firstName:
+          description: The first name.
+          type: string
+        gender:
+          description: |-
+            The gender.
+            >The following values are permitted: `MALE`, `FEMALE`, `UNKNOWN`.
+          enum:
+            - MALE
+            - FEMALE
+            - UNKNOWN
+          maxLength: 1
+          type: string
+        infix:
+          description: |-
+            The name's infix, if applicable.
+            >A maximum length of twenty (20) characters is imposed.
+          type: string
+        lastName:
+          description: The last name.
+          type: string
+      required:
+        - firstName
+        - lastName
+    ViasPersonalData:
+      properties:
+        dateOfBirth:
+          description: The person's date of birth, in ISO-8601 YYYY-MM-DD format. For example, **2000-01-31**.
+          type: string
+        documentData:
+          description: Array that contains information about the person's identification document. You can submit only one entry per document type.
+          items:
+            $ref: "#/components/schemas/PersonalDocumentData"
+          type: array
+          x-addedInVersion: "3"
+        idNumber:
+          deprecated: true
+          description: An ID number of the person.
+          type: string
+          x-deprecatedInVersion: "3"
+          x-deprecatedMessage: Use `individualDetails.personalData.documentData.number` instead.
+        nationality:
+          description: |
+            The nationality of the person represented by a two-character country code,  in [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) format. For example, **NL**.
+          maxLength: 2
+          minLength: 2
+          type: string
+    ViasPhoneNumber:
+      properties:
+        phoneCountryCode:
+          description: |-
+            The two-character country code of the phone number.
+            >The permitted country codes are defined in ISO-3166-1 alpha-2 (e.g. 'NL').
+          type: string
+        phoneNumber:
+          description: |-
+            The phone number.
+            >The inclusion of the phone number country code is not necessary.
+          type: string
+        phoneType:
+          description: |-
+            The type of the phone number.
+            >The following values are permitted: `Landline`, `Mobile`, `SIP`, `Fax`.
+          enum:
+            - Fax
+            - Landline
+            - Mobile
+            - SIP
+          type: string
+      required:
+        - phoneCountryCode
+        - phoneNumber
+  securitySchemes:
+    ApiKeyAuth:
+      in: header
+      name: X-API-Key
+      type: apiKey
+    BasicAuth:
+      scheme: basic
+      type: http
+x-groups:
+  - Account holders
+  - Accounts
+  - Fund management
+  - Other
+x-staticResponse: response.json
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      description: ''
+      operationId: listPets
+      tags:
+        - pet
+      parameters:
+        - name: limit
+          in: header
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - name: variable
+          in: query
+          description: random variable
+          style: form
+          schema:
+            type: array
+            items:
+              type: string
+        - name: variable2
+          in: query
+          description: another random variable
+          style: spaceDelimited
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int64
+      responses:
+        '200':
+          description: An paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pets'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pet
+      responses:
+        '201':
+          description: Null response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pets'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    parameters:
+      - name: petId
+        in: path
+        description: The id of the pet to retrieve
+        required: true
+        schema:
+          type: string
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pet
+      parameters:
+        - name: petId
+          in: path
+          description: The id of the pet to retrieve
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{petId}/uploadImage:
+    post:
+      summary: Uploads an image
+      description: ''
+      operationId: uploadFile
+      tags:
+        - pet
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to update
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          application/octet-stream: {}
+      responses:
+        '201':
+          description: Null response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pets'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'

--- a/test/data/valid_openapi31X/webhooks/payments-webhook-with-servers-in-webhook.yaml
+++ b/test/data/valid_openapi31X/webhooks/payments-webhook-with-servers-in-webhook.yaml
@@ -1,0 +1,2655 @@
+openapi: 3.1.0
+info:
+  contact:
+    email: developer-experience@adyen.com
+    name: Adyen Developer Experience team
+    url: https://www.adyen.help/hc/en-us/community/topics
+    x-twitter: Adyen
+  description: |-
+    The Notification API sends notifications to the endpoints specified in a given subscription. Subscriptions are managed through the Notification Configuration API. The API specifications listed here detail the format of each notification.
+
+    For more information, refer to our [documentation](https://docs.adyen.com/platforms/notifications).
+  termsOfService: https://www.adyen.com/legal/terms-and-conditions
+  title: "Webhooks test - Only webhooks"
+  version: "3"
+  x-apisguru-categories:
+    - payment
+  x-logo:
+    url: https://twitter.com/Adyen/profile_image?size=original
+  x-origin:
+    - converter:
+        url: https://github.com/mermade/oas-kit
+        version: 7.0.4
+      format: openapi
+      url: https://raw.githubusercontent.com/Adyen/adyen-openapi/master/json/MarketPayNotificationService-v3.json
+      version: "3.1"
+  x-preferred: false
+  x-providerName: adyen.com
+  x-publicVersion: true
+  x-serviceName: MarketPayNotificationService
+components:
+  examples:
+    WebhookAck:
+      summary: Acknowledge Webhook
+      value:
+        notificationResponse: "[accepted]"
+    post-ACCOUNT_CLOSED-accountClosed:
+      summary: ACCOUNT CLOSED example
+      value:
+        content:
+          invalidFields:
+            - errorCode: 1
+              errorDescription: Field is missing
+              fieldType:
+                field: AccountHolderDetails.BusinessDetails.Shareholders.unknown
+                fieldName: unknown
+                shareholderCode: SH00001
+          pspReference: TSTPSPR0001
+          resultCode: Success
+          status: Closed
+        error:
+          errorCode: "000"
+          message: test error message
+        eventDate: 2019-01-01T01:00:00+01:00
+        eventType: ACCOUNT_CLOSED
+        executingUserKey: executing-user-key
+        live: false
+        pspReference: TSTPSPR0001
+  schemas:
+    AccountCloseNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/CloseAccountResponse"
+          description: The details of the Account update.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    AccountCreateNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/CreateAccountResponse"
+          description: The details of the account creation.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    AccountEvent:
+      properties:
+        event:
+          description: |-
+            The event.
+            >Permitted values: `InactivateAccount`, `RefundNotPaidOutTransfers`.
+            For more information, refer to [Verification checks](https://docs.adyen.com/platforms/verification-checks).
+          enum:
+            - InactivateAccount
+            - RefundNotPaidOutTransfers
+          type: string
+        executionDate:
+          description: The date on which the event will take place.
+          format: date-time
+          type: string
+        reason:
+          description: The reason why this event has been created.
+          type: string
+      required:
+        - event
+        - executionDate
+        - reason
+    AccountFundsBelowThresholdNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/AccountFundsBelowThresholdNotificationContent"
+          description: Details of the liable account with funds under threshold.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+    AccountFundsBelowThresholdNotificationContent:
+      properties:
+        accountCode:
+          description: The code of the account with funds under threshold
+          type: string
+        balanceDate:
+          $ref: "#/components/schemas/LocalDate"
+          description: The date of the funds were found to be below threshold.
+        currentFunds:
+          $ref: "#/components/schemas/Amount"
+          description: The current funds in the liable account.
+        fundThreshold:
+          $ref: "#/components/schemas/Amount"
+          description: The configured fund threshold for the liable account
+        merchantAccountCode:
+          description: The code of the merchant account.
+          type: string
+      required:
+        - accountCode
+        - merchantAccountCode
+        - fundThreshold
+    AccountHolderCreateNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/CreateAccountHolderResponse"
+          description: The details of the account holder creation.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    AccountHolderDetails:
+      properties:
+        address:
+          $ref: "#/components/schemas/ViasAddress"
+          description: The address of the account holder.
+        bankAccountDetails:
+          description: Array of bank accounts associated with the account holder. For details about the required `BankAccountDetail` fields, refer to [Bank account check](https://docs.adyen.com/platforms/verification-checks/bank-account-check).
+          items:
+            $ref: "#/components/schemas/BankAccountDetail"
+          type: array
+        businessDetails:
+          $ref: "#/components/schemas/BusinessDetails"
+          description: |-
+            Details about the business or nonprofit account holder.
+            Required when creating an account holder with `legalEntity` **Business** or **NonProfit**.
+        email:
+          description: The email address of the account holder.
+          type: string
+        fullPhoneNumber:
+          description: |-
+            The phone number of the account holder provided as a single string. It will be handled as a landline phone.
+            **Examples:** "0031 6 11 22 33 44", "+316/1122-3344", "(0031) 611223344"
+          type: string
+        individualDetails:
+          $ref: "#/components/schemas/IndividualDetails"
+          description: |
+            Details about the individual account holder.
+            Required when creating an account holder with `legalEntity` **Individual**.
+        merchantCategoryCode:
+          description: |-
+            The Merchant Category Code of the account holder.
+            > If not specified in the request, this will be derived from the platform account (which is configured by Adyen).
+          type: string
+        metadata:
+          additionalProperties:
+            type: string
+          description: |-
+            A set of key and value pairs for general use by the account holder or merchant.
+            The keys do not have specific names and may be used for storing miscellaneous data as desired.
+            > The values being stored have a maximum length of eighty (80) characters and will be truncated if necessary.
+            > Note that during an update of metadata, the omission of existing key-value pairs will result in the deletion of those key-value pairs.
+          type: object
+        principalBusinessAddress:
+          $ref: "#/components/schemas/ViasAddress"
+          description: The principal business address of the account holder.
+        webAddress:
+          description: The URL of the website of the account holder.
+          type: string
+      required:
+        - fullPhoneNumber
+        - email
+        - webAddress
+    AccountHolderPayoutNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/AccountHolderPayoutNotificationContent"
+          description: Details of the payout to the Account Holder.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    AccountHolderPayoutNotificationContent:
+      properties:
+        accountCode:
+          description: The code of the account from which the payout was made.
+          type: string
+        accountHolderCode:
+          description: The code of the Account Holder to which the payout was made.
+          type: string
+        amount:
+          $ref: "#/components/schemas/Amount"
+          description: The payout amount.
+        amounts:
+          description: The payout amounts (per currency).
+          items:
+            $ref: "#/components/schemas/Amount"
+          type: array
+        bankAccountDetail:
+          $ref: "#/components/schemas/BankAccountDetail"
+          description: Details of the Bank Account to which the payout was made.
+        description:
+          description: A description of the payout.
+          type: string
+        merchantReference:
+          description: The merchant reference.
+          type: string
+          x-addedInVersion: "2"
+        status:
+          $ref: "#/components/schemas/OperationStatus"
+          description: The payout status.
+      required:
+        - accountHolderCode
+        - accountCode
+    AccountHolderStatus:
+      properties:
+        events:
+          description: A list of events scheduled for the account holder.
+          items:
+            $ref: "#/components/schemas/AccountEvent"
+          type: array
+        payoutState:
+          $ref: "#/components/schemas/AccountPayoutState"
+          description: The payout state of the account holder.
+        processingState:
+          $ref: "#/components/schemas/AccountProcessingState"
+          description: The processing state of the account holder.
+        status:
+          description: |-
+            The status of the account holder.
+            >Permitted values: `Active`, `Inactive`, `Suspended`, `Closed`.
+          enum:
+            - Active
+            - Closed
+            - Inactive
+            - Suspended
+          type: string
+        statusReason:
+          description: The reason why the status was assigned to the account holder.
+          type: string
+      required:
+        - status
+    AccountHolderStatusChangeNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/AccountHolderStatusChangeNotificationContent"
+          description: The details of the Account Holder status change.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+    AccountHolderStatusChangeNotificationContent:
+      properties:
+        accountHolderCode:
+          description: The code of the account holder.
+          type: string
+        newStatus:
+          $ref: "#/components/schemas/AccountHolderStatus"
+          description: The new status of the account holder.
+          x-addedInVersion: "2"
+        oldStatus:
+          $ref: "#/components/schemas/AccountHolderStatus"
+          description: The former status of the account holder.
+          x-addedInVersion: "2"
+        reason:
+          description: The reason for the status change.
+          type: string
+      required:
+        - accountHolderCode
+        - oldStatus
+        - newStatus
+    AccountHolderStoreStatusChangeNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/AccountHolderStoreStatusChangeNotificationContent"
+          description: The details of the Account Holder Store status change.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+    AccountHolderStoreStatusChangeNotificationContent: {}
+    AccountHolderUpcomingDeadlineNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/AccountHolderUpcomingDeadlineNotificationContent"
+          description: The details of the upcoming event.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+    AccountHolderUpcomingDeadlineNotificationContent:
+      properties:
+        accountHolderCode:
+          description: The code of the account holder whom the event refers to.
+          type: string
+        event:
+          description: The event name that will be trigger if no action is taken.
+          enum:
+            - AccessPii
+            - ApiTierUpdate
+            - CloseAccount
+            - CloseStores
+            - DeleteBankAccounts
+            - DeletePayoutMethods
+            - DeleteShareholders
+            - DeleteSignatories
+            - InactivateAccount
+            - KYCDeadlineExtension
+            - RecalculateAccountStatusAndProcessingTier
+            - RefundNotPaidOutTransfers
+            - ResolveEvents
+            - SaveAccountHolder
+            - SaveCriminalityAndPEPChecks
+            - SaveKYCCheckStatus
+            - SuspendAccount
+            - UnSuspendAccount
+            - UpdateAccountHolderState
+            - Verification
+          type: string
+        executionDate:
+          description: The execution date scheduled for the event.
+          format: date-time
+          type: string
+        reason:
+          description: The reason that leads to scheduling of the event.
+          type: string
+    AccountHolderUpdateNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/UpdateAccountHolderResponse"
+          description: The details of the Account Holder update.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    AccountHolderVerificationNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/AccountHolderVerificationNotificationContent"
+          description: The details of the Account Holder verification.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    AccountHolderVerificationNotificationContent:
+      properties:
+        accountHolderCode:
+          description: The code of the account holder.
+          type: string
+        bankAccountUUID:
+          description: The unique ID of the bank account that has been verified.
+          type: string
+        shareholderCode:
+          description: The code of the shareholder that has been verified.
+          type: string
+        signatoryCode:
+          description: The code of the signatory that has been verified.
+          type: string
+        statusSummaryItems:
+          deprecated: true
+          description: A summary of the verification status.
+          items:
+            $ref: "#/components/schemas/KYCCheckDataSummaryItem"
+          type: array
+        verificationStatus:
+          description: The status of verification.
+          enum:
+            - AWAITING_DATA
+            - DATA_PROVIDED
+            - FAILED
+            - INVALID_DATA
+            - PASSED
+            - PENDING
+            - PENDING_REVIEW
+            - RETRY_LIMIT_REACHED
+            - UNCHECKED
+          type: string
+        verificationType:
+          description: The type of validation performed.
+          enum:
+            - BANK_ACCOUNT_VERIFICATION
+            - CARD_VERIFICATION
+            - COMPANY_VERIFICATION
+            - IDENTITY_VERIFICATION
+            - LEGAL_ARRANGEMENT_VERIFICATION
+            - NONPROFIT_VERIFICATION
+            - PASSPORT_VERIFICATION
+            - PAYOUT_METHOD_VERIFICATION
+            - PCI_VERIFICATION
+          type: string
+      required:
+        - accountHolderCode
+    AccountPayoutState:
+      properties:
+        allowPayout:
+          description: Indicates whether payouts are allowed. This field is the overarching payout status, and is the aggregate of multiple conditions (e.g., KYC status, disabled flag, etc). If this field is false, no payouts will be permitted for any of the account holder's accounts. If this field is true, payouts will be permitted for any of the account holder's accounts.
+          type: boolean
+        disableReason:
+          description: The reason why payouts (to all of the account holder's accounts) have been disabled (by the platform). If the `disabled` field is true, this field can be used to explain why.
+          type: string
+        disabled:
+          description: Indicates whether payouts have been disabled (by the platform) for all of the account holder's accounts. A platform may enable and disable this field at their discretion. If this field is true, `allowPayout` will be false and no payouts will be permitted for any of the account holder's accounts. If this field is false, `allowPayout` may or may not be enabled, depending on other factors.
+          type: boolean
+        payoutLimit:
+          $ref: "#/components/schemas/Amount"
+          description: The maximum amount that payouts are limited to. Only applies if payouts are allowed but limited.
+        tierNumber:
+          description: The payout tier that the account holder occupies.
+          format: int32
+          type: integer
+          x-addedInVersion: "3"
+    AccountProcessingState:
+      properties:
+        disableReason:
+          description: The reason why processing has been disabled.
+          type: string
+        disabled:
+          description: Indicates whether the processing of payments is allowed.
+          type: boolean
+        processedFrom:
+          $ref: "#/components/schemas/Amount"
+          description: The lower bound of the processing tier (i.e., an account holder must have processed at least this amount of money in order to be placed into this tier).
+        processedTo:
+          $ref: "#/components/schemas/Amount"
+          description: The upper bound of the processing tier (i.e., an account holder must have processed less than this amount of money in order to be placed into this tier).
+        tierNumber:
+          description: The processing tier that the account holder occupies.
+          format: int32
+          type: integer
+          x-addedInVersion: "3"
+    AccountUpdateNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/UpdateAccountResponse"
+          description: The details of the Account update.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    Amount:
+      properties:
+        currency:
+          description: The three-character [ISO currency code](https://docs.adyen.com/development-resources/currency-codes).
+          maxLength: 3
+          minLength: 3
+          type: string
+        value:
+          description: The amount of the transaction, in [minor units](https://docs.adyen.com/development-resources/currency-codes).
+          format: int64
+          type: integer
+      required:
+        - value
+        - currency
+    BankAccountDetail:
+      properties:
+        accountNumber:
+          description: |-
+            The bank account number (without separators).
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        accountType:
+          description: |-
+            The type of bank account.
+            Only applicable to bank accounts held in the USA.
+            The permitted values are: `checking`, `savings`.
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        bankAccountName:
+          description: The name of the bank account.
+          type: string
+        bankAccountUUID:
+          description: |
+            The unique identifier (UUID) of the Bank Account.
+            >If, during an account holder create or update request, this field is left blank (but other fields provided), a new Bank Account will be created with a procedurally-generated UUID.
+
+            >If, during an account holder create request, a UUID is provided, the creation of the Bank Account will fail while the creation of the account holder will continue.
+
+            >If, during an account holder update request, a UUID that is not correlated with an existing Bank Account is provided, the update of the account holder will fail.
+
+            >If, during an account holder update request, a UUID that is correlated with an existing Bank Account is provided, the existing Bank Account will be updated.
+          type: string
+        bankBicSwift:
+          description: |-
+            The bank identifier code.
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        bankCity:
+          description: |-
+            The city in which the bank branch is located.
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        bankCode:
+          description: |-
+            The bank code of the banking institution with which the bank account is registered.
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        bankName:
+          description: |-
+            The name of the banking institution with which the bank account is held.
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        branchCode:
+          description: |-
+            The branch code of the branch under which the bank account is registered. The value to be specified in this parameter depends on the country of the bank account:
+            * United States - Routing number
+            * United Kingdom - Sort code
+            * Germany - Bankleitzahl
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        checkCode:
+          description: |-
+            The check code of the bank account.
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        countryCode:
+          description: |-
+            The two-letter country code in which the bank account is registered.
+            >The permitted country codes are defined in ISO-3166-1 alpha-2 (e.g. 'NL').
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        currencyCode:
+          description: |-
+            The currency in which the bank account deals.
+            >The permitted currency codes are defined in ISO-4217 (e.g. 'EUR').
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        iban:
+          description: |-
+            The international bank account number.
+            >The IBAN standard is defined in ISO-13616.
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        ownerCity:
+          description: |-
+            The city of residence of the bank account owner.
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        ownerCountryCode:
+          description: |-
+            The country code of the country of residence of the bank account owner.
+            >The permitted country codes are defined in ISO-3166-1 alpha-2 (e.g. 'NL').
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        ownerDateOfBirth:
+          description: |
+            The date of birth of the bank account owner.
+          type: string
+        ownerHouseNumberOrName:
+          description: |-
+            The house name or number of the residence of the bank account owner.
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        ownerName:
+          description: |-
+            The name of the bank account owner.
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        ownerNationality:
+          description: |-
+            The country code of the country of nationality of the bank account owner.
+            >The permitted country codes are defined in ISO-3166-1 alpha-2 (e.g. 'NL').
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        ownerPostalCode:
+          description: |-
+            The postal code of the residence of the bank account owner.
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        ownerState:
+          description: |-
+            The state of residence of the bank account owner.
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        ownerStreet:
+          description: |-
+            The street name of the residence of the bank account owner.
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        primaryAccount:
+          description: If set to true, the bank account is a primary account.
+          type: boolean
+        taxId:
+          description: |-
+            The tax ID number.
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+        urlForVerification:
+          description: |-
+            The URL to be used for bank account verification.
+            This may be generated on bank account creation.
+
+            >Refer to the [Onboarding and verification](https://docs.adyen.com/platforms/onboarding-and-verification) section for details on field requirements.
+          type: string
+    BeneficiarySetupNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/BeneficiarySetupNotificationContent"
+          description: Details of the beneficiary setup.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    BeneficiarySetupNotificationContent:
+      properties:
+        destinationAccountCode:
+          description: The code of the beneficiary account.
+          type: string
+        destinationAccountHolderCode:
+          description: The code of the beneficiary Account Holder.
+          type: string
+        merchantReference:
+          description: The reference provided by the merchant.
+          type: string
+        sourceAccountCode:
+          description: The code of the benefactor account.
+          type: string
+        sourceAccountHolderCode:
+          description: The code of the benefactor Account Holder.
+          type: string
+        transferDate:
+          description: The date on which the beneficiary was set up and funds transferred from benefactor to beneficiary.
+          format: date-time
+          type: string
+        transferredTransactionCount:
+          description: The number of transactions transferred upon the setup of the beneficiary.
+          format: int32
+          type: integer
+      required:
+        - sourceAccountHolderCode
+        - sourceAccountCode
+        - destinationAccountHolderCode
+        - destinationAccountCode
+        - transferDate
+        - transferredTransactionCount
+    BusinessDetails:
+      properties:
+        doingBusinessAs:
+          description: The registered name of the company (if it differs from the legal name of the company).
+          type: string
+        legalBusinessName:
+          description: The legal name of the company.
+          type: string
+        listedUltimateParentCompany:
+          description: Information about the parent public company. Required if the account holder is 100% owned by a publicly listed company.
+          items:
+            $ref: "#/components/schemas/UltimateParentCompany"
+          type: array
+        shareholders:
+          description: Array containing information about individuals associated with the account holder either through ownership or control. For details about how you can identify them, refer to [Identity check](https://docs.adyen.com/platforms/verification-checks/identity-check).
+          items:
+            $ref: "#/components/schemas/ShareholderContact"
+          type: array
+        signatories:
+          description: |-
+            Signatories associated with the company.
+            Each array entry should represent one signatory.
+          items:
+            $ref: "#/components/schemas/SignatoryContact"
+          type: array
+        taxId:
+          description: The tax ID of the company.
+          type: string
+    CloseAccountResponse:
+      properties:
+        pspReference:
+          description: The reference of a request. Can be used to uniquely identify the request.
+          type: string
+        resultCode:
+          description: The result code.
+          type: string
+        status:
+          description: |-
+            The new status of the account.
+            >Permitted values: `Active`, `Inactive`, `Suspended`, `Closed`.
+          enum:
+            - Active
+            - Closed
+            - Inactive
+            - Suspended
+          type: string
+          x-addedInVersion: "2"
+        submittedAsync:
+          description: |-
+            Indicates whether the request is processed asynchronously. Depending on the request's platform settings, the following scenarios may be applied:
+            * **true**: The request is queued and will be executed when the providing service is available in the order in which the requests are received.
+            * **false**: The processing of the request is immediately attempted; it may result in an error if the providing service is unavailable.
+          type: boolean
+      required:
+        - status
+    CompensateNegativeBalanceNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/CompensateNegativeBalanceNotificationContent"
+          description: Details of the negative balance compensation.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+    CompensateNegativeBalanceNotificationContent:
+      properties:
+        records:
+          description: A list of the negative balances compensated.
+          items:
+            $ref: "#/components/schemas/CompensateNegativeBalanceNotificationRecord"
+          type: array
+      required:
+        - records
+    CompensateNegativeBalanceNotificationRecord:
+      properties:
+        accountCode:
+          description: The code of the account whose negative balance has been compensated.
+          type: string
+        amount:
+          $ref: "#/components/schemas/Amount"
+          description: The amount compensated.
+        transferDate:
+          description: The date on which the compensation took place.
+          format: date-time
+          type: string
+      required:
+        - accountCode
+        - transferDate
+        - amount
+    CreateAccountHolderResponse:
+      properties:
+        accountCode:
+          description: The code of a new account created for the account holder.
+          type: string
+        accountHolderCode:
+          description: The code of the new account holder.
+          type: string
+        accountHolderDetails:
+          $ref: "#/components/schemas/AccountHolderDetails"
+          description: Details of the new account holder.
+        accountHolderStatus:
+          $ref: "#/components/schemas/AccountHolderStatus"
+          description: The status of the new account holder.
+          x-addedInVersion: "2"
+        invalidFields:
+          description: A list of fields that caused the `/createAccountHolder` request to fail.
+          items:
+            $ref: "#/components/schemas/ErrorFieldType"
+          type: array
+          x-addedInVersion: "5"
+        pspReference:
+          description: The reference of a request. Can be used to uniquely identify the request.
+          type: string
+        resultCode:
+          description: The result code.
+          type: string
+        submittedAsync:
+          description: |-
+            Indicates whether the request is processed asynchronously. Depending on the request's platform settings, the following scenarios may be applied:
+            * **true**: The request is queued and will be executed when the providing service is available in the order in which the requests are received.
+            * **false**: The processing of the request is immediately attempted; it may result in an error if the providing service is unavailable.
+          type: boolean
+        verification:
+          $ref: "#/components/schemas/KYCVerificationResult2"
+          description: The details of KYC Verification of the account holder.
+          x-addedInVersion: "2"
+      required:
+        - accountHolderCode
+        - accountHolderStatus
+        - accountHolderDetails
+        - verification
+    CreateAccountResponse:
+      properties:
+        accountCode:
+          description: The code of the new account.
+          type: string
+        accountHolderCode:
+          description: The code of the account holder.
+          type: string
+        payoutSchedule:
+          $ref: "#/components/schemas/PayoutScheduleResponse"
+          description: The payout schedule of the account.
+        pspReference:
+          description: The reference of a request. Can be used to uniquely identify the request.
+          type: string
+        resultCode:
+          description: The result code.
+          type: string
+        status:
+          description: |-
+            The status of the account.
+            >Permitted values: `Active`.
+          enum:
+            - Active
+            - Closed
+            - Inactive
+            - Suspended
+          type: string
+          x-addedInVersion: "2"
+        submittedAsync:
+          description: |-
+            Indicates whether the request is processed asynchronously. Depending on the request's platform settings, the following scenarios may be applied:
+            * **true**: The request is queued and will be executed when the providing service is available in the order in which the requests are received.
+            * **false**: The processing of the request is immediately attempted; it may result in an error if the providing service is unavailable.
+          type: boolean
+      required:
+        - accountHolderCode
+        - accountCode
+        - status
+    DirectDebitInitiatedNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/DirectDebitInitiatedNotificationContent"
+          description: Details of the direct debit.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+    DirectDebitInitiatedNotificationContent:
+      properties:
+        accountCode:
+          description: The code of the account.
+          type: string
+        amount:
+          $ref: "#/components/schemas/Amount"
+          description: The amount to be debited from the funding account.
+        debitInitiationDate:
+          $ref: "#/components/schemas/LocalDate"
+          description: The date of the debit initiation.
+        invalidFields:
+          description: Invalid fields list.
+          items:
+            $ref: "#/components/schemas/ErrorFieldType"
+          type: array
+        merchantAccountCode:
+          description: The code of the merchant account.
+          type: string
+        splits:
+          description: The split data for the debit request
+          items:
+            $ref: "#/components/schemas/Split"
+          type: array
+        status:
+          $ref: "#/components/schemas/OperationStatus"
+          description: Direct debit status.
+      required:
+        - amount
+        - accountCode
+        - merchantAccountCode
+    ErrorFieldType:
+      properties:
+        errorCode:
+          description: The validation error code.
+          format: int32
+          type: integer
+        errorDescription:
+          description: A description of the validation error.
+          type: string
+        fieldType:
+          $ref: "#/components/schemas/FieldType"
+          description: The type of error field.
+    FieldType:
+      properties:
+        field:
+          description: The full name of the property.
+          type: string
+        fieldName:
+          description: The type of the field.
+          enum:
+            - accountCode
+            - accountHolderCode
+            - accountHolderDetails
+            - accountNumber
+            - accountStateType
+            - accountStatus
+            - accountType
+            - address
+            - bankAccount
+            - bankAccountCode
+            - bankAccountName
+            - bankAccountUUID
+            - bankBicSwift
+            - bankCity
+            - bankCode
+            - bankName
+            - bankStatement
+            - branchCode
+            - businessContact
+            - cardToken
+            - checkCode
+            - city
+            - companyRegistration
+            - constitutionalDocument
+            - country
+            - countryCode
+            - currency
+            - currencyCode
+            - dateOfBirth
+            - destinationAccountCode
+            - document
+            - documentExpirationDate
+            - documentIssuerCountry
+            - documentIssuerState
+            - documentName
+            - documentNumber
+            - documentType
+            - doingBusinessAs
+            - drivingLicence
+            - drivingLicenceBack
+            - drivingLicense
+            - email
+            - firstName
+            - formType
+            - fullPhoneNumber
+            - gender
+            - hopWebserviceUser
+            - houseNumberOrName
+            - iban
+            - idCard
+            - idNumber
+            - identityDocument
+            - individualDetails
+            - jobTitle
+            - lastName
+            - legalArrangement
+            - legalArrangementCode
+            - legalArrangementEntity
+            - legalArrangementEntityCode
+            - legalArrangementLegalForm
+            - legalArrangementMember
+            - legalArrangementMembers
+            - legalArrangementName
+            - legalArrangementReference
+            - legalArrangementRegistrationNumber
+            - legalArrangementTaxNumber
+            - legalArrangementType
+            - legalBusinessName
+            - legalEntity
+            - legalEntityType
+            - merchantAccount
+            - merchantCategoryCode
+            - merchantReference
+            - microDeposit
+            - name
+            - nationality
+            - originalReference
+            - ownerCity
+            - ownerCountryCode
+            - ownerHouseNumberOrName
+            - ownerName
+            - ownerPostalCode
+            - ownerState
+            - ownerStreet
+            - passport
+            - passportNumber
+            - payoutMethodCode
+            - payoutSchedule
+            - pciSelfAssessment
+            - personalData
+            - phoneCountryCode
+            - phoneNumber
+            - postalCode
+            - primaryCurrency
+            - reason
+            - returnUrl
+            - schedule
+            - shareholder
+            - shareholderCode
+            - shareholderCodeAndSignatoryCode
+            - shareholderCodeOrSignatoryCode
+            - shareholderType
+            - shopperInteraction
+            - signatory
+            - signatoryCode
+            - socialSecurityNumber
+            - sourceAccountCode
+            - splitAccount
+            - splitConfigurationUUID
+            - splitCurrency
+            - splitValue
+            - splits
+            - stateOrProvince
+            - status
+            - stockExchange
+            - stockNumber
+            - stockTicker
+            - store
+            - storeDetail
+            - storeName
+            - storeReference
+            - street
+            - taxId
+            - tier
+            - tierNumber
+            - transferCode
+            - ultimateParentCompany
+            - ultimateParentCompanyAddressDetails
+            - ultimateParentCompanyAddressDetailsCountry
+            - ultimateParentCompanyBusinessDetails
+            - ultimateParentCompanyBusinessDetailsLegalBusinessName
+            - ultimateParentCompanyBusinessDetailsRegistrationNumber
+            - ultimateParentCompanyCode
+            - ultimateParentCompanyStockExchange
+            - ultimateParentCompanyStockNumber
+            - ultimateParentCompanyStockNumberOrStockTicker
+            - ultimateParentCompanyStockTicker
+            - unknown
+            - value
+            - verificationType
+            - virtualAccount
+            - visaNumber
+            - webAddress
+            - year
+          type: string
+        shareholderCode:
+          description: The code of the shareholder that the field belongs to. If empty, the field belongs to an account holder.
+          type: string
+    IndividualDetails:
+      properties:
+        name:
+          $ref: "#/components/schemas/ViasName"
+          description: |-
+            The name of the individual.
+            >Make sure your account holder registers using the name shown on their Photo ID.
+        personalData:
+          $ref: "#/components/schemas/ViasPersonalData"
+          description: Personal information of the individual.
+    KYCBankAccountCheckResult:
+      properties:
+        bankAccountUUID:
+          description: The unique ID of the bank account to which the check applies.
+          type: string
+        checks:
+          description: A list of the checks and their statuses.
+          items:
+            $ref: "#/components/schemas/KYCCheckStatusData"
+          type: array
+    KYCCheckDataSummaryItem:
+      properties:
+        itemCode:
+          description: The code of the item reviewed.
+          format: int32
+          type: integer
+        itemDescription:
+          description: A description of the item reviewed.
+          type: string
+    KYCCheckResult2:
+      properties:
+        checks:
+          description: A list of the checks and their statuses.
+          items:
+            $ref: "#/components/schemas/KYCCheckStatusData"
+          type: array
+    KYCCheckStatusData:
+      properties:
+        requiredFields:
+          description: A list of the fields required for execution of the check.
+          items:
+            type: string
+          type: array
+        status:
+          description: |-
+            The status of the check.
+
+            Possible values: **AWAITING_DATA** , **DATA_PROVIDED**, **FAILED**, **INVALID_DATA**, **PASSED**, **PENDING**, **RETRY_LIMIT_REACHED**.
+          enum:
+            - AWAITING_DATA
+            - DATA_PROVIDED
+            - FAILED
+            - INVALID_DATA
+            - PASSED
+            - PENDING
+            - PENDING_REVIEW
+            - RETRY_LIMIT_REACHED
+            - UNCHECKED
+          type: string
+        summary:
+          $ref: "#/components/schemas/KYCCheckSummary"
+          description: A summary of the execution of the check.
+        type:
+          description: |-
+            The type of check.
+
+            Possible values:
+
+             * **BANK_ACCOUNT_VERIFICATION**: Used in v5 and earlier. Replaced by **PAYOUT_METHOD_VERIFICATION** in v6 and later.
+
+             * **COMPANY_VERIFICATION**
+
+              * **CARD_VERIFICATION**
+
+            * **IDENTITY_VERIFICATION**
+
+            * **LEGAL_ARRANGEMENT_VERIFICATION**
+
+            * **NONPROFIT_VERIFICATION**
+
+             * **PASSPORT_VERIFICATION**
+
+            * **PAYOUT_METHOD_VERIFICATION**: Used in v6 and later.
+
+            * **PCI_VERIFICATION**
+          enum:
+            - BANK_ACCOUNT_VERIFICATION
+            - CARD_VERIFICATION
+            - COMPANY_VERIFICATION
+            - IDENTITY_VERIFICATION
+            - LEGAL_ARRANGEMENT_VERIFICATION
+            - NONPROFIT_VERIFICATION
+            - PASSPORT_VERIFICATION
+            - PAYOUT_METHOD_VERIFICATION
+            - PCI_VERIFICATION
+          type: string
+      required:
+        - type
+        - status
+    KYCCheckSummary:
+      properties:
+        code:
+          description: The code of the check.
+          format: int32
+          type: integer
+        description:
+          description: A description of the check.
+          type: string
+      required:
+        - code
+    KYCShareholderCheckResult:
+      properties:
+        checks:
+          description: A list of the checks and their statuses.
+          items:
+            $ref: "#/components/schemas/KYCCheckStatusData"
+          type: array
+        shareholderCode:
+          description: The code of the shareholder to which the check applies.
+          type: string
+    KYCSignatoryCheckResult:
+      properties:
+        checks:
+          description: A list of the checks and their statuses.
+          items:
+            $ref: "#/components/schemas/KYCCheckStatusData"
+          type: array
+        signatoryCode:
+          description: The code of the signatory to which the check applies.
+          type: string
+    KYCVerificationResult2:
+      properties:
+        accountHolder:
+          $ref: "#/components/schemas/KYCCheckResult2"
+          description: The results of the checks on the account holder.
+        bankAccounts:
+          description: The results of the checks on the bank accounts.
+          items:
+            $ref: "#/components/schemas/KYCBankAccountCheckResult"
+          type: array
+        shareholders:
+          description: The results of the checks on the shareholders.
+          items:
+            $ref: "#/components/schemas/KYCShareholderCheckResult"
+          type: array
+        signatories:
+          description: The results of the checks on the signatories.
+          items:
+            $ref: "#/components/schemas/KYCSignatoryCheckResult"
+          type: array
+    LocalDate:
+      properties:
+        month:
+          format: int32
+          type: integer
+        year:
+          format: int32
+          type: integer
+    Message:
+      properties:
+        code:
+          description: The message code.
+          type: string
+        text:
+          description: The message text.
+          type: string
+    NotificationResponse:
+      properties:
+        notificationResponse:
+          description: Set this parameter to **[accepted]** to acknowledge that you received a notification from Adyen.
+          type: string
+    OperationStatus:
+      properties:
+        message:
+          $ref: "#/components/schemas/Message"
+          description: The message regarding the operation status.
+        statusCode:
+          description: The status code.
+          type: string
+    PaymentFailureNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/PaymentFailureNotificationContent"
+          description: The details of the payment failure.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    PaymentFailureNotificationContent:
+      properties:
+        errorFields:
+          description: Missing or invalid fields that caused the payment error.
+          items:
+            $ref: "#/components/schemas/ErrorFieldType"
+          type: array
+        errorMessage:
+          $ref: "#/components/schemas/Message"
+          description: The error message.
+        modificationMerchantReference:
+          description: The `reference` of the capture or refund.
+          type: string
+        modificationPspReference:
+          description: The `pspReference` of the capture or refund.
+          type: string
+        paymentMerchantReference:
+          description: The `reference` of the payment.
+          type: string
+        paymentPspReference:
+          description: The `pspReference` of the payment.
+          type: string
+      required:
+        - errorMessage
+        - errorFields
+    PayoutScheduleResponse:
+      properties:
+        nextScheduledPayout:
+          description: The date of the next scheduled payout.
+          format: date-time
+          type: string
+        schedule:
+          description: |-
+            The payout schedule of the account.
+            >Permitted values: `DEFAULT`, `HOLD`, `DAILY`, `WEEKLY`, `MONTHLY`.
+          enum:
+            - BIWEEKLY_ON_1ST_AND_15TH_AT_MIDNIGHT
+            - BIWEEKLY_ON_1ST_AND_15TH_AT_NOON
+            - BI_DAILY_AU
+            - BI_DAILY_EU
+            - BI_DAILY_US
+            - DAILY
+            - DAILY_6PM
+            - DAILY_AU
+            - DAILY_EU
+            - DAILY_SG
+            - DAILY_US
+            - DEFAULT
+            - EVERY_6_HOURS_FROM_MIDNIGHT
+            - HOLD
+            - MONTHLY
+            - MONTHLY_ON_15TH_AT_MIDNIGHT
+            - WEEKLY
+            - WEEKLY_MON_TO_FRI_AU
+            - WEEKLY_MON_TO_FRI_EU
+            - WEEKLY_MON_TO_FRI_US
+            - WEEKLY_ON_TUE_FRI_MIDNIGHT
+            - YEARLY
+          type: string
+      required:
+        - schedule
+    PersonalDocumentData:
+      properties:
+        expirationDate:
+          description: |-
+            The expiry date of the document, 
+             in ISO-8601 YYYY-MM-DD format. For example, **2000-01-31**.
+          type: string
+        issuerCountry:
+          description: |-
+            The country where the document was issued, in the two-character 
+            [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) format. For example, **NL**.
+          maxLength: 2
+          minLength: 2
+          type: string
+        issuerState:
+          description: The state where the document was issued (if applicable).
+          type: string
+        number:
+          description: The number in the document.
+          type: string
+        type:
+          description: |-
+            The type of the document. Possible values: **ID**, **DRIVINGLICENSE**, **PASSPORT**, **SOCIALSECURITY**, **VISA**.
+
+            To delete an existing entry for a document `type`, send only the `type` field in your request. 
+          enum:
+            - DRIVINGLICENSE
+            - ID
+            - PASSPORT
+            - SOCIALSECURITY
+            - VISA
+          type: string
+      required:
+        - type
+    RefundFundsTransferNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/RefundFundsTransferNotificationContent"
+          description: Details of the fund transfer refund.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    RefundFundsTransferNotificationContent:
+      properties:
+        amount:
+          $ref: "#/components/schemas/Amount"
+          description: The amount to be refunded.
+        merchantReference:
+          description: A value that can be supplied at the discretion of the executing user in order to link multiple transactions to one another.
+          type: string
+        originalReference:
+          description: A PSP reference of the original fund transfer.
+          type: string
+        status:
+          $ref: "#/components/schemas/OperationStatus"
+          description: The status of the fund transfer refund.
+      required:
+        - originalReference
+        - amount
+    RefundResult:
+      properties:
+        originalTransaction:
+          $ref: "#/components/schemas/Transaction"
+          description: The transaction that has been refunded.
+        pspReference:
+          description: The reference of the refund.
+          type: string
+        response:
+          description: The response indicating if the refund has been received for processing.
+          type: string
+      required:
+        - pspReference
+        - originalTransaction
+    ReportAvailableNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/ReportAvailableNotificationContent"
+          description: Details of the report.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    ReportAvailableNotificationContent:
+      properties:
+        accountCode:
+          description: The code of the Account to which the report applies.
+          type: string
+        accountType:
+          description: The type of Account to which the report applies.
+          type: string
+        eventDate:
+          description: The date of the event to which the report applies.
+          format: date-time
+          type: string
+        remoteAccessUrl:
+          description: The URL at which the report can be accessed.
+          type: string
+        success:
+          description: Indicates whether the event resulted in a success.
+          type: boolean
+    ScheduledRefundsNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/ScheduledRefundsNotificationContent"
+          description: Details of the scheduling of the refunds.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    ScheduledRefundsNotificationContent:
+      properties:
+        accountCode:
+          description: The code of the account.
+          type: string
+        accountHolderCode:
+          description: The code of the Account Holder.
+          type: string
+        lastPayout:
+          $ref: "#/components/schemas/Transaction"
+          description: The most recent payout (after which all transactions were scheduled to be refunded).
+        refundResults:
+          description: A list of the refunds that have been scheduled and their results.
+          items:
+            $ref: "#/components/schemas/RefundResult"
+          type: array
+      required:
+        - accountHolderCode
+        - accountCode
+        - refundResults
+    ShareholderContact:
+      properties:
+        address:
+          $ref: "#/components/schemas/ViasAddress"
+          description: The address of the person.
+        email:
+          description: The e-mail address of the person.
+          type: string
+        fullPhoneNumber:
+          description: |-
+            The phone number of the person provided as a single string.  It will be handled as a landline phone.
+            Examples: "0031 6 11 22 33 44", "+316/1122-3344", "(0031) 611223344"
+          type: string
+        jobTitle:
+          description: |-
+            Job title of the person. Required when the `shareholderType` is **Controller**.
+
+            Example values: **Chief Executive Officer**, **Chief Financial Officer**, **Chief Operating Officer**, **President**, **Vice President**, **Executive President**, **Managing Member**, **Partner**, **Treasurer**, **Director**, or **Other**.
+          type: string
+        name:
+          $ref: "#/components/schemas/ViasName"
+          description: The name of the person.
+        personalData:
+          $ref: "#/components/schemas/ViasPersonalData"
+          description: Contains information about the person.
+        phoneNumber:
+          $ref: "#/components/schemas/ViasPhoneNumber"
+          description: The phone number of the person.
+        shareholderCode:
+          description: |
+            The unique identifier (UUID) of the shareholder entry.
+            >**If, during an Account Holder create or update request, this field is left blank (but other fields provided), a new Shareholder will be created with a procedurally-generated UUID.**
+
+            >**If, during an Account Holder create request, a UUID is provided, the creation of the Shareholder will fail while the creation of the Account Holder will continue.**
+
+            >**If, during an Account Holder update request, a UUID that is not correlated with an existing Shareholder is provided, the update of the Shareholder will fail.**
+
+            >**If, during an Account Holder update request, a UUID that is correlated with an existing Shareholder is provided, the existing Shareholder will be updated.**
+          type: string
+        shareholderType:
+          description: |-
+            Specifies how the person is associated with the account holder. 
+
+            Possible values: 
+
+            * **Owner**: Individuals who directly or indirectly own 25% or more of a company.
+
+            * **Controller**: Individuals who are members of senior management staff responsible for managing a company or organization.
+          enum:
+            - Controller
+            - Owner
+            - Signatory
+          type: string
+        webAddress:
+          description: The URL of the person's website.
+          type: string
+    SignatoryContact:
+      properties:
+        address:
+          $ref: "#/components/schemas/ViasAddress"
+          description: The address of the person.
+        email:
+          description: The e-mail address of the person.
+          type: string
+        fullPhoneNumber:
+          description: |-
+            The phone number of the person provided as a single string.  It will be handled as a landline phone.
+            Examples: "0031 6 11 22 33 44", "+316/1122-3344", "(0031) 611223344"
+          type: string
+        jobTitle:
+          description: |-
+            Job title of the signatory.
+
+            Example values: **Chief Executive Officer**, **Chief Financial Officer**, **Chief Operating Officer**, **President**, **Vice President**, **Executive President**, **Managing Member**, **Partner**, **Treasurer**, **Director**, or **Other**.
+          type: string
+        name:
+          $ref: "#/components/schemas/ViasName"
+          description: The name of the person.
+        personalData:
+          $ref: "#/components/schemas/ViasPersonalData"
+          description: Contains information about the person.
+        phoneNumber:
+          $ref: "#/components/schemas/ViasPhoneNumber"
+          description: The phone number of the person.
+        signatoryCode:
+          description: |
+            The unique identifier (UUID) of the signatory.
+            >**If, during an Account Holder create or update request, this field is left blank (but other fields provided), a new Signatory will be created with a procedurally-generated UUID.**
+
+            >**If, during an Account Holder create request, a UUID is provided, the creation of the Signatory will fail while the creation of the Account Holder will continue.**
+
+            >**If, during an Account Holder update request, a UUID that is not correlated with an existing Signatory is provided, the update of the Signatory will fail.**
+
+            >**If, during an Account Holder update request, a UUID that is correlated with an existing Signatory is provided, the existing Signatory will be updated.**
+          type: string
+        signatoryReference:
+          description: Your reference for the signatory.
+          type: string
+        webAddress:
+          description: The URL of the person's website.
+          type: string
+    Split:
+      properties:
+        account:
+          description: |+
+            Unique identifier of the account where the split amount should be sent. This is required if `type` is **MarketPlace** or **BalanceAccount**.
+
+          type: string
+        amount:
+          $ref: "#/components/schemas/SplitAmount"
+          description: The amount of this split.
+        description:
+          description: A description of this split.
+          type: string
+        reference:
+          description: |-
+            Your reference for the split, which you can use to link the split to other operations such as captures and refunds.
+
+            This is required if `type` is **MarketPlace** or **BalanceAccount**. For the other types, we also recommend sending a reference so you can reconcile the split and the associated payment in the transaction overview and in the reports. If the reference is not provided, the split is reported as part of the aggregated [TransferBalance record type](https://docs.adyen.com/reporting/marketpay-payments-accounting-report) in Adyen for Platforms.
+          type: string
+        type:
+          description: |-
+            The type of split.
+            Possible values: **Default**, **PaymentFee**, **VAT**, **Commission**, **MarketPlace**, **BalanceAccount**.
+          enum:
+            - BalanceAccount
+            - Commission
+            - Default
+            - MarketPlace
+            - PaymentFee
+            - VAT
+            - Verification
+          type: string
+      required:
+        - amount
+        - type
+    SplitAmount:
+      properties:
+        currency:
+          description: |-
+            The three-character [ISO currency code](https://docs.adyen.com/development-resources/currency-codes).
+
+            If this value is not provided, the currency in which the payment is made will be used.
+          maxLength: 3
+          minLength: 3
+          type: string
+        value:
+          description: The amount in [minor units](https://docs.adyen.com/development-resources/currency-codes).
+          format: int64
+          type: integer
+      required:
+        - value
+    Transaction:
+      properties:
+        amount:
+          $ref: "#/components/schemas/Amount"
+          description: The amount of the transaction.
+        bankAccountDetail:
+          $ref: "#/components/schemas/BankAccountDetail"
+          description: The details of the bank account to where a payout was made.
+        captureMerchantReference:
+          description: The merchant reference of a related capture.
+          type: string
+        capturePspReference:
+          description: The psp reference of a related capture.
+          type: string
+        creationDate:
+          description: The date on which the transaction was performed.
+          format: date-time
+          type: string
+        description:
+          description: A description of the transaction.
+          type: string
+        destinationAccountCode:
+          description: The code of the account to which funds were credited during an outgoing fund transfer.
+          type: string
+        disputePspReference:
+          description: The psp reference of the related dispute.
+          type: string
+        disputeReasonCode:
+          description: The reason code of a dispute.
+          type: string
+        merchantReference:
+          description: The merchant reference of a transaction.
+          type: string
+        paymentPspReference:
+          description: The psp reference of the related authorisation or transfer.
+          type: string
+          x-addedInVersion: "3"
+        payoutPspReference:
+          description: The psp reference of the related payout.
+          type: string
+          x-addedInVersion: "3"
+        pspReference:
+          description: The psp reference of a transaction.
+          type: string
+        sourceAccountCode:
+          description: The code of the account from which funds were debited during an incoming fund transfer.
+          type: string
+        transactionStatus:
+          description: |-
+            The status of the transaction.
+            >Permitted values: `PendingCredit`, `CreditFailed`, `CreditClosed`, `CreditSuspended`, `Credited`, `Converted`, `PendingDebit`, `DebitFailed`, `Debited`, `DebitReversedReceived`, `DebitedReversed`, `ChargebackReceived`, `Chargeback`, `ChargebackReversedReceived`, `ChargebackReversed`, `Payout`, `PayoutReversed`, `FundTransfer`, `PendingFundTransfer`, `ManualCorrected`.
+          enum:
+            - BalanceNotPaidOutTransfer
+            - Chargeback
+            - ChargebackCorrection
+            - ChargebackCorrectionReceived
+            - ChargebackReceived
+            - ChargebackReversed
+            - ChargebackReversedCorrection
+            - ChargebackReversedCorrectionReceived
+            - ChargebackReversedReceived
+            - Converted
+            - CreditClosed
+            - CreditFailed
+            - CreditReversed
+            - CreditReversedReceived
+            - CreditSuspended
+            - Credited
+            - DebitFailed
+            - DebitReversedReceived
+            - Debited
+            - DebitedReversed
+            - DepositCorrectionCredited
+            - DepositCorrectionDebited
+            - Fee
+            - FundTransfer
+            - FundTransferReversed
+            - InvoiceDeductionCredited
+            - InvoiceDeductionDebited
+            - ManualCorrected
+            - ManualCorrectionCredited
+            - ManualCorrectionDebited
+            - MerchantPayin
+            - MerchantPayinReversed
+            - Payout
+            - PayoutReversed
+            - PendingCredit
+            - PendingDebit
+            - PendingFundTransfer
+            - SecondChargeback
+            - SecondChargebackCorrection
+            - SecondChargebackCorrectionReceived
+            - SecondChargebackReceived
+          type: string
+        transferCode:
+          description: The transfer code of the transaction.
+          type: string
+    TransferFundsNotification:
+      properties:
+        content:
+          $ref: "#/components/schemas/TransferFundsNotificationContent"
+          description: Details of the fund transfer.
+        eventType:
+          description: The event type of the notification.
+          type: string
+        executingUserKey:
+          description: The user or process that has triggered the notification.
+          type: string
+        live:
+          description: Indicates whether the notification originated from the live environment or the test environment. If true, the notification originated from the live environment. If false, the notification originated from the test environment.
+          type: boolean
+        pspReference:
+          description: The PSP reference of the request from which the notification originates.
+          type: string
+      required:
+        - executingUserKey
+        - pspReference
+        - eventType
+        - live
+        - content
+    TransferFundsNotificationContent:
+      properties:
+        amount:
+          $ref: "#/components/schemas/Amount"
+          description: The amount transferred.
+        destinationAccountCode:
+          description: The code of the Account to which funds were credited.
+          type: string
+        merchantReference:
+          description: The reference provided by the merchant.
+          type: string
+          x-addedInVersion: "2"
+        sourceAccountCode:
+          description: The code of the Account from which funds were debited.
+          type: string
+        status:
+          $ref: "#/components/schemas/OperationStatus"
+          description: The status of the fund transfer.
+        transferCode:
+          description: The transfer code.
+          type: string
+      required:
+        - sourceAccountCode
+        - destinationAccountCode
+        - amount
+        - transferCode
+    UltimateParentCompany:
+      properties:
+        address:
+          $ref: "#/components/schemas/ViasAddress"
+          description: Address of the ultimate parent company.
+        businessDetails:
+          $ref: "#/components/schemas/UltimateParentCompanyBusinessDetails"
+          description: Details about the ultimate parent company's business.
+        ultimateParentCompanyCode:
+          description: Adyen-generated unique alphanumeric identifier (UUID) for the entry, returned in the response when you create an ultimate parent company. Required when updating an existing entry in an `/updateAccountHolder` request.
+          type: string
+    UltimateParentCompanyBusinessDetails:
+      properties:
+        legalBusinessName:
+          description: The legal name of the company.
+          type: string
+        registrationNumber:
+          description: The registration number of the company.
+          type: string
+        stockExchange:
+          description: Market Identifier Code (MIC).
+          type: string
+        stockNumber:
+          description: International Securities Identification Number (ISIN).
+          type: string
+        stockTicker:
+          description: Stock Ticker symbol.
+          type: string
+    UpdateAccountHolderResponse:
+      properties:
+        accountHolderCode:
+          description: The code of the account holder.
+          type: string
+        accountHolderDetails:
+          $ref: "#/components/schemas/AccountHolderDetails"
+          description: Details of the account holder.
+        accountHolderStatus:
+          $ref: "#/components/schemas/AccountHolderStatus"
+          description: The new status of the account holder.
+          x-addedInVersion: "2"
+        invalidFields:
+          description: in case the account holder has not been updated, contains account holder fields, that did not pass the validation.
+          items:
+            $ref: "#/components/schemas/ErrorFieldType"
+          type: array
+          x-addedInVersion: "5"
+        pspReference:
+          description: The reference of a request. Can be used to uniquely identify the request.
+          type: string
+        resultCode:
+          description: The result code.
+          type: string
+        submittedAsync:
+          description: |-
+            Indicates whether the request is processed asynchronously. Depending on the request's platform settings, the following scenarios may be applied:
+            * **true**: The request is queued and will be executed when the providing service is available in the order in which the requests are received.
+            * **false**: The processing of the request is immediately attempted; it may result in an error if the providing service is unavailable.
+          type: boolean
+        updatedFields:
+          description: A list of the fields updated through the request.
+          items:
+            $ref: "#/components/schemas/FieldType"
+          type: array
+        verification:
+          $ref: "#/components/schemas/KYCVerificationResult2"
+          description: The details of KYC Verification of the account holder.
+          x-addedInVersion: "2"
+      required:
+        - accountHolderStatus
+        - verification
+    UpdateAccountResponse:
+      properties:
+        accountCode:
+          description: The code of the account.
+          type: string
+        payoutSchedule:
+          $ref: "#/components/schemas/PayoutScheduleResponse"
+          description: The payout schedule of the account.
+        pspReference:
+          description: The reference of a request. Can be used to uniquely identify the request.
+          type: string
+        resultCode:
+          description: The result code.
+          type: string
+        submittedAsync:
+          description: |-
+            Indicates whether the request is processed asynchronously. Depending on the request's platform settings, the following scenarios may be applied:
+            * **true**: The request is queued and will be executed when the providing service is available in the order in which the requests are received.
+            * **false**: The processing of the request is immediately attempted; it may result in an error if the providing service is unavailable.
+          type: boolean
+      required:
+        - accountCode
+    ViasAddress:
+      properties:
+        city:
+          description: The name of the city. Required if the `houseNumberOrName`, `street`, `postalCode`, or `stateOrProvince` are provided.
+          type: string
+        country:
+          description: The two-character country code of the address in ISO-3166-1 alpha-2 format. For example, **NL**.
+          type: string
+        houseNumberOrName:
+          description: The number or name of the house.
+          type: string
+        postalCode:
+          description: |-
+            The postal code. Required if the `houseNumberOrName`, `street`, `city`, or `stateOrProvince` are provided.
+
+            Maximum length:
+
+            * 5 digits for addresses in the US.
+
+            * 10 characters for all other countries.
+          type: string
+        stateOrProvince:
+          description: |
+            The abbreviation of the state or province. Required if the `houseNumberOrName`, `street`, `city`, or `postalCode` are provided. 
+
+            Maximum length:
+
+            * 2 characters for addresses in the US or Canada.
+
+            * 3 characters for all other countries.
+          type: string
+        street:
+          description: The name of the street. Required if the `houseNumberOrName`, `city`, `postalCode`, or `stateOrProvince` are provided.
+          type: string
+      required:
+        - country
+    ViasName:
+      properties:
+        firstName:
+          description: The first name.
+          type: string
+        gender:
+          description: |-
+            The gender.
+            >The following values are permitted: `MALE`, `FEMALE`, `UNKNOWN`.
+          enum:
+            - MALE
+            - FEMALE
+            - UNKNOWN
+          maxLength: 1
+          type: string
+        infix:
+          description: |-
+            The name's infix, if applicable.
+            >A maximum length of twenty (20) characters is imposed.
+          type: string
+        lastName:
+          description: The last name.
+          type: string
+      required:
+        - firstName
+        - lastName
+    ViasPersonalData:
+      properties:
+        dateOfBirth:
+          description: The person's date of birth, in ISO-8601 YYYY-MM-DD format. For example, **2000-01-31**.
+          type: string
+        documentData:
+          description: Array that contains information about the person's identification document. You can submit only one entry per document type.
+          items:
+            $ref: "#/components/schemas/PersonalDocumentData"
+          type: array
+          x-addedInVersion: "3"
+        idNumber:
+          deprecated: true
+          description: An ID number of the person.
+          type: string
+          x-deprecatedInVersion: "3"
+          x-deprecatedMessage: Use `individualDetails.personalData.documentData.number` instead.
+        nationality:
+          description: |
+            The nationality of the person represented by a two-character country code,  in [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) format. For example, **NL**.
+          maxLength: 2
+          minLength: 2
+          type: string
+    ViasPhoneNumber:
+      properties:
+        phoneCountryCode:
+          description: |-
+            The two-character country code of the phone number.
+            >The permitted country codes are defined in ISO-3166-1 alpha-2 (e.g. 'NL').
+          type: string
+        phoneNumber:
+          description: |-
+            The phone number.
+            >The inclusion of the phone number country code is not necessary.
+          type: string
+        phoneType:
+          description: |-
+            The type of the phone number.
+            >The following values are permitted: `Landline`, `Mobile`, `SIP`, `Fax`.
+          enum:
+            - Fax
+            - Landline
+            - Mobile
+            - SIP
+          type: string
+      required:
+        - phoneCountryCode
+        - phoneNumber
+  securitySchemes:
+    ApiKeyAuth:
+      in: header
+      name: X-API-Key
+      type: apiKey
+    BasicAuth:
+      scheme: basic
+      type: http
+webhooks:
+  /ACCOUNT_CLOSED:
+    post:
+      description: This notification is sent when an account has been closed.
+      operationId: post-ACCOUNT_CLOSED
+      requestBody:
+        content:
+          application/json:
+            examples:
+              accountClosed:
+                $ref: "#/components/examples/post-ACCOUNT_CLOSED-accountClosed"
+            schema:
+              $ref: "#/components/schemas/AccountCloseNotification"
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                accountClosed:
+                  $ref: "#/components/examples/WebhookAck"
+              schema:
+                $ref: "#/components/schemas/NotificationResponse"
+          description: OK - the request has succeeded.
+      security:
+        - BasicAuth: []
+        - ApiKeyAuth: []
+      summary: Triggered upon the closure of an account.
+      servers:
+        - url:  https://{username}.gigantic-server.com:{port}/{basePath}
+          description: Common url for all operations in this path
+          variables:
+            username:
+              default: demo
+              description: Assigned by the service provider
+            port:
+              enum:
+                - '8843'
+                - '443'
+
+              default: '8843'
+            basePath:
+              default: v2
+      tags:
+        - Accounts
+      x-groupName: Accounts
+      x-sortIndex: 3
+  /ACCOUNT_CREATED:
+    post:
+      description: This notification is sent when an account has been created.
+      operationId: post-ACCOUNT_CREATED
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AccountCreateNotification"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationResponse"
+          description: OK - the request has succeeded.
+      security:
+        - BasicAuth: []
+        - ApiKeyAuth: []
+      summary: Triggered upon the creation of an account.
+      tags:
+        - Accounts
+      x-groupName: Accounts
+      x-sortIndex: 1
+  /ACCOUNT_FUNDS_BELOW_THRESHOLD:
+    post:
+      description: This notification is sent when a liable account's current funds are below configured threshold from the Adyen platform.
+      operationId: post-ACCOUNT_FUNDS_BELOW_THRESHOLD
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AccountFundsBelowThresholdNotification"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationResponse"
+          description: OK - the request has succeeded.
+      security:
+        - BasicAuth: []
+        - ApiKeyAuth: []
+      summary: Triggered when a liable account current funds are below configured threshold.
+      tags:
+        - Fund management
+      x-groupName: Fund management
+      x-sortIndex: 7
+  /ACCOUNT_HOLDER_CREATED:
+    post:
+      description: This notification is sent when an account holder has been created.
+      operationId: post-ACCOUNT_HOLDER_CREATED
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AccountHolderCreateNotification"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationResponse"
+          description: OK - the request has succeeded.
+      security:
+        - BasicAuth: []
+        - ApiKeyAuth: []
+      summary: Triggered upon the creation of an account holder.
+      tags:
+        - Account holders
+      x-groupName: Account holders
+      x-sortIndex: 1
+  /ACCOUNT_HOLDER_PAYOUT:
+    post:
+      description: This notification is sent when a payout request to an account holder has been processed and the payout has been scheduled.
+      operationId: post-ACCOUNT_HOLDER_PAYOUT
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AccountHolderPayoutNotification"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationResponse"
+          description: OK - the request has succeeded.
+      security:
+        - BasicAuth: []
+        - ApiKeyAuth: []
+      summary: Triggered upon a payout to an account holder.
+      tags:
+        - Fund management
+      x-groupName: Fund management
+      x-sortIndex: 1
+  /ACCOUNT_HOLDER_STATUS_CHANGE:
+    post:
+      description: This notification is sent when the status of an account holder has been changed.
+      operationId: post-ACCOUNT_HOLDER_STATUS_CHANGE
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AccountHolderStatusChangeNotification"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationResponse"
+          description: OK - the request has succeeded.
+      security:
+        - BasicAuth: []
+        - ApiKeyAuth: []
+      summary: Triggered upon the status change of an account holder.
+      tags:
+        - Account holders
+      x-groupName: Account holders
+      x-sortIndex: 4
+  /ACCOUNT_HOLDER_STORE_STATUS_CHANGE:
+    post:
+      description: This notification is sent when the status of a store tied to an account holder has been changed.
+      operationId: post-ACCOUNT_HOLDER_STORE_STATUS_CHANGE
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AccountHolderStoreStatusChangeNotification"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationResponse"
+          description: OK - the request has succeeded.
+      security:
+        - BasicAuth: []
+        - ApiKeyAuth: []
+      summary: Triggered upon the status change of a store tied to an account holder.
+      tags:
+        - Account holders
+      x-groupName: Account holders
+      x-sortIndex: 4
+  /ACCOUNT_HOLDER_UPCOMING_DEADLINE:
+    post:
+      description: This notification is sent when an Account Holder has a deadline, to fulfill the requirements of a specific event, coming up.
+      operationId: post-ACCOUNT_HOLDER_UPCOMING_DEADLINE
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AccountHolderUpcomingDeadlineNotification"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationResponse"
+          description: OK - the request has succeeded.
+      security:
+        - BasicAuth: []
+        - ApiKeyAuth: []
+      summary: Triggered upon an upcoming deadline.
+      tags:
+        - Account holders
+      x-groupName: Account holders
+      x-sortIndex: 1
+  /ACCOUNT_HOLDER_UPDATED:
+    post:
+      description: This notification is sent when an account holder has been updated.
+      operationId: post-ACCOUNT_HOLDER_UPDATED
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AccountHolderUpdateNotification"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationResponse"
+          description: OK - the request has succeeded.
+      security:
+        - BasicAuth: []
+        - ApiKeyAuth: []
+      summary: Triggered upon the update of an account holder.
+      tags:
+        - Account holders
+      x-groupName: Account holders
+      x-sortIndex: 2
+  /ACCOUNT_HOLDER_VERIFICATION:
+    post:
+      description: This notification is sent when KYC Verification results are made available.
+      operationId: post-ACCOUNT_HOLDER_VERIFICATION
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AccountHolderVerificationNotification"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationResponse"
+          description: OK - the request has succeeded.
+      security:
+        - BasicAuth: []
+        - ApiKeyAuth: []
+      summary: Triggered upon the receipt of KYC Verification results.
+      tags:
+        - Account holders
+      x-groupName: Account holders
+      x-sortIndex: 3
+  /ACCOUNT_UPDATED:
+    post:
+      description: This notification is sent when an account has been updated.
+      operationId: post-ACCOUNT_UPDATED
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AccountUpdateNotification"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationResponse"
+          description: OK - the request has succeeded.
+      security:
+        - BasicAuth: []
+        - ApiKeyAuth: []
+      summary: Triggered upon the update of an account.
+      tags:
+        - Accounts
+      x-groupName: Accounts
+      x-sortIndex: 2
+  /BENEFICIARY_SETUP:
+    post:
+      description: This notification is sent when a benefactor/beneficiary relationship between accounts has been set up.
+      operationId: post-BENEFICIARY_SETUP
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BeneficiarySetupNotification"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationResponse"
+          description: OK - the request has succeeded.
+      security:
+        - BasicAuth: []
+        - ApiKeyAuth: []
+      summary: Triggered upon the setup of a beneficiary.
+      tags:
+        - Fund management
+      x-groupName: Fund management
+      x-sortIndex: 3
+  /COMPENSATE_NEGATIVE_BALANCE:
+    post:
+      description: This notification is sent when funds have been transferred from your platform's liable account to an overdrawn account in order to compensate for the overdraft.
+      operationId: post-COMPENSATE_NEGATIVE_BALANCE
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CompensateNegativeBalanceNotification"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationResponse"
+          description: OK - the request has succeeded.
+      security:
+        - BasicAuth: []
+        - ApiKeyAuth: []
+      summary: Triggered upon the compensation of negative account balances.
+      tags:
+        - Fund management
+      x-groupName: Fund management
+      x-sortIndex: 5
+  /DIRECT_DEBIT_INITIATED:
+    post:
+      description: This notification is sent when an automated direct debit is initiated from the Adyen platform.
+      operationId: post-DIRECT_DEBIT_INITIATED
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DirectDebitInitiatedNotification"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationResponse"
+          description: OK - the request has succeeded.
+      security:
+        - BasicAuth: []
+        - ApiKeyAuth: []
+      summary: Triggered when an automated direct debit is initiated.
+      tags:
+        - Fund management
+      x-groupName: Fund management
+      x-sortIndex: 7
+  /PAYMENT_FAILURE:
+    post:
+      description: This notification is sent when a [split payment](https://docs.adyen.com/platforms/processing-payments#providing-split-information) booking for a capture or refund fails. When a booking fails due to an invalid account status or an unknown `accountCode`, the funds are credited or debited to your platform's liable account instead of the account specified in the split data.
+      operationId: post-PAYMENT_FAILURE
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PaymentFailureNotification"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationResponse"
+          description: OK - the request has succeeded.
+      security:
+        - BasicAuth: []
+        - ApiKeyAuth: []
+      summary: Triggered when a booking for a capture or refund fails.
+      tags:
+        - Other
+      x-groupName: Other
+      x-sortIndex: 1
+  /REFUND_FUNDS_TRANSFER:
+    post:
+      description: This notification is sent when the refund of funds from an account have been transferred to another account.
+      operationId: post-REFUND_FUNDS_TRANSFER
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RefundFundsTransferNotification"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationResponse"
+          description: OK - the request has succeeded.
+      security:
+        - BasicAuth: []
+        - ApiKeyAuth: []
+      summary: Triggered upon the transfer refund of funds between accounts.
+      tags:
+        - Fund management
+      x-groupName: Fund management
+      x-sortIndex: 6
+  /REPORT_AVAILABLE:
+    post:
+      description: This notification is sent when a report has been made available.
+      operationId: post-REPORT_AVAILABLE
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReportAvailableNotification"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationResponse"
+          description: OK - the request has succeeded.
+      security:
+        - BasicAuth: []
+        - ApiKeyAuth: []
+      summary: Triggered when a report is made available.
+      tags:
+        - Other
+      x-groupName: Other
+      x-sortIndex: 2
+  /SCHEDULED_REFUNDS:
+    post:
+      description: This notification is sent when a 'Refund Transfers Not Paid Out' call has been processed and the associated refunds have been scheduled.
+      operationId: post-SCHEDULED_REFUNDS
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ScheduledRefundsNotification"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationResponse"
+          description: OK - the request has succeeded.
+      security:
+        - BasicAuth: []
+        - ApiKeyAuth: []
+      summary: Triggered upon the scheduling of refunds requested by a 'Refund Transfers Not Paid Out' call.
+      tags:
+        - Fund management
+      x-groupName: Fund management
+      x-sortIndex: 4
+  /TRANSFER_FUNDS:
+    post:
+      description: This notification is sent when the funds from an account have been transferred to another account.
+      operationId: post-TRANSFER_FUNDS
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TransferFundsNotification"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationResponse"
+          description: OK - the request has succeeded.
+      security:
+        - BasicAuth: []
+        - ApiKeyAuth: []
+      summary: Triggered upon the transfer of funds between accounts.
+      tags:
+        - Fund management
+      x-groupName: Fund management
+      x-sortIndex: 2
+x-groups:
+  - Account holders
+  - Accounts
+  - Fund management
+  - Other
+x-staticResponse: response.json

--- a/test/unit/x31schemapack.test.js
+++ b/test/unit/x31schemapack.test.js
@@ -822,4 +822,53 @@ describe('Webhooks support', function() {
           .with.length(3);
       });
     });
+
+  it('Should resolve correctly a file with only paths, with includeWebhooks in true',
+    function() {
+      const fileSource = path.join(__dirname, OPENAPI_31_FOLDER + '/webhooks/only-paths.yaml'),
+        fileData = fs.readFileSync(fileSource, 'utf8'),
+        input = {
+          type: 'string',
+          data: fileData
+        },
+        converter = new SchemaPack(input, { includeWebhooks: true });
+
+      converter.convert((err, result) => {
+        expect(err).to.be.null;
+        expect(result.result).to.be.true;
+        expect(result.output[0].data.item).to.be.an('array')
+          .with.length(1);
+        expect(result.output[0].data.item).to.be.an('array').with.length(1);
+        expect(result.output[0].data.item[0].name).to.equal('pets');
+        expect(result.output[0].data.item[0].item).to.be.an('array')
+          .with.length(3);
+      });
+    });
+
+  it('Should resolve correctly a file and ignore servers object in webhook, with includeWebhooks in true',
+    function() {
+      const fileSource = path.join(__dirname, OPENAPI_31_FOLDER +
+        '/webhooks/payments-webhook-with-servers-in-webhook.yaml'),
+        fileData = fs.readFileSync(fileSource, 'utf8'),
+        input = {
+          type: 'string',
+          data: fileData
+        },
+        converter = new SchemaPack(input, { includeWebhooks: true });
+
+      converter.convert((err, result) => {
+        expect(err).to.be.null;
+        expect(result.result).to.be.true;
+        expect(result.output[0].data.item).to.be.an('array')
+          .with.length(1);
+        expect(result.output[0].data.item).to.be.an('array').with.length(1);
+        expect(result.output[0].data.item[0].name).to.equal('Webhooks');
+        expect(result.output[0].data.item[0].item[0].request.url.host).to.be.an('array')
+          .with.length(1);
+        expect(result.output[0].data.item[0].item[0].request.url.host[0])
+          .to.be.equal('{{ACCOUNT_CLOSED}}');
+        expect(result.output[0].data.item[0].item).to.be.an('array')
+          .with.length(19);
+      });
+    });
 });


### PR DESCRIPTION
- Set description as the fallback value in webhooks naming
- Local servers and global servers are ignored in webhooks
- Avoiding to add the webhooks folder when includeWebhooks is true and there is not any webhook