### PR TITLE
Fix/bundle issues2

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -4931,8 +4931,8 @@ module.exports = {
       try {
         res.output.data = this.mapProcessRelatedFiles(inputRelatedFiles.rootFiles, inputRelatedFiles.data,
           inputRelatedFiles.origin, version, inputRelatedFiles.bundleFormat, toBundle);
-        if (res.output.data === undefined || res.output.data.length === 0 ||
-          res.output.data.result === false) {
+        if (res.output.data === undefined || res.output.data.result === false ||
+           res.output.data.length === 0) {
           res.result = false;
         }
         return res;

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -4931,23 +4931,21 @@ module.exports = {
       try {
         res.output.data = this.mapProcessRelatedFiles(inputRelatedFiles.rootFiles, inputRelatedFiles.data,
           inputRelatedFiles.origin, version, inputRelatedFiles.bundleFormat, toBundle);
+        if (res.output.data === undefined || res.output.data.length === 0 ||
+          res.output.data.result === false) {
+          res.result = false;
+        }
+        return res;
       }
       catch (error) {
         if (error instanceof ParseError) {
-          return {
-            result: false,
-            reason: error.message
-          };
-        }
-        else {
           throw (error);
         }
+        let newError = new Error('There was an error during the process');
+        newError.stack = error.stack;
+        throw (newError);
       }
-      if (res.output.data.result === false) {
-        res.result = res.output.data.result;
-        res.error = res.output.data.error;
-      }
-      return res;
+
     }
     else {
       return res;
@@ -4957,11 +4955,12 @@ module.exports = {
   /**
    *
    * @description Validates the input for multi file APIs
-   * @param {string} processInput - Process input data
+   * @param {object} processInput - Process input data
+   * @param {boolean} bundleProcess - Wheter the process input corresponds to bundel process
    *
    * @returns {undefined} - nothing
    */
-  validateInputMultiFileAPI(processInput) {
+  validateInputMultiFileAPI(processInput, bundleProcess = false) {
     if (_.isEmpty(processInput)) {
       throw new Error('Input object must have "type" and "data" information');
     }
@@ -4973,6 +4972,9 @@ module.exports = {
     }
     if (processInput.data[0].path === '') {
       throw new Error('"Path" of the data element should be provided');
+    }
+    if (bundleProcess && (!processInput.rootFiles || processInput.rootFiles.length === 0)) {
+      throw new Error('"RootFiles" parameter should be provided');
     }
   }
 };

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -698,21 +698,7 @@ class SchemaPack {
   async bundle() {
     const input = this.input;
 
-    schemaUtils.validateInputMultiFileAPI(input);
-    if (!input.rootFiles || input.rootFiles.length === 0) {
-      let rootFiles = await this.detectRootFiles(input);
-      if (rootFiles.output.data) {
-        let inputContent = [];
-        rootFiles.output.data.forEach((rootFile) => {
-          let founInData = input.data.find((dataFile) => { return dataFile.fileName === rootFile.path; });
-          if (founInData) {
-            inputContent.push({ fileName: founInData.fileName, content: founInData.content });
-          }
-        });
-        input.rootFiles = inputContent;
-        return schemaUtils.processRelatedFiles(input, true);
-      }
-    }
+    schemaUtils.validateInputMultiFileAPI(input, true);
     let adaptedRootFiles = input.rootFiles.map((rootFile) => {
       return { fileName: rootFile.path, content: rootFile.content };
     });

--- a/test/unit/bundle.test.js
+++ b/test/unit/bundle.test.js
@@ -419,12 +419,14 @@ describe('bundle files method - 3.0', function () {
           }
         ]
       };
-    const res = await Converter.bundle(input);
-    expect(res).to.not.be.empty;
-    expect(res.result).to.be.false;
-    expect(res.reason).to.equal('Invalid format. Input must be in YAML or JSON ' +
-      'format. Specification is not a valid YAML. YAMLException: duplicated mapping' +
-      ' key at line 30, column -54:\n    components:\n    ^');
+    try {
+      await Converter.bundle(input);
+    }
+    catch (error) {
+      expect(error.message).to.equal('Invalid format. Input must be in YAML or JSON ' +
+        'format. Specification is not a valid YAML. YAMLException: duplicated mapping' +
+        ' key at line 30, column -54:\n    components:\n    ^');
+    }
   });
 
   it('Should return bundled file from same_ref_different_source', async function () {
@@ -828,6 +830,35 @@ describe('bundle files method - 3.0', function () {
     catch (error) {
       expect(error).to.not.be.undefined;
       expect(error.message).to.equal('Input object must have "type" and "data" information');
+    }
+  });
+
+  it('should return error when input has no root files', async function () {
+    let contentRootFile = fs.readFileSync(refExample + '/root.yaml', 'utf8'),
+      input = {
+        type: 'folder',
+        specificationVersion: '3.0',
+        rootFiles: [],
+        data: [
+          {
+            path: '/root.yaml',
+            content: contentRootFile
+          },
+          {
+            path: '/root.yaml',
+            content: contentRootFile
+          }
+
+        ],
+        options: {},
+        bundleFormat: 'JSON'
+      };
+    try {
+      await Converter.bundle(input);
+    }
+    catch (error) {
+      expect(error).to.not.be.undefined;
+      expect(error.message).to.equal('"RootFiles" parameter should be provided');
     }
   });
 });


### PR DESCRIPTION
Propagate error when there are no root files instead of running the process of "getRelatedFiles"
Avoid returning result = true when data in output is an undefined or empty array.