### PR TITLE
Change deepObject generation

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1550,9 +1550,9 @@ module.exports = {
    */
   extractDeepObjectParams: function (deepObject, objectKey) {
     let extractedParams = [];
-    // console.log(deepObject);
 
-    _.forEach(deepObject, (value, key) => {
+    Object.keys(deepObject).forEach((key) => {
+      let value = deepObject[key];
       if (typeof value === 'object') {
         extractedParams = _.concat(extractedParams, this.extractDeepObjectParams(value, objectKey + '[' + key + ']'));
       }

--- a/test/data/valid_openapi/deepObjectLengthProperty.yaml
+++ b/test/data/valid_openapi/deepObjectLengthProperty.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.1
+info:
+  title: Demo
+  version: "1.0"
+paths:
+  /get:
+    get:
+      operationId: someRequest
+      parameters:
+        - $ref: '#/components/parameters/DeepObjectNestedList'
+        - $ref: '#/components/parameters/DeepObjectLengthParameter'
+      responses:
+        '200':
+          description: Response on success.
+components:
+  parameters:
+    DeepObjectLengthParameter:
+      name: deepObjectLengthParameter
+      in: query
+      required: false
+      style: deepObject
+      schema:
+        $ref: '#/components/schemas/DeepObjectLengthParameter'
+      explode: true
+  schemas:
+    DeepObjectLengthParameter:
+      type: object
+      properties:
+        length:
+          nullable: true
+          type: integer
+          format: int32
+          minimum: 1
+          example: 20

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -45,7 +45,8 @@ describe('CONVERT FUNCTION TESTS ', function() {
       emptySecurityTestCase = path.join(__dirname, VALID_OPENAPI_PATH + '/empty-security-test-case.yaml'),
       rootUrlServerWithVariables = path.join(__dirname, VALID_OPENAPI_PATH + '/root_url_server_with_variables.json'),
       parameterExamples = path.join(__dirname, VALID_OPENAPI_PATH + '/parameteres_with_examples.yaml'),
-      issue10229 = path.join(__dirname, VALID_OPENAPI_PATH, '/issue#10229.json');
+      issue10229 = path.join(__dirname, VALID_OPENAPI_PATH, '/issue#10229.json'),
+      deepObjectLengthProperty = path.join(__dirname, VALID_OPENAPI_PATH, '/deepObjectLengthProperty.yaml');
 
 
     it('Should add collection level auth with type as `bearer`' +
@@ -1091,6 +1092,20 @@ describe('CONVERT FUNCTION TESTS ', function() {
           expect(err).to.be.null;
           let request = conversionResult.output[0].data.item[0].request;
           expect(request.auth.type).to.equal('noauth');
+          done();
+        });
+    });
+
+    it('[Github #10752]: Should convert deepObject length property' +
+    deepObjectLengthProperty, function(done) {
+      var openapi = fs.readFileSync(deepObjectLengthProperty, 'utf8');
+      Converter.convert({ type: 'string', data: openapi },
+        { schemaFaker: true, requestParametersResolution: 'Example' }, (err, conversionResult) => {
+          expect(err).to.be.null;
+          expect(conversionResult.result).to.equal(true);
+          expect(conversionResult.output[0].data.item[0].request.url.query[0].key)
+            .to.equal('deepObjectLengthParameter[length]');
+          expect(conversionResult.output[0].data.item[0].request.url.query[0].value).to.equal('20');
           done();
         });
     });


### PR DESCRIPTION
Change deepObject generation

Currently, lodash's foreach interprets {length:20} as an array, so it generates 20 objects with an incremental key [1.2.3....20]
You can see the detail here: 

https://github.com/postmanlabs/postman-app-support/issues/10752


Changed to traverse manually the keys of the objects with plain javascript.
After changes the generated collection looks like this:


![Screen Shot 2022-04-12 at 11 57 38](https://user-images.githubusercontent.com/46000487/163015065-74240898-23ac-4453-b1ff-41b502a1b324.png)

