### PR TITLE
Fix input validation in multi file APIs

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -4921,26 +4921,23 @@ module.exports = {
       try {
         res.output.data = this.mapProcessRelatedFiles(inputRelatedFiles.rootFiles, inputRelatedFiles.data,
           inputRelatedFiles.origin, version, inputRelatedFiles.bundleFormat, toBundle);
+        if (res.output.data === undefined || res.output.data.result === false ||
+          res.output.data.length === 0) {
+          res.result = false;
+        }
       }
       catch (error) {
         if (error instanceof ParseError) {
-          return {
-            result: false,
-            reason: error.message
-          };
-        }
-        else {
           throw (error);
         }
-      }
-      if (res.output.data.result === false) {
-        res.result = res.output.data.result;
-        res.error = res.output.data.error;
+        let newError = new Error('There was an error during the process');
+        newError.stack = error.stack;
+        throw (newError);
       }
       return res;
     }
     else {
-      return res;
+      throw new Error('Input should have at least one root file');
     }
   },
 

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -4815,6 +4815,16 @@ module.exports = {
     };
   },
 
+  /**
+   *
+   * @description Takes in a the root files obtains the related files and
+   * generates the result object
+   * @param {object} parsedRootFiles - found parsed root files
+   * @param {array} inputData - file data information [{path, content}]
+   * @param {Array} origin - process origin (BROWSER or node)
+   *
+   * @returns {object} process result { rootFile, relatedFiles, missingRelatedFiles }
+   */
   getRelatedFilesData(parsedRootFiles, inputData, origin) {
     const data = parsedRootFiles.map((root) => {
       let relatedData = getRelatedFiles(root, inputData, origin),
@@ -4828,6 +4838,17 @@ module.exports = {
     return data;
   },
 
+  /*
+   *
+   * @description Takes in parsed root files and bundle it
+   * @param {object} parsedRootFiles - found parsed root files
+   * @param {array} inputData - file data information [{path, content}]
+   * @param {Array} origin - process origin (BROWSER or node)
+   * @param {string} format - output format could be either YAML or JSON
+   * @param {string} version - specification version specified in the input
+   *
+   * @returns {object} process result { rootFile, bundledContent }
+   */
   getBundledFileData(parsedRootFiles, inputData, origin, format) {
     const data = parsedRootFiles.map((root) => {
       let bundleData = getBundleContentAndComponents(root, inputData, origin);
@@ -4920,6 +4941,28 @@ module.exports = {
     }
     else {
       return res;
+    }
+  },
+
+  /**
+   *
+   * @description Validates the input for multi file APIs
+   * @param {string} processInput - Process input data
+   *
+   * @returns {undefined} - nothing
+   */
+  validateInputMultiFileAPI(processInput) {
+    if (_.isEmpty(processInput)) {
+      throw new Error('Input object must have "type" and "data" information');
+    }
+    if (!processInput.type) {
+      throw new Error('"Type" parameter should be provided');
+    }
+    if (!processInput.data || processInput.data.length === 0) {
+      throw new Error('"Data" parameter should be provided');
+    }
+    if (processInput.data[0].path === '') {
+      throw new Error('"Path" of the data element should be provided');
     }
   },
 

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -629,10 +629,8 @@ class SchemaPack {
    */
   async detectRootFiles() {
     const input = this.input;
-    if (input.data[0].path === '') {
-      throw new Error('undefined input');
-    }
 
+    schemaUtils.validateInputMultiFileAPI(input);
     if (!this.hasDefinedVersion && ('content' in input.data[0])) {
       return schemaUtils.mapGetRootFilesOutputToDetectRootFilesOutput([], input.specificationVersion);
     }
@@ -668,6 +666,8 @@ class SchemaPack {
    */
   async detectRelatedFiles() {
     const input = this.input;
+
+    schemaUtils.validateInputMultiFileAPI(input);
     if (!input.rootFiles || input.rootFiles.length === 0) {
       let rootFiles = await this.detectRootFiles(input);
       if (rootFiles.output.data) {
@@ -698,6 +698,8 @@ class SchemaPack {
    */
   async bundle() {
     const input = this.input;
+
+    schemaUtils.validateInputMultiFileAPI(input);
     if (!input.rootFiles || input.rootFiles.length === 0) {
       let rootFiles = await this.detectRootFiles(input);
       if (rootFiles.output.data) {

--- a/test/unit/bundle.test.js
+++ b/test/unit/bundle.test.js
@@ -806,4 +806,50 @@ describe('getReferences method when node does not have any reference', function(
     expect(result.referencesInNode[0].path).to.equal('./user.yaml');
     expect(result.referencesInNode[0].newValue.$ref).to.equal('the/parent/user.yaml');
   });
+
+  it('should return error when "type" parameter is not sent', async function () {
+    let input = {
+      rootFiles: [
+        {
+          path: '/root.yaml',
+          content: ''
+        }
+      ],
+      data: [
+        {
+          path: '/examples.yaml',
+          content: ''
+        }
+      ],
+      options: {},
+      bundleFormat: 'JSON'
+    };
+    try {
+      await Converter.bundle(input);
+    }
+    catch (error) {
+      expect(error).to.not.be.undefined;
+      expect(error.message).to.equal('"Type" parameter should be provided');
+    }
+  });
+
+  it('should return error when input is an empty object', async function () {
+    try {
+      await Converter.bundle({});
+    }
+    catch (error) {
+      expect(error).to.not.be.undefined;
+      expect(error.message).to.equal('Input object must have "type" and "data" information');
+    }
+  });
+
+  it('should return error when input data is an empty array', async function () {
+    try {
+      await Converter.bundle({ type: 'folder', data: [] });
+    }
+    catch (error) {
+      expect(error).to.not.be.undefined;
+      expect(error.message).to.equal('"Data" parameter should be provided');
+    }
+  });
 });

--- a/test/unit/detectRelatedFiles.test.js
+++ b/test/unit/detectRelatedFiles.test.js
@@ -139,8 +139,7 @@ describe('detectRelatedFiles method', function () {
             content: contentFileMissedRef
           }
         ],
-        data: [
-        ]
+        data: [{}]
       },
       res = await Converter.detectRelatedFiles(input);
     expect(res).to.not.be.empty;
@@ -242,8 +241,7 @@ describe('detectRelatedFiles method', function () {
             content: contentFileHop
           }
         ],
-        data: [
-        ]
+        data: [{}]
       };
     const res = await Converter.detectRelatedFiles(input);
     expect(res).to.not.be.empty;
@@ -266,8 +264,7 @@ describe('detectRelatedFiles method', function () {
             content: contentFileHop
           }
         ],
-        data: [
-        ]
+        data: [{}]
       };
     const res = await Converter.detectRelatedFiles(input);
     expect(res).to.not.be.empty;
@@ -286,8 +283,7 @@ describe('detectRelatedFiles method', function () {
             content: contentFile
           }
         ],
-        data: [
-        ]
+        data: [{}]
       };
     const res = await Converter.detectRelatedFiles(input);
     expect(res).to.not.be.empty;
@@ -368,4 +364,50 @@ describe('detectRelatedFiles method', function () {
     expect(res.output.data[0].missingRelatedFiles.length).to.equal(6);
   });
 
+  it('should return error when "type" parameter is not sent', async function () {
+    let contentRootFile = fs.readFileSync(petstoreMultipleFiles, 'utf8'),
+      contentFileResPets = fs.readFileSync(resourcesPets, 'utf8'),
+      input = {
+        rootFiles: [
+          {
+            path: '/openapi.yaml',
+            content: contentRootFile
+          }
+        ],
+        data: [
+          {
+            path: '/resources/pets.yaml',
+            content: contentFileResPets
+          }
+        ]
+      };
+
+    try {
+      await Converter.detectRelatedFiles(input);
+    }
+    catch (error) {
+      expect(error).to.not.be.undefined;
+      expect(error.message).to.equal('"Type" parameter should be provided');
+    }
+  });
+
+  it('should return error when input is an empty object', async function () {
+    try {
+      await Converter.detectRelatedFiles({});
+    }
+    catch (error) {
+      expect(error).to.not.be.undefined;
+      expect(error.message).to.equal('Input object must have "type" and "data" information');
+    }
+  });
+
+  it('should return error when input data is an empty array', async function () {
+    try {
+      await Converter.detectRelatedFiles({ type: 'folder', data: [] });
+    }
+    catch (error) {
+      expect(error).to.not.be.undefined;
+      expect(error.message).to.equal('"Data" parameter should be provided');
+    }
+  });
 });

--- a/test/unit/detectRelatedFiles.test.js
+++ b/test/unit/detectRelatedFiles.test.js
@@ -30,7 +30,7 @@ let expect = require('chai').expect,
 
 describe('detectRelatedFiles method', function () {
 
-  it('should return empty data when there is no root in the entry', async function () {
+  it('should return error when there is no root in the entry', async function () {
     let contentFile = fs.readFileSync(petstoreSeparatedPet, 'utf8'),
       input = {
         type: 'folder',
@@ -44,10 +44,12 @@ describe('detectRelatedFiles method', function () {
           }
         ]
       };
-    const res = await Converter.detectRelatedFiles(input);
-    expect(res).to.not.be.empty;
-    expect(res.result).to.be.true;
-    expect(res.output.data.length).to.equal(0);
+    try {
+      await Converter.detectRelatedFiles(input);
+    }
+    catch (error) {
+      expect(error.message).to.equal('Input should have at least one root file');
+    }
   });
 
   it('should locate root and return empty data when there is no ref', async function () {

--- a/test/unit/detectRoot.test.js
+++ b/test/unit/detectRoot.test.js
@@ -218,7 +218,7 @@ describe('detectRoot method', function() {
       await Converter.detectRootFiles(input);
     }
     catch (ex) {
-      expect(ex.message).to.equal('undefined input');
+      expect(ex.message).to.equal('"Path" of the data element should be provided');
     }
   });
 
@@ -264,6 +264,47 @@ describe('detectRoot method', function() {
     expect(res.result).to.be.true;
     expect(res.output.data[0].path).to.equal(validHopService31x);
 
+  });
+
+  it('should return error when "type" parameter is not sent', async function () {
+    let input = {
+      data: [
+        {
+          path: validPetstore
+        },
+        {
+          path: validHopService31x
+        }
+      ]
+    };
+
+    try {
+      await Converter.detectRootFiles(input);
+    }
+    catch (error) {
+      expect(error).to.not.be.undefined;
+      expect(error.message).to.equal('"Type" parameter should be provided');
+    }
+  });
+
+  it('should return error when input is an empty object', async function () {
+    try {
+      await Converter.detectRootFiles({});
+    }
+    catch (error) {
+      expect(error).to.not.be.undefined;
+      expect(error.message).to.equal('Input object must have "type" and "data" information');
+    }
+  });
+
+  it('should return error when input data is an empty array', async function () {
+    try {
+      await Converter.detectRootFiles({ type: 'folder', data: [] });
+    }
+    catch (error) {
+      expect(error).to.not.be.undefined;
+      expect(error.message).to.equal('"Data" parameter should be provided');
+    }
   });
 
 });


### PR DESCRIPTION
 Fixed multi-file support issues:

**1. Providing no type parameter to APIs still returns result. (Also for other apis like detectRoot and related APIs)**

- Appropriate error message should be provided.

**2. Providing no data to APIs throws type error**

- Appropriate error message should be provided.

**3. Providing empty array as data to APIs throws type error**

- Appropriate error message should be provided.

**4. Multiple files in data with no root files**

- We should not provide result if there is no root files found and should provide an appropriate error message.

