### PR TITLE
Add a reference map to bundle output

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -22,3 +22,4 @@ allowUrlPathVarMatching|boolean|-|false|Whether to allow matching path variables
 disableOptionalParameters|boolean|-|false|Whether to set optional parameters as disabled|CONVERSION
 keepImplicitHeaders|boolean|-|false|Whether to keep implicit headers from the OpenAPI specification, which are removed by default.|CONVERSION
 includeWebhooks|boolean|-|false|Select whether to include Webhooks in the generated collection|CONVERSION
+includeReferenceMap|boolean|-|false|Whether or not to include reference map or not as part of output|BUNDLE

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const SchemaPack = require('./lib/schemapack.js').SchemaPack;
+const _ = require('lodash'),
+  SchemaPack = require('./lib/schemapack.js').SchemaPack;
 
 module.exports = {
   // Old API wrapping the new API
@@ -43,7 +44,7 @@ module.exports = {
   },
 
   bundle: async function(input) {
-    var schema = new SchemaPack(input);
+    var schema = new SchemaPack(input, _.has(input, 'options') ? input.options : {});
     return schema.bundle();
   },
 

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -1,4 +1,5 @@
-const {
+const _ = require('lodash'),
+  {
     isExtRef,
     getKeyInComponents,
     getJsonPointerRelationToRoot,
@@ -10,8 +11,8 @@ const {
   } = require('./jsonPointer'),
   traverseUtility = require('traverse'),
   parse = require('./parse.js'),
-  { ParseError } = require('./common/ParseError');
-const { getBundleRulesDataByVersion } = require('./common/versionUtils');
+  { ParseError } = require('./common/ParseError'),
+  { getBundleRulesDataByVersion } = require('./common/versionUtils');
 
 let path = require('path'),
   pathBrowserify = require('path-browserify'),
@@ -414,16 +415,20 @@ function generateComponentsWrapper(parsedOasObject) {
 }
 
 /**
+ *
  * Generates a map of generated refernce to the original reference
- * @param {object} globalReferences
- * @returns {object}
+ *
+ * @param {object} globalReferences - Global references present at each root file context
+ * @returns {object} referncce map
  */
 function getReferenceMap(globalReferences) {
   const output = {};
-  for (const key in globalReferences) {
-    const value = globalReferences[key];
-    output[value.reference] = key;
-  }
+
+  _.forEach(globalReferences, (globalReference, refKey) => {
+    if (_.isString(refKey) && _.isString(globalReference.reference)) {
+      output[globalReference.reference] = refKey;
+    }
+  });
 
   return output;
 }

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -413,6 +413,21 @@ function generateComponentsWrapper(parsedOasObject) {
   return components;
 }
 
+/**
+ * Generates a map of generated refernce to the original reference
+ * @param {object} globalReferences
+ * @returns {object}
+ */
+function getReferenceMap(globalReferences) {
+  const output = {};
+  for (const key in globalReferences) {
+    const value = globalReferences[key];
+    output[value.reference] = key;
+  }
+
+  return output;
+}
+
 module.exports = {
   /**
    * Takes in an spec root file and an array of data files
@@ -445,7 +460,8 @@ module.exports = {
     return {
       fileContent: rootContextData.nodeContents[specRoot.fileName],
       components,
-      fileName: specRoot.fileName
+      fileName: specRoot.fileName,
+      referenceMap: getReferenceMap(rootContextData.globalReferences)
     };
   },
   getReferences,

--- a/lib/options.js
+++ b/lib/options.js
@@ -298,6 +298,16 @@ module.exports = {
         external: false,
         usage: ['CONVERSION'],
         supportedIn: [VERSION31]
+      },
+      {
+        name: 'Include Reference map',
+        id: 'includeReferenceMap',
+        type: 'boolean',
+        default: false,
+        description: 'Whether or not to include reference map or not as part of output',
+        external: false,
+        usage: ['BUNDLE'],
+        supportedIn: [VERSION20, VERSION30, VERSION31]
       }
     ];
 

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -4843,11 +4843,14 @@ module.exports = {
    * Maps the output for each bundled root file
    * @param {object} format - defined output format from options
    * @param {string} parsedRootFiles - specified version of the process
+   * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
    * @returns {object} -  { rootFile: { path }, bundledContent }
    */
-  mapBundleOutput(format, parsedRootFiles) {
+  mapBundleOutput(format, parsedRootFiles, options = {}) {
     return (contentAndComponents) => {
-      let bundledFile = contentAndComponents.fileContent;
+      let bundledFile = contentAndComponents.fileContent,
+        bundleOutput;
+
       bundledFile.components = contentAndComponents.components;
       if (!format) {
         let rootFormat = parsedRootFiles.find((inputRoot) => {
@@ -4866,11 +4869,16 @@ module.exports = {
       else if (format.toLowerCase() === parse.JSON_FORMAT) {
         bundledFile = parse.toJSON(bundledFile, null);
       }
-      return {
+
+      bundleOutput = {
         rootFile: { path: contentAndComponents.fileName },
-        bundledContent: bundledFile,
-        referenceMap: contentAndComponents.referenceMap
+        bundledContent: bundledFile
       };
+
+      if (options.includeReferenceMap) {
+        bundleOutput.referenceMap = contentAndComponents.referenceMap;
+      }
+      return bundleOutput;
     };
   },
 
@@ -4881,16 +4889,17 @@ module.exports = {
    * @param {Array} origin - process origin (BROWSER or node)
    * @param {string} format - output format could be either YAML or JSON
    * @param {string} version - specification version specified in the input
+   * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
    *
    * @returns {object} process result { rootFile, bundledContent }
    */
-  getBundledFileData(parsedRootFiles, inputData, origin, format, version) {
+  getBundledFileData(parsedRootFiles, inputData, origin, format, version, options = {}) {
     const data = parsedRootFiles.map((root) => {
       let bundleData = getBundleContentAndComponents(root, inputData, origin, version);
       return bundleData;
     });
 
-    let bundleData = data.map(this.mapBundleOutput(format, parsedRootFiles));
+    let bundleData = data.map(this.mapBundleOutput(format, parsedRootFiles, options));
 
     return bundleData;
   },
@@ -4905,10 +4914,11 @@ module.exports = {
    * @param {string} version -  process specification version
    * @param {string} format - the format required by the user
    * @param {boolean} toBundle - if it will be used in bundle
+   * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
    *
    * @returns {object} root files information and data input
    */
-  mapProcessRelatedFiles(rootFiles, inputData, origin, version, format, toBundle = false) {
+  mapProcessRelatedFiles(rootFiles, inputData, origin, version, format, toBundle = false, options = {}) {
     let bundleFormat = format,
       parsedRootFiles = rootFiles.map((rootFile) => {
         let parsedContent = parseFileOrThrow(rootFile.content);
@@ -4920,7 +4930,7 @@ module.exports = {
         return compareVersion(version, fileVersion);
       }),
       data = toBundle ?
-        this.getBundledFileData(parsedRootFiles, inputData, origin, bundleFormat, version) :
+        this.getBundledFileData(parsedRootFiles, inputData, origin, bundleFormat, version, options) :
         this.getRelatedFilesData(parsedRootFiles, inputData, origin);
     return data;
 
@@ -4932,10 +4942,11 @@ module.exports = {
    * root file perspective (using $ref property)
    * @param {string} inputRelatedFiles - {rootFile:{path:string}, data: [{path:string}]}
    * @param {boolean} toBundle - if true it will return the bundle data
+   * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
    *
    * @returns {object} root files information and data input
    */
-  processRelatedFiles(inputRelatedFiles, toBundle = false) {
+  processRelatedFiles(inputRelatedFiles, toBundle = false, options = {}) {
     let version = inputRelatedFiles.specificationVersion ? inputRelatedFiles.specificationVersion : '3.0',
       res = {
         result: true,
@@ -4952,7 +4963,7 @@ module.exports = {
     if (inputRelatedFiles.rootFiles && inputRelatedFiles.rootFiles.length > 0) {
       try {
         res.output.data = this.mapProcessRelatedFiles(inputRelatedFiles.rootFiles, inputRelatedFiles.data,
-          inputRelatedFiles.origin, version, inputRelatedFiles.bundleFormat, toBundle);
+          inputRelatedFiles.origin, version, inputRelatedFiles.bundleFormat, toBundle, options);
         if (res.output.data === undefined || res.output.data.result === false ||
           res.output.data.length === 0) {
           res.result = false;

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -4860,7 +4860,11 @@ module.exports = {
       else if (format.toLowerCase() === parse.YAML_FORMAT) {
         bundledFile = parse.toYAML(bundledFile);
       }
-      return { rootFile: { path: contentAndComponents.fileName }, bundledContent: bundledFile };
+      return {
+        rootFile: { path: contentAndComponents.fileName },
+        bundledContent: bundledFile,
+        referenceMap: contentAndComponents.referenceMap
+      };
     };
   },
 

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -698,7 +698,6 @@ class SchemaPack {
     return schemaUtils.processRelatedFiles(input);
   }
 
-
   /**
    *
    * @description Takes in a folder and identifies the related files from the
@@ -734,7 +733,7 @@ class SchemaPack {
       throw new Error('Root file content not found in data array');
     }
     input.rootFiles = adaptedRootFiles;
-    return schemaUtils.processRelatedFiles(input, true);
+    return schemaUtils.processRelatedFiles(input, true, this.computedOptions);
   }
 }
 

--- a/test/system/structure.test.js
+++ b/test/system/structure.test.js
@@ -180,6 +180,14 @@ const optionIds = [
       default: false,
       description: 'Whether to allow matching path variables that are available as part of URL itself ' +
         'in the collection request'
+    },
+    includeReferenceMap: {
+      name: 'Include Reference map',
+      type: 'boolean',
+      default: false,
+      description: 'Whether or not to include reference map or not as part of output',
+      external: false,
+      usage: ['BUNDLE']
     }
   };
 

--- a/test/system/structure.test.js
+++ b/test/system/structure.test.js
@@ -25,7 +25,8 @@ const optionIds = [
     'disableOptionalParameters',
     'keepImplicitHeaders',
     'includeWebhooks',
-    'allowUrlPathVarMatching'
+    'allowUrlPathVarMatching',
+    'includeReferenceMap'
   ],
   expectedOptions = {
     collapseFolders: {


### PR DESCRIPTION
This adds a new field `referenceMap` to the bundle output. This is needed to resolve validation errors to specific files and line numbers.