### PR TITLE
Fix detectRootFiles not working in browser

### DIFF
--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -647,6 +647,7 @@ class SchemaPack {
       });
     }
     adaptedInput = schemaUtils.mapDetectRootFilesInputToGetRootFilesInput(input);
+    adaptedInput.origin = input.origin;
     rootFiles = parse.getRootFiles(adaptedInput, concreteUtils.inputValidation, this.computedOptions, files,
       input.specificationVersion);
     res = schemaUtils.mapGetRootFilesOutputToDetectRootFilesOutput(rootFiles, input.specificationVersion);


### PR DESCRIPTION
Add `origin` field to `adaptedInput` that is passed to `parse.getRootFiles`.