### PR TITLE
fix: requestNameSource with operationId

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -1,6 +1,6 @@
 id|type|available options|default|description|usage
 |---|---|---|---|---|---|
-requestNameSource|enum|URL, Fallback|Fallback|Determines how the requests inside the generated collection will be named. If “Fallback” is selected, the request will be named after one of the following schema values: `description`, `operationid`, `url`.|CONVERSION, VALIDATION
+requestNameSource|enum|URL, Fallback, operationId|Fallback|Determines how the requests inside the generated collection will be named. If “Fallback” is selected, the request will be named after one of the following schema values: `description`, `url`.|CONVERSION, VALIDATION
 indentCharacter|enum|Space, Tab|Space|Option for setting indentation character|CONVERSION
 collapseFolders|boolean|-|true|Importing will collapse all folders that have only one child element and lack persistent folder-level data.|CONVERSION
 optimizeConversion|boolean|-|true|Optimizes conversion for large specification, disabling this option might affect the performance of conversion.|CONVERSION

--- a/lib/options.js
+++ b/lib/options.js
@@ -60,7 +60,7 @@ module.exports = {
         id: 'requestNameSource',
         type: 'enum',
         default: 'Fallback',
-        availableOptions: ['URL', 'Fallback'],
+        availableOptions: ['URL', 'Fallback','operationId'],
         description: 'Determines how the requests inside the generated collection will be named.' +
         ' If “Fallback” is selected, the request will be named after one of the following schema' +
         ' values: `description`, `operationid`, `url`.',

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2356,6 +2356,10 @@ module.exports = {
         }
         break;
       }
+      case 'operationid':{
+        reqName = operation.operationId
+        break;
+      }
       case 'url' : {
         reqName = displayUrl || baseUrl;
         break;


### PR DESCRIPTION
In openapi-to-postman, option `requestNameSource` with Fallback was not working for `operationId`. Now a change applied with `operationId` as enum for ` requestNameSource`. In Postman collection `name` of request will be with `operationId`. 
`requestNameSource=operationId`