### PR TITLE
Fixes nullable field not passing on to resolved JSON schema if the object references to another object

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -206,6 +206,9 @@ module.exports = {
         let refResolvedSchema = this.resolveRefs(resolvedSchema, parameterSourceOption,
           components, schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
 
+        if (schema.nullable) {
+          refResolvedSchema.nullable = schema.nullable;
+        }
         return refResolvedSchema;
       }
       return { value: 'reference ' + schema.$ref + ' not found in the OpenAPI spec' };

--- a/test/unit/deref.test.js
+++ b/test/unit/deref.test.js
@@ -427,7 +427,7 @@ describe('DEREF FUNCTION TESTS ', function() {
           }
         },
         parameterSource = 'RESPONSE',
-        componentsAndPaths = { //eslint-disable-line
+        componentsAndPaths = {
           'components': {
             'examples': {
               'menu-basecrusts': {

--- a/test/unit/deref.test.js
+++ b/test/unit/deref.test.js
@@ -413,7 +413,7 @@ describe('DEREF FUNCTION TESTS ', function() {
       expect(deref._getEscaped(null, { randomObject: 1 })).to.equal(null);
     });
   });
-  describe('APIDES-597 | nullable field should be passed on to converted json schema', function() {
+  describe('APIDES-597 | nullable field should be passed on to converted/resolved json schema', function() {
     it('JSON schema should contain nullable fields if the parent refs to another schema', function(done) {
       var schema = {
           'type': 'object',
@@ -549,6 +549,7 @@ describe('DEREF FUNCTION TESTS ', function() {
       expect(output.properties.items.type).to.eql('array');
       expect(output.properties.items.items.type).to.eql('object');
       expect(output.properties.items.items.properties.addOnInfo.nullable).to.eql(true);
+      expect(output.properties.items.items.properties.addOnInfo.properties.addOnItems.nullable).to.eql(true);
       expect(output.properties.items.items.properties.itemId.nullable).to.eql(undefined);
       done();
     });


### PR DESCRIPTION
This PR fixes the bug in which users are receiving an error message when validating their OpenAPI schema/request.

Error seen is: `The response body property <PROPERTY_NAME> must be object.`

Error was caused due to `nullable` field not passing on to the resolved schema when the recursion bubbles up in `lib/defer.js`. The nullable key was not being passed to the resolved JSON schema if the object having the nullable field `$ref`/references to another schema object within itself.