### PR TITLE
Fixed an issue where readOnly and writeOnly properties were not removed from required in resolved schema.

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -273,9 +273,17 @@ module.exports = {
             }
 
             if (property.readOnly && parameterSourceOption === PARAMETER_SOURCE.REQUEST) {
+              // remove property from required as it'll not be present in resolved schema
+              if (_.includes(tempSchema.required, prop)) {
+                _.remove(tempSchema.required, _.matches(prop));
+              }
               continue;
             }
             else if (property.writeOnly && parameterSourceOption === PARAMETER_SOURCE.RESPONSE) {
+              // remove property from required as it'll not be present in resolved schema
+              if (_.includes(tempSchema.required, prop)) {
+                _.remove(tempSchema.required, _.matches(prop));
+              }
               continue;
             }
             /* eslint-enable */

--- a/test/unit/deref.test.js
+++ b/test/unit/deref.test.js
@@ -357,6 +357,66 @@ describe('DEREF FUNCTION TESTS ', function() {
         .equal(componentsAndPaths.components.schemas.schemaUsed);
       done();
     });
+
+    it('should not contain readOnly properties in resolved schema if they are not contained' +
+      ' in resolved schema', function(done) {
+      var schema = {
+          type: 'object',
+          required: ['id', 'name'],
+          properties: {
+            id: {
+              type: 'integer',
+              format: 'int64',
+              readOnly: true
+            },
+            name: {
+              type: 'string'
+            },
+            tag: {
+              type: 'string',
+              writeOnly: true
+            }
+          }
+        },
+        parameterSource = 'REQUEST',
+        output;
+
+      output = deref.resolveRefs(schema, parameterSource, { concreteUtils: schemaUtils30X });
+      expect(output.type).to.equal('object');
+      expect(output.properties).to.not.haveOwnProperty('id');
+      expect(output.required).to.not.include('id');
+      done();
+    });
+
+    it('should not contain writeOnly properties in resolved schema if they are not contained' +
+      ' in resolved schema', function(done) {
+      var schema = {
+          type: 'object',
+          required: ['id', 'tag'],
+          properties: {
+            id: {
+              type: 'integer',
+              format: 'int64',
+              readOnly: true
+            },
+            name: {
+              type: 'string'
+            },
+            tag: {
+              type: 'string',
+              writeOnly: true
+            }
+          }
+        },
+        parameterSource = 'RESPONSE',
+        output;
+
+      output = deref.resolveRefs(schema, parameterSource, { concreteUtils: schemaUtils30X });
+      expect(output.type).to.equal('object');
+      expect(output.properties).to.not.haveOwnProperty('tag');
+      expect(output.required).to.not.include('tag');
+      done();
+    });
   });
 
   describe('resolveAllOf Function', function () {


### PR DESCRIPTION
This PR fixes issue where `readOnly` and  writeOnly` properties were removed from resolved schema but if they did get present under `required` array for the corresponding object.

This created incorrectly resolved schema, resulting in mismatches reported during `validateTransaction()` API.