### PR TITLE
match with servers

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2643,9 +2643,16 @@ module.exports = {
         }
         return accumulator;
       }, []);
-
+      let schemaMatchResult = { match: false };
       // check if path and pathToMatch match (non-null)
-      let schemaMatchResult = this.getPostmanUrlSchemaMatchScore(pathToMatch, path, options);
+      // check in explicit (local defined) servers
+      if (pathItemObject[method.toLowerCase()].servers) {
+        schemaMatchResult = this.getPostmanUrlSchemaMatchScoreServers(pathItemObject[method.toLowerCase()].servers,
+          pathToMatch, path, options);
+      }
+      else {
+        schemaMatchResult = this.getPostmanUrlSchemaMatchScore(pathToMatch, path, options);
+      }
       if (!schemaMatchResult.match) {
         // there was no reasonable match b/w the postman path and this schema path
         return true;
@@ -4426,6 +4433,31 @@ module.exports = {
       var retVal = _.keyBy(_.reject(result, (ai) => { return !ai; }), 'id');
       return cb(null, retVal);
     });
+  },
+
+  /**
+   * Match the Postman url across the defined servers in the schema path object
+   * @param {Array} servers - servers defined in the schema path object
+   * @param {string} pathToMatch - parsed path (exclude host and params) from the Postman request
+   * @param {string} schemaPath - schema path from the OAS spec (exclude servers object)
+   * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
+   * @returns {*} score + match + pathVars - higher score - better match. null - no match
+   */
+  getPostmanUrlSchemaMatchScoreServers: function (servers, pathToMatch, schemaPath, options) {
+    let result = {
+      match: false
+    };
+    servers.forEach((server) => {
+      let serverPathname = require('url').parse(server.url).pathname,
+        schemaMatchResult;
+      pathToMatch = pathToMatch.replace(serverPathname, '');
+      schemaMatchResult = this.getPostmanUrlSchemaMatchScore(pathToMatch, schemaPath, options);
+      if (schemaMatchResult.match) {
+        result = schemaMatchResult;
+        return;
+      }
+    });
+    return result;
   },
 
   /**

--- a/test/data/valid_openapi/explicit_server_in_path.json
+++ b/test/data/valid_openapi/explicit_server_in_path.json
@@ -30,7 +30,6 @@
         "tags": [
           "Authorization"
         ],
-        "x-box-tag": "authorization",
         "security": [],
         "servers": [
           {
@@ -129,7 +128,6 @@
         "tags": [
           "Authorization"
         ],
-        "x-box-tag": "authorization",
         "security": [],
         "servers": [
           {
@@ -232,7 +230,6 @@
         "tags": [
           "Authorization"
         ],
-        "x-box-tag": "authorization",
         "security": [],
         "parameters": [
           {

--- a/test/data/valid_openapi/explicit_server_in_path.json
+++ b/test/data/valid_openapi/explicit_server_in_path.json
@@ -1,0 +1,336 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Platform API",
+    "description": "Provides functionality to provide access.",
+    "termsOfService": "https://TOSServer/s/rmwxu64h1ipr41u49w3bbuvbsa29wku9",
+    "contact": {
+      "name": "name",
+      "url": "https://app.dev",
+      "email": "dev@app.com"
+    },
+    "license": {
+      "name": "Apache-2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    },
+    "version": "2.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://server/2.0",
+      "description": "Platform API server"
+    }
+  ],
+  "paths": {
+    "/authorize": {
+      "get": {
+        "operationId": "get_authorize",
+        "summary": "Authorize user",
+        "description": "Authorize a user ...",
+        "tags": [
+          "Authorization"
+        ],
+        "x-box-tag": "authorization",
+        "security": [],
+        "servers": [
+          {
+            "url": "https://server/api/oauth2",
+            "description": "Server for client-side authentication"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "response_type",
+            "description": "The type of response we'd like to receive.",
+            "in": "query",
+            "example": "code",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "token",
+              "enum": [
+                "code"
+              ]
+            }
+          },
+          {
+            "name": "client_id",
+            "description": "The Client ID.",
+            "in": "query",
+            "example": "ly1nj6n11vionaie65emwzk575hnnmrk",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "redirect_uri",
+            "description": "The URI to redirecton.",
+            "in": "query",
+            "example": "http://example.com/auth/callback",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "url"
+            }
+          },
+          {
+            "name": "state",
+            "description": "A custom string of your choice.",
+            "in": "query",
+            "example": "my_state",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "scope",
+            "description": "A comma-separated list.",
+            "in": "query",
+            "example": "admin_readwrite",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Does not return any data, but rather should be used in the browser.",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string",
+                  "format": "html"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Does not return any data, but rather should be used in the browser.",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string",
+                  "format": "html"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pathServers": {
+      "get": {
+        "operationId": "get_authorize",
+        "summary": "Authorize user",
+        "description": "...",
+        "tags": [
+          "Authorization"
+        ],
+        "x-box-tag": "authorization",
+        "security": [],
+        "servers": [
+          {
+            "url": "https://server/api/oauth2",
+            "description": "Server for client-side authentication"
+          },
+          {
+            "url": "https://server/api/oauth3",
+            "description": "Server for client-side authentication"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "response_type",
+            "description": "The type of response we'd like to receive.",
+            "in": "query",
+            "example": "code",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "token",
+              "enum": [
+                "code"
+              ]
+            }
+          },
+          {
+            "name": "client_id",
+            "description": "The Client ID.",
+            "in": "query",
+            "example": "ly1nj6n11vionaie65emwzk575hnnmrk",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "redirect_uri",
+            "description": "The URI to redirect",
+            "in": "query",
+            "example": "http://example.com/auth/callback",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "url"
+            }
+          },
+          {
+            "name": "state",
+            "description": "A custom string of your choice.",
+            "in": "query",
+            "example": "my_state",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "scope",
+            "description": "A comma-separated list.",
+            "in": "query",
+            "example": "admin_readwrite",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Does not return any data, but rather should be used in the browser.",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string",
+                  "format": "html"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Does not return any data, but rather should be used in the browser.",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string",
+                  "format": "html"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth": {
+      "get": {
+        "operationId": "get_authorize",
+        "summary": "Authorize user",
+        "description": "Authorize a user.",
+        "tags": [
+          "Authorization"
+        ],
+        "x-box-tag": "authorization",
+        "security": [],
+        "parameters": [
+          {
+            "name": "response_type",
+            "description": "The type of response we'd like to receive.",
+            "in": "query",
+            "example": "code",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "token",
+              "enum": [
+                "code"
+              ]
+            }
+          },
+          {
+            "name": "client_id",
+            "description": "The Client ID.",
+            "in": "query",
+            "example": "ly1nj6n11vionaie65emwzk575hnnmrk",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "redirect_uri",
+            "description": "The URI.",
+            "in": "query",
+            "example": "http://example.com/auth/callback",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "url"
+            }
+          },
+          {
+            "name": "state",
+            "description": "A custom string of your choice.",
+            "in": "query",
+            "example": "my_state",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "scope",
+            "description": "A comma-separated",
+            "in": "query",
+            "example": "admin_readwrite",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Does not return any data, but rather should be used in the browser.",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string",
+                  "format": "html"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Does not return any data, but rather should be used in the browser.",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string",
+                  "format": "html"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+    }
+  },
+  "security": [
+    {
+      "OAuth2Security": []
+    }
+  ],
+  "tags": [
+  ],
+  "externalDocs": {
+    "description": "Developer Documentation",
+    "url": "https://developer.com"
+  }
+}

--- a/test/unit/validator.test.js
+++ b/test/unit/validator.test.js
@@ -66,42 +66,6 @@ function getFoldersByVersion(folder30Path, folder31Path) {
 
 describe('Validation with different resolution parameters options', function () {
 
-  it('Should validate correctly schema with explicit servers', function () {
-    let fileData = fs.readFileSync(path.join(__dirname, VALID_OPENAPI_FOLDER_PATH,
-        '/explicit_server_in_path.json'), 'utf8'),
-      options = {
-        requestParametersResolution: 'Schema',
-        exampleParametersResolution: 'Schema',
-        showMissingInSchemaErrors: true,
-        strictRequestMatching: true,
-        ignoreUnresolvedVariables: true,
-        validateMetadata: true,
-        suggestAvailableFixes: true,
-        detailedBlobValidation: true
-      },
-      schemaPack = new Converter.SchemaPack({ type: 'string', data: fileData }, options);
-    schemaPack.convert((err, conversionResult) => {
-      expect(err).to.be.null;
-      expect(conversionResult.result).to.equal(true);
-
-      let historyRequest = [];
-      getAllTransactions(conversionResult.output[0].data, historyRequest);
-      schemaPack.validateTransaction(historyRequest, (err, result) => {
-        expect(err).to.be.null;
-        expect(result).to.be.an('object');
-        let requestIds = Object.keys(result.requests);
-        expect(err).to.be.null;
-        requestIds.forEach((requestId) => {
-          expect(result.requests[requestId].endpoints[0].matched).to.be.true;
-          const responsesIds = Object.keys(result.requests[requestId].endpoints[0].responses);
-          responsesIds.forEach((responseId) => {
-            expect(result.requests[requestId].endpoints[0].responses[responseId].matched).to.be.true;
-          });
-        });
-      });
-    });
-  });
-
   it('Should validate correctly with request and example parameters as Schema', function () {
     let fileData = fs.readFileSync(path.join(__dirname, VALID_OPENAPI_FOLDER_PATH,
         '/issue#479_2.yaml'), 'utf8'),

--- a/test/unit/validator.test.js
+++ b/test/unit/validator.test.js
@@ -65,6 +65,43 @@ function getFoldersByVersion(folder30Path, folder31Path) {
 
 
 describe('Validation with different resolution parameters options', function () {
+
+  it('Should validate correctly schema with explicit servers', function () {
+    let fileData = fs.readFileSync(path.join(__dirname, VALID_OPENAPI_FOLDER_PATH,
+        '/explicit_server_in_path.json'), 'utf8'),
+      options = {
+        requestParametersResolution: 'Schema',
+        exampleParametersResolution: 'Schema',
+        showMissingInSchemaErrors: true,
+        strictRequestMatching: true,
+        ignoreUnresolvedVariables: true,
+        validateMetadata: true,
+        suggestAvailableFixes: true,
+        detailedBlobValidation: true
+      },
+      schemaPack = new Converter.SchemaPack({ type: 'string', data: fileData }, options);
+    schemaPack.convert((err, conversionResult) => {
+      expect(err).to.be.null;
+      expect(conversionResult.result).to.equal(true);
+
+      let historyRequest = [];
+      getAllTransactions(conversionResult.output[0].data, historyRequest);
+      schemaPack.validateTransaction(historyRequest, (err, result) => {
+        expect(err).to.be.null;
+        expect(result).to.be.an('object');
+        let requestIds = Object.keys(result.requests);
+        expect(err).to.be.null;
+        requestIds.forEach((requestId) => {
+          expect(result.requests[requestId].endpoints[0].matched).to.be.true;
+          const responsesIds = Object.keys(result.requests[requestId].endpoints[0].responses);
+          responsesIds.forEach((responseId) => {
+            expect(result.requests[requestId].endpoints[0].responses[responseId].matched).to.be.true;
+          });
+        });
+      });
+    });
+  });
+
   it('Should validate correctly with request and example parameters as Schema', function () {
     let fileData = fs.readFileSync(path.join(__dirname, VALID_OPENAPI_FOLDER_PATH,
         '/issue#479_2.yaml'), 'utf8'),


### PR DESCRIPTION

Currently, with paths that have servers defined explicitly, the validateTransaction method returns missing endpoints.

fixes #496 

The problem was the operations where servers are defined explicitly. For example:

```
/authorize": {
      "get": {
        "operationId": "get_authorize",
        "summary": "Authorize user",
        "description": "Authorize ...",
        "tags": [
          "Authorization"
        ],
        "security": [],
        "servers": [
          {
            "url": "https://server/api/oauth2",
            "description": "Server for client-side authentication"
          }
        ],
```
Now we look up to the servers and try to find the path with the request using the url from the server.

Steps to reproduce:

Generate collection from the OpenAPI specification with explicit servers defined.
Validate collection against the specification and see the result provided.