### PR TITLE
Adding fix to issue 14

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -481,7 +481,11 @@ function generateComponentsObject (documentContext, rootContent, refTypeResolver
             }
           }
           if (refData.inline) {
-            refData.node = refData.nodeContent;
+            let referenceSiblings = _.omit(property, ['$ref']),
+              hasSiblings = !_.isEmpty(referenceSiblings);
+            refData.node = hasSiblings ?
+              _.merge(referenceSiblings, refData.nodeContent) :
+              refData.nodeContent;
           }
           this.update(refData.node);
           if (!refData.inline) {

--- a/lib/bundleRules/spec30.js
+++ b/lib/bundleRules/spec30.js
@@ -8,7 +8,8 @@ const SCHEMA_CONTAINERS = [
     'schema'
   ],
   EXAMPLE_CONTAINERS = [
-    'example'
+    'example',
+    'value'
   ],
   REQUEST_BODY_CONTAINER = [
     'requestBody'

--- a/lib/bundleRules/spec31.js
+++ b/lib/bundleRules/spec31.js
@@ -8,7 +8,8 @@ const SCHEMA_CONTAINERS = [
     'schema'
   ],
   EXAMPLE_CONTAINERS = [
-    'example'
+    'example',
+    'value'
   ],
   REQUEST_BODY_CONTAINER = [
     'requestBody'

--- a/test/data/toBundleExamples/nested_examples_as_value/expected.json
+++ b/test/data/toBundleExamples/nested_examples_as_value/expected.json
@@ -1,0 +1,304 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Google Maps Platform",
+    "description": "API Specification for Google Maps Platform",
+    "version": "1.17.16"
+  },
+  "servers": [
+    {
+      "url": "https://www.googleapis.com"
+    }
+  ],
+  "paths": {
+    "/geolocation/v1/geolocate": {
+      "post": {
+        "servers": [
+          {
+            "url": "https://www.googleapis.com"
+          }
+        ],
+        "tags": [
+          "Geolocation API"
+        ],
+        "description": "Geolocation API returns a location and accuracy radius based on information about cell towers and WiFi nodes that the mobile client can detect. This document describes the protocol used to send this data to the server and to return a response to the client.\n\nCommunication is done over HTTPS using POST. Both request and response are formatted as JSON, and the content type of both is `application/json`.\n\nYou must specify a key in your request, included as the value of a`key` parameter. A `key` is your application's  API key. This key identifies your application for purposes of quota management. Learn how to [get a key](https://developers.google.com/maps/documentation/geolocation/get-api-key).",
+        "responses": {
+          "200": {
+            "description": "200 OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_schemas_GeolocationResponse.yml"
+                },
+                "examples": {
+                  "WIFI": {
+                    "value": {
+                      "$ref": "#/components/examples/_responses_maps_http_geolocation_wifi_response.yml"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400 BAD REQUEST",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "$ref": "#/components/schemas/_schemas_test.yml"
+                    },
+                    "other": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "description": "The request body must be formatted as JSON.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/_schemas_GeolocationRequest.yml"
+              },
+              "examples": {
+                "WIFI": {
+                  "value": {
+                    "$ref": "#/components/examples/_requests_maps_http_geolocation_wifi_request.yml"
+                  }
+                }
+              }
+            }
+          },
+          "required": false
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "arrival_time": {
+        "name": "arrival_time",
+        "description": "Specifies the desired time of arrival for transit directions, in seconds since midnight, January 1, 1970 UTC. You can specify either `departure_time` or `arrival_time`, but not both. Note that `arrival_time` must be specified as an integer.\n",
+        "in": "query",
+        "schema": {
+          "type": "number"
+        }
+      }
+    },
+    "schemas": {
+      "_schemas_LatLngLiteral.yml": {
+        "type": "object",
+        "title": "LatLngLiteral",
+        "description": "An object describing a specific location with Latitude and Longitude in decimal degrees.",
+        "required": [
+          "lat",
+          "lng"
+        ],
+        "properties": {
+          "lat": {
+            "type": "number",
+            "description": "Latitude in decimal degrees"
+          },
+          "lng": {
+            "type": "number",
+            "description": "Longitude in decimal degrees"
+          }
+        }
+      },
+      "_schemas_GeolocationResponse.yml": {
+        "type": "object",
+        "title": "GeolocationResponse",
+        "description": "A successful geolocation request will return a JSON-formatted response defining a location and radius.",
+        "required": [
+          "location",
+          "accuracy"
+        ],
+        "properties": {
+          "location": {
+            "description": "The user’s estimated latitude and longitude, in degrees.",
+            "$ref": "#/components/schemas/_schemas_LatLngLiteral.yml"
+          },
+          "accuracy": {
+            "description": "The accuracy of the estimated location, in meters. This represents the radius of a circle around the given `location`. If your Geolocation response shows a very high value in the `accuracy` field, the service may be geolocating based on the  request IP, instead of WiFi points or cell towers. This can happen if no cell towers or access points are valid or recognized. To confirm that this is the issue, set `considerIp` to `false` in your request. If the response is a `404`, you've confirmed that your `wifiAccessPoints` and `cellTowers` objects could not be geolocated.",
+            "type": "number"
+          }
+        },
+        "example": {
+          "$ref": "#/components/examples/_responses_maps_http_geolocation_wifi_response.yml"
+        }
+      },
+      "_schemas_test.yml": {
+        "type": "object",
+        "properties": {
+          "first": {
+            "type": "string"
+          },
+          "second": {
+            "type": "integer"
+          }
+        }
+      },
+      "_schemas_GeolocationRequest.yml": {
+        "type": "object",
+        "title": "GeolocationRequest",
+        "description": "The request body must be formatted as JSON. The following fields are supported, and all fields are optional.",
+        "properties": {
+          "homeMobileCountryCode": {
+            "type": "integer",
+            "description": "The cell tower's Mobile Country Code (MCC)."
+          },
+          "homeMobileNetworkCode": {
+            "type": "integer",
+            "description": "The cell tower's Mobile Network Code. This is the MNC for GSM and WCDMA; CDMA uses the System ID (SID)."
+          },
+          "radioType": {
+            "type": "string",
+            "description": "The mobile radio type. Supported values are lte, gsm, cdma, and wcdma. While this field is optional, it should be included if a value is available, for more accurate results."
+          },
+          "carrier": {
+            "type": "string",
+            "description": "The carrier name."
+          },
+          "considerIp": {
+            "type": "string",
+            "description": "Specifies whether to fall back to IP geolocation if wifi and cell tower signals are not available. Defaults to true. Set considerIp to false to disable fall back."
+          },
+          "cellTowers": {
+            "type": "array",
+            "description": "The request body's cellTowers array contains zero or more cell tower objects.",
+            "items": {
+              "$ref": "#/components/schemas/_schemas_CellTower.yml"
+            }
+          }
+        }
+      },
+      "_schemas_CellTower.yml": {
+        "type": "object",
+        "title": "CellTower",
+        "description": "Attributes used to describe a cell tower. The following optional fields are not currently used, but may be included if values are available: `age`, `signalStrength`, `timingAdvance`.",
+        "required": [
+          "cellId",
+          "locationAreaCode",
+          "mobileCountryCode",
+          "mobileNetworkCode"
+        ],
+        "properties": {
+          "cellId": {
+            "description": "Unique identifier of the cell. On GSM, this is the Cell ID (CID); CDMA networks use the Base Station ID (BID). WCDMA networks use the UTRAN/GERAN Cell Identity (UC-Id), which is a 32-bit value concatenating the Radio Network Controller (RNC) and Cell ID. Specifying only the 16-bit Cell ID value in WCDMA networks may return inaccurate results.",
+            "type": "integer"
+          },
+          "locationAreaCode": {
+            "description": "The Location Area Code (LAC) for GSM and WCDMA networks. The Network ID (NID) for CDMA networks.",
+            "type": "integer"
+          },
+          "mobileCountryCode": {
+            "description": "The cell tower's Mobile Country Code (MCC).",
+            "type": "integer"
+          },
+          "mobileNetworkCode": {
+            "description": "The cell tower's Mobile Network Code. This is the MNC for GSM and WCDMA; CDMA uses the System ID (SID).",
+            "type": "integer"
+          },
+          "age": {
+            "description": "The number of milliseconds since this cell was primary. If age is 0, the cellId represents a current measurement.",
+            "type": "integer"
+          },
+          "signalStrength": {
+            "description": "Radio signal strength measured in dBm.",
+            "type": "number"
+          },
+          "timingAdvance": {
+            "description": "The timing advance value.",
+            "type": "number"
+          }
+        },
+        "example": {
+          "$ref": "#/components/examples/_requests_maps_http_geolocation_celltowers_request.yml"
+        }
+      },
+      "Bounds": {
+        "title": "Bounds",
+        "type": "object",
+        "description": "A rectangle in geographical coordinates from points at the southwest and northeast corners.",
+        "required": [
+          "northeast",
+          "southwest"
+        ],
+        "properties": {
+          "northeast": {
+            "description": "The user’s estimated latitude and longitude, in degrees.",
+            "$ref": "#/components/schemas/_schemas_LatLngLiteral.yml"
+          },
+          "southwest": {
+            "description": "The user’s estimated latitude and longitude, in degrees.",
+            "$ref": "#/components/schemas/_schemas_LatLngLiteral.yml"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "key"
+      }
+    },
+    "examples": {
+      "_responses_maps_http_geolocation_wifi_response.yml": {
+        "location": {
+          "lat": 37.421925,
+          "lng": -122.0841293
+        },
+        "accuracy": 30
+      },
+      "_requests_maps_http_geolocation_wifi_request.yml": {
+        "considerIp": "false",
+        "wifiAccessPoints": [
+          {
+            "macAddress": "84:d4:7e:09:a5:f1",
+            "signalStrength": -43,
+            "signalToNoiseRatio": 0
+          },
+          {
+            "macAddress": "44:48:c1:a6:f3:d0",
+            "signalStrength": -55,
+            "signalToNoiseRatio": 0
+          }
+        ]
+      },
+      "_requests_maps_http_geolocation_celltowers_request.yml": {
+        "cellTowers": [
+          {
+            "cellId": 170402199,
+            "locationAreaCode": 35632,
+            "mobileCountryCode": 310,
+            "mobileNetworkCode": 410,
+            "age": 0,
+            "signalStrength": -60,
+            "timingAdvance": 15
+          }
+        ]
+      }
+    }
+  },
+  "security": [
+    {
+      "ApiKeyAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Directions",
+      "description": "The Directions API is a web service that uses an HTTP request to return JSON or XML-formatted directions between locations. You can receive directions for several modes of transportation, such as transit, driving, walking, or cycling.",
+      "externalDocs": {
+        "url": "https://developers.google.com/maps/documentation/directions/overview"
+      }
+    }
+  ]
+}

--- a/test/data/toBundleExamples/nested_examples_as_value/index.yml
+++ b/test/data/toBundleExamples/nested_examples_as_value/index.yml
@@ -1,0 +1,42 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+openapi: 3.0.3
+info:
+  title: Google Maps Platform
+  description: API Specification for Google Maps Platform
+  version: 1.17.16
+servers:
+  - url: "https://www.googleapis.com"
+paths:
+  $ref: "./paths/_index.yml"
+components:
+  parameters:
+    $ref: "./parameters/_index.yml"
+  schemas:
+    $ref: "./schemas/_index.yml"
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: query
+      name: key
+security:
+  - ApiKeyAuth: []
+tags:
+  - name: Directions
+    description: |-
+      The Directions API is a web service that uses an HTTP request to return JSON or XML-formatted directions between locations. You can receive directions for several modes of transportation, such as transit, driving, walking, or cycling.
+    externalDocs:
+      url: https://developers.google.com/maps/documentation/directions/overview
+ 

--- a/test/data/toBundleExamples/nested_examples_as_value/parameters/_index.yml
+++ b/test/data/toBundleExamples/nested_examples_as_value/parameters/_index.yml
@@ -1,0 +1,158 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# WARNING: This file is automatically updated as part of `npm run build`.
+
+arrival_time:
+  $ref: "./arrival_time.yml"
+# departure_time:
+#   $ref: "./departure_time.yml"
+# directions_alternatives:
+#   $ref: "./directions/alternatives.yml"
+# directions_avoid:
+#   $ref: "./directions/avoid.yml"
+# directions_departure_time:
+#   $ref: "./directions/departure_time.yml"
+# directions_destination:
+#   $ref: "./directions/destination.yml"
+# directions_origin:
+#   $ref: "./directions/origin.yml"
+# directions_units:
+#   $ref: "./directions/units.yml"
+# directions_waypoints:
+#   $ref: "./directions/waypoints.yml"
+# distancematrix_avoid:
+#   $ref: "./distanceMatrix/avoid.yml"
+# distancematrix_destinations:
+#   $ref: "./distanceMatrix/destinations.yml"
+# distancematrix_origins:
+#   $ref: "./distanceMatrix/origins.yml"
+# distancematrix_units:
+#   $ref: "./distanceMatrix/units.yml"
+# elevation_locations:
+#   $ref: "./elevation/locations.yml"
+# elevation_path:
+#   $ref: "./elevation/path.yml"
+# elevation_samples:
+#   $ref: "./elevation/samples.yml"
+# geocode_address:
+#   $ref: "./geocode/address.yml"
+# geocode_bounds:
+#   $ref: "./geocode/bounds.yml"
+# geocode_components:
+#   $ref: "./geocode/components.yml"
+# geocode_latlng:
+#   $ref: "./geocode/latlng.yml"
+# geocode_location_type:
+#   $ref: "./geocode/location_type.yml"
+# geocode_place_id:
+#   $ref: "./geocode/place_id.yml"
+# geocode_result_type:
+#   $ref: "./geocode/result_type.yml"
+# language:
+#   $ref: "./language.yml"
+# mode:
+#   $ref: "./mode.yml"
+# nearestroads_points:
+#   $ref: "./nearestRoads/points.yml"
+# places_components:
+#   $ref: "./places/components.yml"
+# places_fields:
+#   $ref: "./places/fields.yml"
+# places_inputtype:
+#   $ref: "./places/inputtype.yml"
+# places_keyword:
+#   $ref: "./places/keyword.yml"
+# places_location-required:
+#   $ref: "./places/location-required.yml"
+# places_location-weighted:
+#   $ref: "./places/location-weighted.yml"
+# places_location:
+#   $ref: "./places/location.yml"
+# places_locationbias:
+#   $ref: "./places/locationbias.yml"
+# places_maxheight:
+#   $ref: "./places/maxheight.yml"
+# places_maxprice:
+#   $ref: "./places/maxprice.yml"
+# places_maxwidth:
+#   $ref: "./places/maxwidth.yml"
+# places_minprice:
+#   $ref: "./places/minprice.yml"
+# places_name:
+#   $ref: "./places/name.yml"
+# places_offset:
+#   $ref: "./places/offset.yml"
+# places_opennow:
+#   $ref: "./places/opennow.yml"
+# places_origin:
+#   $ref: "./places/origin.yml"
+# places_pagetoken:
+#   $ref: "./places/pagetoken.yml"
+# places_photo_reference:
+#   $ref: "./places/photo_reference.yml"
+# places_place_id:
+#   $ref: "./places/place_id.yml"
+# places_query:
+#   $ref: "./places/query.yml"
+# places_radius:
+#   $ref: "./places/radius.yml"
+# places_rankby:
+#   $ref: "./places/rankby.yml"
+# places_sessiontoken:
+#   $ref: "./places/sessiontoken.yml"
+# places_strictbounds:
+#   $ref: "./places/strictbounds.yml"
+# places_type:
+#   $ref: "./places/type.yml"
+# places_types:
+#   $ref: "./places/types.yml"
+# region:
+#   $ref: "./region.yml"
+# snaptoroads_interpolate:
+#   $ref: "./snapToRoads/interpolate.yml"
+# snaptoroads_path:
+#   $ref: "./snapToRoads/path.yml"
+# streetview_fov:
+#   $ref: "./streetview/fov.yml"
+# streetview_heading:
+#   $ref: "./streetview/heading.yml"
+# streetview_location:
+#   $ref: "./streetview/location.yml"
+# streetview_pano:
+#   $ref: "./streetview/pano.yml"
+# streetview_pitch:
+#   $ref: "./streetview/pitch.yml"
+# streetview_radius:
+#   $ref: "./streetview/radius.yml"
+# streetview_return_error_code:
+#   $ref: "./streetview/return_error_code.yml"
+# streetview_signature:
+#   $ref: "./streetview/signature.yml"
+# streetview_size_optional:
+#   $ref: "./streetview/size_optional.yml"
+# streetview_size:
+#   $ref: "./streetview/size.yml"
+# streetview_source:
+#   $ref: "./streetview/source.yml"
+# timezone_location:
+#   $ref: "./timezone/location.yml"
+# timezone_timestamp:
+#   $ref: "./timezone/timestamp.yml"
+# traffic_model:
+#   $ref: "./traffic_model.yml"
+# transit_mode:
+#   $ref: "./transit_mode.yml"
+# transit_routing_preference:
+#   $ref: "./transit_routing_preference.yml"

--- a/test/data/toBundleExamples/nested_examples_as_value/parameters/arrival_time.yml
+++ b/test/data/toBundleExamples/nested_examples_as_value/parameters/arrival_time.yml
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: arrival_time
+description: |
+  Specifies the desired time of arrival for transit directions, in seconds since midnight, January 1, 1970 UTC. You can specify either `departure_time` or `arrival_time`, but not both. Note that `arrival_time` must be specified as an integer.
+in: query
+schema:
+  type: number

--- a/test/data/toBundleExamples/nested_examples_as_value/paths/_index.yml
+++ b/test/data/toBundleExamples/nested_examples_as_value/paths/_index.yml
@@ -1,0 +1,82 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+/geolocation/v1/geolocate:
+  post:
+    operationId: geolocate
+    $ref: "./geolocate.yml"
+# /maps/api/directions/json:
+#   get:
+#     operationId: directions
+#     $ref: "./directions.yml"
+# /maps/api/elevation/json:
+#   get:
+#     operationId: elevation
+#     $ref: "./elevation.yml"
+# /maps/api/geocode/json:
+#   get:
+#     operationId: geocode
+#     $ref: "./geocode.yml"
+# /maps/api/timezone/json:
+#   get:
+#     operationId: timezone
+#     $ref: "./timezone.yml"
+# /v1/snaptoroads:
+#   get:
+#     operationId: snapToRoads
+#     $ref: "./snapToRoads.yml"
+# /v1/nearestRoads:
+#   get:
+#     operationId: nearestRoads
+#     $ref: "./nearestRoads.yml"
+# /maps/api/distancematrix/json:
+#   get:
+#     operationId: distanceMatrix
+#     $ref: "./distanceMatrix.yml"
+# /maps/api/place/details/json:
+#   get:
+#     operationId: placeDetails
+#     $ref: "./places/details.yml"
+# /maps/api/place/findplacefromtext/json:
+#   get:
+#     operationId: findPlaceFromText
+#     $ref: "./places/findplacefromtext.yml"
+# /maps/api/place/nearbysearch/json:  
+#   get:
+#     operationId: nearbySearch
+#     $ref: "./places/nearbysearch.yml"
+# /maps/api/place/textsearch/json:  
+#   get:
+#     operationId: textSearch
+#     $ref: "./places/textsearch.yml"
+# /maps/api/place/photo:  
+#   get:
+#     operationId: placePhoto
+#     $ref: "./places/photo.yml"
+# /maps/api/place/queryautocomplete/json:  
+#   get:
+#     operationId: queryAutocomplete
+#     $ref: "./places/queryautocomplete.yml"
+# /maps/api/place/autocomplete/json:  
+#   get:
+#     operationId: autocomplete
+#     $ref: "./places/autocomplete.yml"
+# /maps/api/streetview:  
+#   get:
+#     operationId: streetView
+#     $ref: "./streetview/static.yml"
+# /maps/api/streetview/metadata:  
+#   get:
+#     operationId: streetViewMetadata
+#     $ref: "./streetview/metadata.yml"

--- a/test/data/toBundleExamples/nested_examples_as_value/paths/geolocate.yml
+++ b/test/data/toBundleExamples/nested_examples_as_value/paths/geolocate.yml
@@ -1,0 +1,80 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+servers:
+  - url: https://www.googleapis.com
+tags:
+  - Geolocation API
+description: |-
+  Geolocation API returns a location and accuracy radius based on information about cell towers and WiFi nodes that the mobile client can detect. This document describes the protocol used to send this data to the server and to return a response to the client.
+
+  Communication is done over HTTPS using POST. Both request and response are formatted as JSON, and the content type of both is `application/json`.
+
+  You must specify a key in your request, included as the value of a`key` parameter. A `key` is your application's  API key. This key identifies your application for purposes of quota management. Learn how to [get a key](https://developers.google.com/maps/documentation/geolocation/get-api-key).
+responses:
+  "200":
+    description: 200 OK
+    content:
+      application/json:
+        schema:
+          $ref: "../schemas/GeolocationResponse.yml"          
+        examples:
+          WIFI:
+            value:
+              $ref: ../responses/maps_http_geolocation_wifi_response.yml
+          # Cell Towers:
+          #   value:
+          #     $ref: ../responses/maps_http_geolocation_celltowers_response.yml
+          # IP Only:
+          #   value:
+          #     $ref: ../responses/maps_http_geolocation_ip_response.yml
+  "400":
+    description: 400 BAD REQUEST
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            value:
+              $ref: "../schemas/test.yml"
+            other:
+              type: string
+        
+  # "404":
+  #   description: 404 NOT FOUND
+  #   content:
+  #     application/json:
+  #       schema:
+  #         $ref: "../schemas/errors/ErrorResponse.yml"
+  #       examples:
+  #         Invalid:            
+  #           value:
+  #             $ref: ../responses/maps_http_geolocation_error_404_response.yml
+requestBody:
+  description: The request body must be formatted as JSON.
+  content:
+    "application/json":
+      schema:
+          $ref: "../schemas/GeolocationRequest.yml" 
+      examples:
+        WIFI:
+          value:
+            $ref: ../requests/maps_http_geolocation_wifi_request.yml
+        # Cell Towers:
+        #   value:
+        #     $ref: ../requests/maps_http_geolocation_celltowers_request.yml
+        # IP Only:
+        #   value:
+        #     $ref: ../requests/maps_http_geolocation_ip_request.yml
+  required: false

--- a/test/data/toBundleExamples/nested_examples_as_value/requests/maps_http_geolocation_celltowers_request.yml
+++ b/test/data/toBundleExamples/nested_examples_as_value/requests/maps_http_geolocation_celltowers_request.yml
@@ -1,0 +1,29 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START maps_http_geolocation_celltowers_request]
+{
+  "cellTowers": [
+    {
+      "cellId": 170402199,
+      "locationAreaCode": 35632,
+      "mobileCountryCode": 310,
+      "mobileNetworkCode": 410,
+      "age": 0,
+      "signalStrength": -60,
+      "timingAdvance": 15
+    }
+  ]
+}
+# [END maps_http_geolocation_celltowers_request]

--- a/test/data/toBundleExamples/nested_examples_as_value/requests/maps_http_geolocation_wifi_request.yml
+++ b/test/data/toBundleExamples/nested_examples_as_value/requests/maps_http_geolocation_wifi_request.yml
@@ -1,0 +1,31 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START maps_http_geolocation_wifi_request]
+{
+  "considerIp": "false",
+  "wifiAccessPoints": [
+    {
+      "macAddress": "84:d4:7e:09:a5:f1",
+      "signalStrength": -43,
+      "signalToNoiseRatio": 0
+    },
+    {
+      "macAddress": "44:48:c1:a6:f3:d0",
+      "signalStrength": -55,
+      "signalToNoiseRatio": 0
+    }
+  ]
+}
+# [END maps_http_geolocation_wifi_request]

--- a/test/data/toBundleExamples/nested_examples_as_value/responses/maps_http_geolocation_wifi_response.yml
+++ b/test/data/toBundleExamples/nested_examples_as_value/responses/maps_http_geolocation_wifi_response.yml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START maps_http_geolocation_wifi_response]
+{
+  "location": {
+    "lat": 37.421925,
+    "lng": -122.0841293
+  },
+  "accuracy": 30
+}
+# [END maps_http_geolocation_wifi_response]

--- a/test/data/toBundleExamples/nested_examples_as_value/schemas/Bounds.yml
+++ b/test/data/toBundleExamples/nested_examples_as_value/schemas/Bounds.yml
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+title: Bounds
+type: object
+description: A rectangle in geographical coordinates from points at the southwest and northeast corners.
+required: [northeast, southwest]
+properties:
+  northeast:
+    $ref: './LatLngLiteral.yml'
+  southwest:
+    $ref: './LatLngLiteral.yml'

--- a/test/data/toBundleExamples/nested_examples_as_value/schemas/CellTower.yml
+++ b/test/data/toBundleExamples/nested_examples_as_value/schemas/CellTower.yml
@@ -1,0 +1,57 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+type: object
+title: CellTower
+description: "Attributes used to describe a cell tower. The following optional fields are not currently used, but may be included if values are available: `age`, `signalStrength`, `timingAdvance`."
+required:
+  - cellId
+  - locationAreaCode
+  - mobileCountryCode
+  - mobileNetworkCode
+properties:
+  cellId:
+    description:
+      Unique identifier of the cell. On GSM, this is the Cell ID (CID);
+      CDMA networks use the Base Station ID (BID). WCDMA networks use the
+      UTRAN/GERAN Cell Identity (UC-Id), which is a 32-bit value
+      concatenating the Radio Network Controller (RNC) and Cell ID.
+      Specifying only the 16-bit Cell ID value in WCDMA networks may
+      return inaccurate results.
+    type: integer
+  locationAreaCode:
+    description: The Location Area Code (LAC) for GSM and WCDMA networks. The
+      Network ID (NID) for CDMA networks.
+    type: integer
+  mobileCountryCode:
+    description: The cell tower's Mobile Country Code (MCC).
+    type: integer
+  mobileNetworkCode:
+    description:
+      The cell tower's Mobile Network Code. This is the MNC for GSM and
+      WCDMA; CDMA uses the System ID (SID).
+    type: integer
+  age:
+    description:
+      The number of milliseconds since this cell was primary. If age is
+      0, the cellId represents a current measurement.
+    type: integer
+  signalStrength:
+    description: Radio signal strength measured in dBm.
+    type: number
+  timingAdvance:
+    description: The timing advance value.
+    type: number
+example: 
+  $ref: ../requests/maps_http_geolocation_celltowers_request.yml

--- a/test/data/toBundleExamples/nested_examples_as_value/schemas/GeolocationRequest.yml
+++ b/test/data/toBundleExamples/nested_examples_as_value/schemas/GeolocationRequest.yml
@@ -1,0 +1,45 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+type: object
+title: GeolocationRequest
+description: The request body must be formatted as JSON. The following fields are supported, and all fields are optional.
+properties:
+  homeMobileCountryCode:
+    type: integer
+    description: The cell tower's Mobile Country Code (MCC).
+  homeMobileNetworkCode:
+    type: integer
+    description:
+      The cell tower's Mobile Network Code. This is the MNC for GSM and
+      WCDMA; CDMA uses the System ID (SID).
+  radioType:
+    type: string
+    description: The mobile radio type. Supported values are lte, gsm, cdma, and wcdma. While this field is optional, it should be included if a value is available, for more accurate results.
+  carrier:
+    type: string
+    description: The carrier name.
+  considerIp:
+    type: string
+    description: Specifies whether to fall back to IP geolocation if wifi and cell tower signals are not available. Defaults to true. Set considerIp to false to disable fall back.
+  cellTowers:
+    type: array
+    description: The request body's cellTowers array contains zero or more cell tower objects.
+    items:
+      $ref: "./CellTower.yml"
+  # wifiAccessPoints:
+  #   type: array
+  #   description: An array of two or more WiFi access point objects.
+  #   items:
+  #     $ref: "./WiFiAccessPoint.yml"

--- a/test/data/toBundleExamples/nested_examples_as_value/schemas/GeolocationResponse.yml
+++ b/test/data/toBundleExamples/nested_examples_as_value/schemas/GeolocationResponse.yml
@@ -1,0 +1,27 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+type: object
+title: GeolocationResponse
+description: A successful geolocation request will return a JSON-formatted response defining a location and radius.
+required: [location, accuracy]
+properties:
+  location:
+    description: The user’s estimated latitude and longitude, in degrees.
+    $ref: "./LatLngLiteral.yml"
+  accuracy:
+    description: The accuracy of the estimated location, in meters. This represents the radius of a circle around the given `location`. If your Geolocation response shows a very high value in the `accuracy` field, the service may be geolocating based on the  request IP, instead of WiFi points or cell towers. This can happen if no cell towers or access points are valid or recognized. To confirm that this is the issue, set `considerIp` to `false` in your request. If the response is a `404`, you've confirmed that your `wifiAccessPoints` and `cellTowers` objects could not be geolocated.
+    type: number
+example:
+  $ref: ../responses/maps_http_geolocation_wifi_response.yml

--- a/test/data/toBundleExamples/nested_examples_as_value/schemas/LatLngLiteral.yml
+++ b/test/data/toBundleExamples/nested_examples_as_value/schemas/LatLngLiteral.yml
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+type: object
+title: LatLngLiteral
+description: An object describing a specific location with Latitude and Longitude in decimal degrees.
+required:
+  - lat
+  - lng
+properties:
+  lat:
+    type: number
+    description: Latitude in decimal degrees
+  lng:
+    type: number
+    description: Longitude in decimal degrees

--- a/test/data/toBundleExamples/nested_examples_as_value/schemas/_index.yml
+++ b/test/data/toBundleExamples/nested_examples_as_value/schemas/_index.yml
@@ -1,0 +1,169 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Bounds:
+  $ref: "./Bounds.yml"
+# LatLngArrayString:
+#   $ref: "./LatLngArrayString.yml"
+# LatLngLiteral:
+#   $ref: "./LatLngLiteral.yml"
+# LatitudeLongitudeLiteral:
+#   $ref: "./LatitudeLongitudeLiteral.yml"
+# AddressComponent:
+#   $ref: "./AddressComponent.yml"
+# Fare:
+#   $ref: "./Fare.yml"
+# Geometry:
+#   $ref: "./Geometry.yml"
+# PlusCode:
+#   $ref: "./PlusCode.yml"
+# TravelMode:
+#   $ref: "./TravelMode.yml"
+# TextValueObject:
+#   $ref: "./TextValueObject.yml"
+# TimeZoneTextValueObject:
+#   $ref: "./TimeZoneTextValueObject.yml"
+# # Distance Matrix
+# DistanceMatrixElementStatus:
+#   $ref: "./DistanceMatrixElementStatus.yml"
+# DistanceMatrixResponse:
+#   $ref: "./DistanceMatrixResponse.yml"
+# DistanceMatrixRow:
+#   $ref: "./DistanceMatrixRow.yml"
+# DistanceMatrixElement:
+#   $ref: "./DistanceMatrixElement.yml"
+# DistanceMatrixStatus:
+#   $ref: "./DistanceMatrixStatus.yml"
+# # Directions
+# DirectionsResponse:
+#   $ref: "./DirectionsResponse.yml"
+# DirectionsStep:
+#   $ref: "./DirectionsStep.yml"
+# DirectionsLeg:
+#   $ref: "./DirectionsLeg.yml"
+# DirectionsRoute:
+#   $ref: "./DirectionsRoute.yml"
+# DirectionsStatus:
+#   $ref: "./DirectionsStatus.yml"
+# DirectionsGeocodedWaypoint:
+#   $ref: "./DirectionsGeocodedWaypoint.yml"
+# DirectionsPolyline:
+#   $ref: "./DirectionsPolyline.yml"
+# DirectionsTrafficSpeedEntry:
+#   $ref: "./DirectionsTrafficSpeedEntry.yml"
+# DirectionsTransitAgency:
+#   $ref: "./DirectionsTransitAgency.yml"
+# DirectionsTransitDetails:
+#   $ref: "./DirectionsTransitDetails.yml"
+# DirectionsTransitLine:
+#   $ref: "./DirectionsTransitLine.yml"
+# DirectionsTransitStop:
+#   $ref: "./DirectionsTransitStop.yml"
+# DirectionsTransitVehicle:
+#   $ref: "./DirectionsTransitVehicle.yml"
+# DirectionsViaWaypoint:
+#   $ref: "./DirectionsViaWaypoint.yml"
+# # Elevation
+# ElevationResult:
+#   $ref: "./ElevationResult.yml"
+# ElevationResponse:
+#   $ref: "./ElevationResponse.yml"
+# ElevationStatus:
+#   $ref: "./ElevationStatus.yml"
+# # Geocoding
+# GeocodingResult:
+#   $ref: "./GeocodingResult.yml"
+# GeocodingResponse:
+#   $ref: "./GeocodingResponse.yml"
+# GeocodingStatus:
+#   $ref: "./GeocodingStatus.yml"
+# GeocodingGeometry:
+#   $ref: "./GeocodingGeometry.yml"
+# # Geolocation
+# GeolocationRequest:
+#   $ref: "./GeolocationRequest.yml"
+# GeolocationResponse:
+#   $ref: "./GeolocationResponse.yml"
+# CellTower:
+#   $ref: "./CellTower.yml"
+# WiFiAccessPoint:
+#   $ref: "./WiFiAccessPoint.yml"
+# # Roads
+# NearestRoadsError:
+#   $ref: "./NearestRoadsError.yml"
+# NearestRoadsErrorResponse:
+#   $ref: "./NearestRoadsErrorResponse.yml"
+# NearestRoadsResponse:
+#   $ref: "./NearestRoadsResponse.yml"
+# SnappedPoint:
+#   $ref: "./SnappedPoint.yml"
+# SnapToRoadsResponse:
+#   $ref: "./SnapToRoadsResponse.yml"
+# # Time Zone
+# TimeZoneResponse:
+#   $ref: "./TimeZoneResponse.yml"
+# TimeZoneStatus:
+#   $ref: "./TimeZoneStatus.yml"
+# # Errors
+# ErrorResponse:
+#   $ref: "./errors/ErrorResponse.yml"
+# ErrorObject:
+#   $ref: "./errors/ErrorObject.yml"
+# ErrorDetail:
+#   $ref: "./errors/ErrorDetail.yml"
+# FieldViolation:
+#   $ref: "./errors/FieldViolation.yml"
+# # Places
+# Place:
+#   $ref: "./Place.yml"
+# PlaceAutocompleteMatchedSubstring:
+#   $ref: "./PlaceAutocompleteMatchedSubstring.yml"
+# PlaceAutocompletePrediction:
+#   $ref: "./PlaceAutocompletePrediction.yml"
+# PlaceAutocompleteStructuredFormat:
+#   $ref: "./PlaceAutocompleteStructuredFormat.yml"
+# PlaceAutocompleteTerm:
+#   $ref: "./PlaceAutocompleteTerm.yml"
+# PlacePhoto:
+#   $ref: "./PlacePhoto.yml"
+# PlaceOpeningHours:
+#   $ref: "./PlaceOpeningHours.yml"
+# PlaceOpeningHoursPeriod:
+#   $ref: "./PlaceOpeningHoursPeriod.yml"
+# PlaceOpeningHoursPeriodDetail:
+#   $ref: "./PlaceOpeningHoursPeriodDetail.yml"
+# PlaceReview:
+#   $ref: "./PlaceReview.yml"
+# PlacesAutocompleteResponse:
+#   $ref: "./PlacesAutocompleteResponse.yml"
+# PlacesAutocompleteStatus:
+#   $ref: "./PlacesAutocompleteStatus.yml"
+# PlacesDetailsResponse:
+#   $ref: "./PlacesDetailsResponse.yml"
+# PlacesDetailsStatus:
+#   $ref: "./PlacesDetailsStatus.yml"
+# PlacesFindPlaceFromTextResponse:
+#   $ref: "./PlacesFindPlaceFromTextResponse.yml"
+# PlacesNearbySearchResponse:
+#   $ref: "./PlacesNearbySearchResponse.yml"
+# PlacesQueryAutocompleteResponse:
+#   $ref: "./PlacesQueryAutocompleteResponse.yml"
+# PlacesSearchStatus:
+#   $ref: "./PlacesSearchStatus.yml"
+# PlacesTextSearchResponse:
+#   $ref: "./PlacesTextSearchResponse.yml"
+# StreetViewStatus:
+#   $ref: "./StreetViewStatus.yml"
+# StreetViewResponse:
+#   $ref: "./StreetViewResponse.yml"

--- a/test/data/toBundleExamples/nested_examples_as_value/schemas/test.yml
+++ b/test/data/toBundleExamples/nested_examples_as_value/schemas/test.yml
@@ -1,0 +1,6 @@
+type: object
+properties:
+  first:
+    type: string
+  second:
+    type: integer

--- a/test/unit/bundle.test.js
+++ b/test/unit/bundle.test.js
@@ -41,7 +41,8 @@ let expect = require('chai').expect,
   longPath = path.join(__dirname, BUNDLES_FOLDER + '/longPath'),
   schemaCollision = path.join(__dirname, BUNDLES_FOLDER + '/schema_collision_from_responses'),
   schemaCollisionWRootComponent = path.join(__dirname, BUNDLES_FOLDER + '/schema_collision_w_root_components'),
-  referencedProperties = path.join(__dirname, BUNDLES_FOLDER + '/referenced_properties');
+  referencedProperties = path.join(__dirname, BUNDLES_FOLDER + '/referenced_properties'),
+  nestedExamplesAsValue = path.join(__dirname, BUNDLES_FOLDER + '/nested_examples_as_value');
 
 describe('bundle files method - 3.0', function () {
   it('Should return bundled file as json - schema_from_response', async function () {
@@ -2248,6 +2249,105 @@ describe('bundle files method - 3.0', function () {
     expect(res).to.not.be.empty;
     expect(res.result).to.be.true;
     expect(res.output.specification.version).to.equal('3.0');
+    expect(JSON.stringify(JSON.parse(res.output.data[0].bundledContent), null, 2)).to.be.equal(expected);
+  });
+
+  it('Should return bundled file - TestSpec_from_issue_14', async function () {
+    let contentRoot = fs.readFileSync(nestedExamplesAsValue + '/index.yml', 'utf8'),
+      parametersIndex = fs.readFileSync(nestedExamplesAsValue + '/parameters/_index.yml', 'utf8'),
+      arrivalTime = fs.readFileSync(nestedExamplesAsValue + '/parameters/arrival_time.yml', 'utf8'),
+      pathsIndex = fs.readFileSync(nestedExamplesAsValue + '/paths/_index.yml', 'utf8'),
+      geolocate = fs.readFileSync(nestedExamplesAsValue + '/paths/geolocate.yml', 'utf8'),
+      requests =
+        fs.readFileSync(nestedExamplesAsValue + '/requests/maps_http_geolocation_celltowers_request.yml', 'utf8'),
+      schemasIndex = fs.readFileSync(nestedExamplesAsValue + '/schemas/_index.yml', 'utf8'),
+      bounds = fs.readFileSync(nestedExamplesAsValue + '/schemas/Bounds.yml', 'utf8'),
+      cellTower = fs.readFileSync(nestedExamplesAsValue + '/schemas/CellTower.yml', 'utf8'),
+      geolocationRequest = fs.readFileSync(nestedExamplesAsValue + '/schemas/GeolocationRequest.yml', 'utf8'),
+      latLngLiteral = fs.readFileSync(nestedExamplesAsValue + '/schemas/LatLngLiteral.yml', 'utf8'),
+      wifiResponse =
+        fs.readFileSync(nestedExamplesAsValue + '/responses/maps_http_geolocation_wifi_response.yml', 'utf8'),
+      wifiRequest = fs.readFileSync(nestedExamplesAsValue + '/requests/maps_http_geolocation_wifi_request.yml', 'utf8'),
+      geolocationResponse = fs.readFileSync(nestedExamplesAsValue + '/schemas/GeolocationResponse.yml', 'utf8'),
+      testSchema = fs.readFileSync(nestedExamplesAsValue + '/schemas/test.yml', 'utf8'),
+      expected = fs.readFileSync(nestedExamplesAsValue + '/expected.json', 'utf8'),
+      input = {
+        type: 'multiFile',
+        specificationVersion: '3.0',
+        rootFiles: [
+          {
+            path: '/index.yml'
+          }
+        ],
+        data: [
+          {
+            path: '/index.yml',
+            content: contentRoot
+          },
+          {
+            path: '/parameters/_index.yml',
+            content: parametersIndex
+          },
+          {
+            path: '/parameters/arrival_time.yml',
+            content: arrivalTime
+          },
+          {
+            path: '/paths/_index.yml',
+            content: pathsIndex
+          },
+          {
+            path: '/paths/geolocate.yml',
+            content: geolocate
+          },
+          {
+            path: '/requests/maps_http_geolocation_celltowers_request.yml',
+            content: requests
+          },
+          {
+            path: '/schemas/_index.yml',
+            content: schemasIndex
+          },
+          {
+            path: '/schemas/Bounds.yml',
+            content: bounds
+          },
+          {
+            path: '/schemas/CellTower.yml',
+            content: cellTower
+          },
+          {
+            path: '/schemas/GeolocationRequest.yml',
+            content: geolocationRequest
+          },
+          {
+            path: '/schemas/LatLngLiteral.yml',
+            content: latLngLiteral
+          },
+          {
+            path: '/schemas/GeolocationResponse.yml',
+            content: geolocationResponse
+          },
+          {
+            path: '/requests/maps_http_geolocation_wifi_request.yml',
+            content: wifiRequest
+          },
+          {
+            path: '/responses/maps_http_geolocation_wifi_response.yml',
+            content: wifiResponse
+          },
+          {
+            path: '/schemas/test.yml',
+            content: testSchema
+          }
+        ],
+        options: {},
+        bundleFormat: 'JSON'
+      };
+    const res = await Converter.bundle(input);
+
+    expect(res).to.not.be.empty;
+    expect(res.result).to.be.true;
     expect(JSON.stringify(JSON.parse(res.output.data[0].bundledContent), null, 2)).to.be.equal(expected);
   });
 });


### PR DESCRIPTION
- When references a reusable components object in any root components key it will merge those with the pre existent reusable components instead of overwrite all the object

- Adding support to use the key value as an example container. It won't be used as example if it is down a definition key ie. properties
