### PR TITLE
Fixed issue where newly converted collection had mismatches from validateTransaction() API.

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -137,16 +137,16 @@ module.exports = {
     stack++;
     schemaResolutionCache = schemaResolutionCache || {};
 
-    if (stack > stackLimit) {
-      return { value: ERR_TOO_MANY_LEVELS };
-    }
-
     // Update max stack reached for all current refs that's being resolved
     if (!_.isEmpty(this._currentRefStack)) {
       _.forEach(this._currentRefStack, (refKey) => {
         _.set(schemaResolutionCache, [refKey, 'maxStack'],
           Math.max(_.get(schemaResolutionCache, [refKey, 'maxStack'], 0), stack));
       });
+    }
+
+    if (stack > stackLimit) {
+      return { value: ERR_TOO_MANY_LEVELS };
     }
 
     if (!schema) {
@@ -176,10 +176,6 @@ module.exports = {
     if (schema.allOf) {
       return this.resolveAllOf(schema.allOf, parameterSourceOption, components, schemaResolutionCache, resolveFor,
         resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
-    }
-    if (schema.additionalProperties && !_.isBoolean(schema.additionalProperties)) {
-      schema.additionalProperties = this.resolveRefs(schema.additionalProperties, parameterSourceOption,
-        components, schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
     }
     if (schema.$ref && _.isFunction(schema.$ref.split)) {
       let refKey = schema.$ref,
@@ -254,13 +250,26 @@ module.exports = {
       }
       return { value: 'reference ' + schema.$ref + ' not found in the OpenAPI spec' };
     }
-    if (concreteUtils.compareTypes(schema.type, 'objects') || schema.hasOwnProperty('properties')) {
+    if (concreteUtils.compareTypes(schema.type, 'objects') || schema.hasOwnProperty('properties') ||
+      schema.hasOwnProperty('additionalProperties')) {
       // go through all props
       schema.type = 'object';
-      if (schema.hasOwnProperty('properties')) {
+      if (_.has(schema, 'properties') || _.has(schema, 'additionalProperties')) {
         // shallow cloning schema object except properties object
-        let tempSchema = _.omit(schema, 'properties');
-        tempSchema.properties = {};
+        let tempSchema = _.omit(schema, ['properties', 'additionalProperties']);
+
+        if (_.has(schema, 'additionalProperties')) {
+          // don't resolve boolean values
+          if (_.isBoolean(schema.additionalProperties)) {
+            tempSchema.additionalProperties = schema.additionalProperties;
+          }
+          else {
+            tempSchema.additionalProperties = this.resolveRefs(schema.additionalProperties, parameterSourceOption,
+              components, schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
+          }
+        }
+
+        !_.isEmpty(schema.properties) && (tempSchema.properties = {});
         for (prop in schema.properties) {
           if (schema.properties.hasOwnProperty(prop)) {
             /* eslint-disable max-depth */

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -915,7 +915,7 @@ module.exports = {
   convertPathVariables: function(type, providedPathVars, commonPathVars, components, options, schemaCache) {
     options = _.merge({}, defaultOptions, options);
 
-    var variables = providedPathVars;
+    var variables = [];
     // converting the base uri path variables, if any
     // commonPathVars is an object for type = root/method
     // array otherwise
@@ -948,7 +948,8 @@ module.exports = {
       });
     }
 
-    return variables;
+    // keep already provided varables (server variables) at last
+    return _.concat(variables, providedPathVars);
   },
 
   /**
@@ -1429,8 +1430,13 @@ module.exports = {
     else if (bodyObj.schema) {
       if (bodyObj.schema.hasOwnProperty('$ref')) {
         let outerProps = concreteUtils.getOuterPropsIfIsSupported(bodyObj.schema),
+          resolvedSchema;
+
+        // skip beforehand resolution for OAS 3.0
+        if (outerProps) {
           resolvedSchema = this.getRefObject(bodyObj.schema.$ref, components, options);
-        bodyObj.schema = concreteUtils.addOuterPropsToRefSchemaIfIsSupported(resolvedSchema, outerProps);
+          bodyObj.schema = concreteUtils.addOuterPropsToRefSchemaIfIsSupported(resolvedSchema, outerProps);
+        }
       }
       if (options.schemaFaker) {
         if (this.getHeaderFamily(contentType) === HEADER_TYPE.XML) {
@@ -1438,7 +1444,7 @@ module.exports = {
         }
         // Do not fake schemas if the complexity score is 10
         if (options.complexityScore === 10) {
-          schemaType = bodyObj.schema.type;
+          schemaType = _.get(this.getRefObject(bodyObj.schema.$ref, components, options), 'type');
           if (schemaType === 'object') {
             return {
               value: '<Error: Spec size too large, skipping faking of schemas>'
@@ -1760,12 +1766,14 @@ module.exports = {
     // handling for the urlencoded media type
     if (contentObj.hasOwnProperty(URLENCODED)) {
       rDataMode = 'urlencoded';
-      if (contentObj[URLENCODED].hasOwnProperty('schema') && contentObj[URLENCODED].schema.hasOwnProperty('$ref')) {
-        contentObj[URLENCODED].schema = this.getRefObject(contentObj[URLENCODED].schema.$ref, components, options);
-      }
       bodyData = this.convertToPmBodyData(contentObj[URLENCODED], requestType, URLENCODED,
         PARAMETER_SOURCE.REQUEST, options.indentCharacter, components, options, schemaCache);
       encoding = contentObj[URLENCODED].encoding ? contentObj[URLENCODED].encoding : {};
+
+      if (contentObj[URLENCODED].hasOwnProperty('schema') && contentObj[URLENCODED].schema.hasOwnProperty('$ref')) {
+        contentObj[URLENCODED].schema = this.getRefObject(contentObj[URLENCODED].schema.$ref, components, options);
+      }
+
       // create query parameters and add it to the request body object
       _.forOwn(bodyData, (value, key) => {
 

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -373,6 +373,7 @@ class SchemaPack {
   validateTransaction(transactions, callback) {
     let schema = this.openapi,
       componentsAndPaths,
+      analysis,
       options = this.computedOptions,
       schemaCache = {
         schemaResolutionCache: this.schemaResolutionCache,
@@ -380,6 +381,15 @@ class SchemaPack {
       },
       matchedEndpoints = [],
       jsonSchemaDialect = schema.jsonSchemaDialect;
+
+    // Only change the stack limit if the optimizeConversion option is true
+    if (options.optimizeConversion) {
+      // Deciding stack limit based on size of the schema, number of refs and number of paths.
+      analysis = schemaUtils.analyzeSpec(schema);
+
+      // Update options on the basis of analysis.
+      options = schemaUtils.determineOptions(analysis, options);
+    }
 
     if (!this.validated) {
       return callback(new OpenApiErr('The schema must be validated before attempting conversion'));

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -373,7 +373,6 @@ class SchemaPack {
   validateTransaction(transactions, callback) {
     let schema = this.openapi,
       componentsAndPaths,
-      analysis,
       options = this.computedOptions,
       schemaCache = {
         schemaResolutionCache: this.schemaResolutionCache,
@@ -381,15 +380,6 @@ class SchemaPack {
       },
       matchedEndpoints = [],
       jsonSchemaDialect = schema.jsonSchemaDialect;
-
-    // Only change the stack limit if the optimizeConversion option is true
-    if (options.optimizeConversion) {
-      // Deciding stack limit based on size of the schema, number of refs and number of paths.
-      analysis = schemaUtils.analyzeSpec(schema);
-
-      // Update options on the basis of analysis.
-      options = schemaUtils.determineOptions(analysis, options);
-    }
 
     if (!this.validated) {
       return callback(new OpenApiErr('The schema must be validated before attempting conversion'));

--- a/test/data/valid_openapi/petstore-detailed.yaml
+++ b/test/data/valid_openapi/petstore-detailed.yaml
@@ -424,9 +424,10 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties:
-                  type: integer
-                  format: int32
+                properties:
+                  prop123:
+                    type: integer
+                    format: int32
       security:
         - api_key: []
   /store/order:

--- a/test/data/valid_openapi/readOnly.json
+++ b/test/data/valid_openapi/readOnly.json
@@ -34,7 +34,20 @@
 					"content": {
 						"application/json": {
 							"schema": {
-								"$ref": "#/components/schemas/Pet"
+								"properties": {
+									"id": {
+										"type": "integer",
+										"format": "int64",
+										"readOnly": true
+									},
+									"name": {
+										"type": "string"
+									},
+									"tag": {
+										"type": "string",
+										"writeOnly": true
+									}
+								}
 							}
 						}
 					}

--- a/test/unit/deref.test.js
+++ b/test/unit/deref.test.js
@@ -100,6 +100,14 @@ describe('DEREF FUNCTION TESTS ', function() {
                   name: {
                     type: 'string'
                   }
+                },
+                additionalProperties: {
+                  type: 'object',
+                  properties: {
+                    hello: {
+                      type: 'string'
+                    }
+                  }
                 }
               }
             }
@@ -119,7 +127,8 @@ describe('DEREF FUNCTION TESTS ', function() {
           _.cloneDeep(componentsAndPaths), {}, 'VALIDATION'),
         output_emptyObject = deref.resolveRefs(schemaWithEmptyObject, parameterSource, _.cloneDeep(componentsAndPaths)),
         output_additionalProps = deref.resolveRefs(schemaWithAdditionPropRef, parameterSource,
-          _.cloneDeep(componentsAndPaths), {}, 'VALIDATION');
+          _.cloneDeep(componentsAndPaths), {}, 'VALIDATION'),
+        output_additionalPropsOverride;
 
       expect(output).to.deep.include({ type: 'object',
         required: ['id'],
@@ -170,6 +179,15 @@ describe('DEREF FUNCTION TESTS ', function() {
       // additionalProperties $ref should be resolved
       expect(output_additionalProps).to.deep.include(componentsAndPaths.components.schemas.schemaAdditionalProps);
 
+      // add default to above resolved schema
+      output_additionalProps.additionalProperties.properties.hello.default = '<string>';
+
+      output_additionalPropsOverride = deref.resolveRefs(schemaWithAdditionPropRef, parameterSource,
+        _.cloneDeep(componentsAndPaths), {}, 'VALIDATION');
+
+      // override should not affect newly resolved schema
+      expect(output_additionalPropsOverride).to.deep.include(
+        componentsAndPaths.components.schemas.schemaAdditionalProps);
       done();
     });
 


### PR DESCRIPTION
This PR fixes, issue where in `convert()` and `validateTransaction()` APIs, for same request/response body, resolved schema were resolved till different nesting levels.

This was happening due to the following reasons.
- During conversion, we were resolving $ref beforehand to see types.
- During the resolution of additional properties, we were using same reference to resolved object instead of creating new clone.