### PR TITLE
Don't throw error in `detectRootFiles` if function if supplied with an invalid file.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -124,7 +124,8 @@ module.exports = {
           oasObject = obj.oasObject;
         }
         else {
-          throw new Error(obj.reason);
+          // Ignore this file. 
+          return;
         }
         if (inputValidation.validateSpec(oasObject, options).result) {
           if (specificationVersion) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -124,7 +124,7 @@ module.exports = {
           oasObject = obj.oasObject;
         }
         else {
-          // Ignore this file. 
+          // Ignore this file.
           return;
         }
         if (inputValidation.validateSpec(oasObject, options).result) {


### PR DESCRIPTION
In the app we send all the user uploaded files to `detectRootFiles` function, some of which can be invalid. The function should not throw an error for them, instead just silently ignore them.