### PR TITLE
Feat/add root detection again

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -402,7 +402,8 @@ module.exports = {
     generateComponentsObject(rootContextData, rootContextData.nodeContents[specRoot.fileName], isExtRef, components);
     return {
       fileContent: rootContextData.nodeContents[specRoot.fileName],
-      components
+      components,
+      fileName: specRoot.fileName
     };
   },
   getReferences

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -4839,8 +4839,32 @@ module.exports = {
     return data;
   },
 
+  /**
+   * Maps the output for each bundled root file
+   * @param {object} format - defined output format from options
+   * @param {string} parsedRootFiles - specified version of the process
+   * @returns {object} -  { rootFile: { path }, bundledContent }
+   */
+  mapBundleOutput(format, parsedRootFiles) {
+    return (contentAndComponents) => {
+      let bundledFile = contentAndComponents.fileContent;
+      bundledFile.components = contentAndComponents.components;
+      if (!format) {
+        let rootFormat = parsedRootFiles.find((inputRoot) => {
+          return inputRoot.fileName === contentAndComponents.fileName;
+        }).parsed.inputFormat;
+        if (rootFormat.toLowerCase() === parse.YAML_FORMAT) {
+          bundledFile = parse.toYAML(bundledFile);
+        }
+      }
+      else if (format.toLowerCase() === parse.YAML_FORMAT) {
+        bundledFile = parse.toYAML(bundledFile);
+      }
+      return { rootFile: { path: parsedRootFiles[0].fileName }, bundledContent: bundledFile };
+    };
+  },
+
   /*
-   *
    * @description Takes in parsed root files and bundle it
    * @param {object} parsedRootFiles - found parsed root files
    * @param {array} inputData - file data information [{path, content}]
@@ -4856,14 +4880,7 @@ module.exports = {
       return bundleData;
     });
 
-    let bundleData = data.map((contentAndComponents) => {
-      let bundledFile = contentAndComponents.fileContent;
-      bundledFile.components = contentAndComponents.components;
-      if (format === parse.YAML_FORMAT) {
-        bundledFile = parse.toYAML(bundledFile);
-      }
-      return { rootFile: { path: parsedRootFiles[0].fileName }, bundledContent: bundledFile };
-    });
+    let bundleData = data.map(this.mapBundleOutput(format, parsedRootFiles));
 
     return bundleData;
   },
@@ -4887,11 +4904,11 @@ module.exports = {
         let parsedContent = this.parseFileOrThrow(rootFile.content);
         return { fileName: rootFile.fileName, content: rootFile.content, parsed: parsedContent };
       }).filter((rootWithParsedContent) => {
-        bundleFormat = bundleFormat ? bundleFormat : rootWithParsedContent.parsed.inputFormat;
+        // bundleFormat = bundleFormat ? bundleFormat : rootWithParsedContent.parsed.inputFormat;
         return compareVersion(version, rootWithParsedContent.parsed.oasObject.openapi);
       }),
       data = toBundle ?
-        this.getBundledFileData(parsedRootFiles, inputData, origin, bundleFormat.toLowerCase()) :
+        this.getBundledFileData(parsedRootFiles, inputData, origin, bundleFormat) :
         this.getRelatedFilesData(parsedRootFiles, inputData, origin);
     return data;
 

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -4904,7 +4904,6 @@ module.exports = {
         let parsedContent = parseFileOrThrow(rootFile.content);
         return { fileName: rootFile.fileName, content: rootFile.content, parsed: parsedContent };
       }).filter((rootWithParsedContent) => {
-        // bundleFormat = bundleFormat ? bundleFormat : rootWithParsedContent.parsed.inputFormat;
         return compareVersion(version, rootWithParsedContent.parsed.oasObject.openapi);
       }),
       data = toBundle ?

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -669,7 +669,18 @@ class SchemaPack {
 
     schemaUtils.validateInputMultiFileAPI(input);
     if (!input.rootFiles || input.rootFiles.length === 0) {
-      throw new Error('Input should have at least one root file');
+      let rootFiles = await this.detectRootFiles(input);
+      if (rootFiles.output.data) {
+        let inputContent = [];
+        rootFiles.output.data.forEach((rootFile) => {
+          let founInData = input.data.find((dataFile) => { return dataFile.fileName === rootFile.path; });
+          if (founInData) {
+            inputContent.push({ fileName: founInData.fileName, content: founInData.content });
+          }
+        });
+        input.rootFiles = inputContent;
+        return schemaUtils.processRelatedFiles(input);
+      }
     }
 
     let adaptedRootFiles = input.rootFiles.map((rootFile) => {
@@ -699,7 +710,18 @@ class SchemaPack {
     const input = this.input;
     schemaUtils.validateInputMultiFileAPI(input);
     if (!input.rootFiles || input.rootFiles.length === 0) {
-      throw new Error('Input should have at least one root file');
+      let rootFiles = await this.detectRootFiles(input);
+      if (rootFiles.output.data) {
+        let inputContent = [];
+        rootFiles.output.data.forEach((rootFile) => {
+          let founInData = input.data.find((dataFile) => { return dataFile.fileName === rootFile.path; });
+          if (founInData) {
+            inputContent.push({ fileName: founInData.fileName, content: founInData.content });
+          }
+        });
+        input.rootFiles = inputContent;
+        return schemaUtils.processRelatedFiles(input, true);
+      }
     }
     let adaptedRootFiles = input.rootFiles.map((rootFile) => {
       let foundInData = input.data.find((file) => { return file.fileName === rootFile.path; });

--- a/test/data/toBundleExamples/schema_from_response/root.json
+++ b/test/data/toBundleExamples/schema_from_response/root.json
@@ -1,0 +1,37 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Sample API",
+    "description": "Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.",
+    "version": "0.1.9"
+  },
+  "servers": [
+    {
+      "url": "http://api.example.com/v1",
+      "description": "Optional server description, e.g. Main (production) server"
+    },
+    {
+      "url": "http://staging-api.example.com",
+      "description": "Optional server description, e.g. Internal staging server for testing"
+    }
+  ],
+  "paths": {
+    "/users/{userId}": {
+      "get": {
+        "summary": "Get a user by ID",
+        "responses": {
+          "200": {
+            "description": "A single user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./schemas/user.yaml"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/unit/bundle.test.js
+++ b/test/unit/bundle.test.js
@@ -872,7 +872,7 @@ describe('bundle files method - 3.0', function () {
     expect(JSON.stringify(res.output.data[0].bundledContent, null, 2)).to.be.equal(expected);
   });
 
-  it('Should throw error when root files is undefinied and in data there is no root file', async function () {
+  it('Should throw error when root files is undefined and in data there is no root file', async function () {
     let user = fs.readFileSync(schemaFromResponse + '/schemas/user.yaml', 'utf8'),
       input = {
         type: 'multiFile',

--- a/test/unit/bundle.test.js
+++ b/test/unit/bundle.test.js
@@ -826,8 +826,14 @@ describe('bundle files method - 3.0', function () {
     expect(JSON.stringify(res.output.data[0].bundledContent, null, 2)).to.be.equal(expected);
   });
 
-  it('Should throw error when root files is undefined', async function () {
+  it('Should take the root file from data array root file prop undefined', async function () {
     let contentRootFile = fs.readFileSync(sameRefDiffSource + '/root.yaml', 'utf8'),
+      user = fs.readFileSync(sameRefDiffSource + '/schemas/user/user.yaml', 'utf8'),
+      client = fs.readFileSync(sameRefDiffSource + '/schemas/client/client.yaml', 'utf8'),
+      specialUser = fs.readFileSync(sameRefDiffSource + '/schemas/user/special.yaml', 'utf8'),
+      specialClient = fs.readFileSync(sameRefDiffSource + '/schemas/client/special.yaml', 'utf8'),
+      magic = fs.readFileSync(sameRefDiffSource + '/schemas/client/magic.yaml', 'utf8'),
+      expected = fs.readFileSync(sameRefDiffSource + '/expected.json', 'utf8'),
       input = {
         type: 'multiFile',
         specificationVersion: '3.0',
@@ -835,6 +841,46 @@ describe('bundle files method - 3.0', function () {
           {
             path: '/root.yaml',
             content: contentRootFile
+          },
+          {
+            path: '/schemas/user/user.yaml',
+            content: user
+          },
+          {
+            path: '/schemas/user/special.yaml',
+            content: specialUser
+          },
+          {
+            path: '/schemas/client/client.yaml',
+            content: client
+          },
+          {
+            path: '/schemas/client/special.yaml',
+            content: specialClient
+          },
+          {
+            path: '/schemas/client/magic.yaml',
+            content: magic
+          }
+        ],
+        options: {},
+        bundleFormat: 'JSON'
+      };
+    const res = await Converter.bundle(input);
+    expect(res).to.not.be.empty;
+    expect(res.result).to.be.true;
+    expect(JSON.stringify(res.output.data[0].bundledContent, null, 2)).to.be.equal(expected);
+  });
+
+  it('Should throw error when root files is undefinied and in data there is no root file', async function () {
+    let user = fs.readFileSync(schemaFromResponse + '/schemas/user.yaml', 'utf8'),
+      input = {
+        type: 'multiFile',
+        specificationVersion: '3.0',
+        data: [
+          {
+            path: '/schemas/user.yaml',
+            content: user
           }
         ],
         options: {},
@@ -849,7 +895,54 @@ describe('bundle files method - 3.0', function () {
     }
   });
 
-  it('Should throw error when root files is empty array', async function () {
+  it('Should take the root file from data array root file prop empty array', async function () {
+    let contentRootFile = fs.readFileSync(sameRefDiffSource + '/root.yaml', 'utf8'),
+      user = fs.readFileSync(sameRefDiffSource + '/schemas/user/user.yaml', 'utf8'),
+      client = fs.readFileSync(sameRefDiffSource + '/schemas/client/client.yaml', 'utf8'),
+      specialUser = fs.readFileSync(sameRefDiffSource + '/schemas/user/special.yaml', 'utf8'),
+      specialClient = fs.readFileSync(sameRefDiffSource + '/schemas/client/special.yaml', 'utf8'),
+      magic = fs.readFileSync(sameRefDiffSource + '/schemas/client/magic.yaml', 'utf8'),
+      expected = fs.readFileSync(sameRefDiffSource + '/expected.json', 'utf8'),
+      input = {
+        type: 'multiFile',
+        specificationVersion: '3.0',
+        rootFiles: [],
+        data: [
+          {
+            path: '/root.yaml',
+            content: contentRootFile
+          },
+          {
+            path: '/schemas/user/user.yaml',
+            content: user
+          },
+          {
+            path: '/schemas/user/special.yaml',
+            content: specialUser
+          },
+          {
+            path: '/schemas/client/client.yaml',
+            content: client
+          },
+          {
+            path: '/schemas/client/special.yaml',
+            content: specialClient
+          },
+          {
+            path: '/schemas/client/magic.yaml',
+            content: magic
+          }
+        ],
+        options: {},
+        bundleFormat: 'JSON'
+      };
+    const res = await Converter.bundle(input);
+    expect(res).to.not.be.empty;
+    expect(res.result).to.be.true;
+    expect(JSON.stringify(res.output.data[0].bundledContent, null, 2)).to.be.equal(expected);
+  });
+
+  it('Should throw error when root files is empty array and in data there is no root file', async function () {
     let user = fs.readFileSync(schemaFromResponse + '/schemas/user.yaml', 'utf8'),
       input = {
         type: 'multiFile',

--- a/test/unit/detectRelatedFiles.test.js
+++ b/test/unit/detectRelatedFiles.test.js
@@ -489,4 +489,44 @@ describe('detectRelatedFiles method', function () {
     expect(res.output.data[0].rootFile.path).to.equal('/petstore.yaml');
     expect(res.output.data.length).to.equal(1);
   });
+
+  it('Should take the root file from data array root file prop empty array', async function () {
+    let contentFile = fs.readFileSync(swaggerRoot, 'utf8'),
+      input = {
+        type: 'multiFile',
+        specificationVersion: '3.0',
+        rootFiles: [
+        ],
+        data: [
+          {
+            path: '/swagger.yaml',
+            content: contentFile
+          }
+        ]
+      };
+    const res = await Converter.detectRelatedFiles(input);
+    expect(res).to.not.be.empty;
+    expect(res.result).to.be.true;
+    expect(res.output.data[0].rootFile.path).to.equal('/swagger.yaml');
+    expect(res.output.data.length).to.equal(1);
+  });
+
+  it('Should take the root file from data array root file prop undefined', async function () {
+    let contentFile = fs.readFileSync(swaggerRoot, 'utf8'),
+      input = {
+        type: 'multiFile',
+        specificationVersion: '3.0',
+        data: [
+          {
+            path: '/swagger.yaml',
+            content: contentFile
+          }
+        ]
+      };
+    const res = await Converter.detectRelatedFiles(input);
+    expect(res).to.not.be.empty;
+    expect(res.result).to.be.true;
+    expect(res.output.data[0].rootFile.path).to.equal('/swagger.yaml');
+    expect(res.output.data.length).to.equal(1);
+  });
 });


### PR DESCRIPTION
Add the root location using detectRootFiles API,
If the root files input is undefined or an empty array we will look for the root files using the API. If after searching for the root files using the API still no root files present then we throw an error.