### PR TITLE
Released v3.1.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # OpenAPI-Postman Changelog
 
+#### v3.1.0 (March 04, 2022)
+* Removed usage of schema resolution cache to avoid incorrect resolution.
+* Fixed issue where newly converted collection had mismatches from validateTransaction() API.
+* Fixed issue where falsy example were not getting converted correctly in generated collection.
+* Fixed issue where readOnly and writeOnly properties were not removed from required in resolved schema.
+* Fixed issue where if schema had pattern as property, conversion failed with error.
+
 #### v3.0.0 (Feb 11, 2022)
 * Add support for OpenAPI 3.1.x https://www.openapis.org/blog/2021/02/18/openapi-specification-3-1-released.
 * Separated schemUtils into common, 3.1, and 3.0 specific files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-to-postmanv2",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-to-postmanv2",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Convert a given OpenAPI specification to Postman Collection v2.0",
   "homepage": "https://github.com/postmanlabs/openapi-to-postman",
   "bugs": "https://github.com/postmanlabs/openapi-to-postman/issues",


### PR DESCRIPTION
#### v3.1.0 (March 04, 2022)
* Removed usage of schema resolution cache to avoid incorrect resolution.
* Fixed issue where newly converted collection had mismatches from validateTransaction() API.
* Fixed issue where falsy example were not getting converted correctly in generated collection.
* Fixed issue where readOnly and writeOnly properties were not removed from required in resolved schema.
* Fixed issue where if schema had pattern as property, conversion failed with error.