### PR TITLE
Fix/components object referenced

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -248,7 +248,14 @@ function getTraceFromParentKeyInComponents(nodeContext, tempRef, mainKeys, versi
       [key, ...parentKeys],
     nodeTrace = getRootFileTrace(nodeParentsKey),
     componentKey = createComponentMainKey(tempRef, mainKeys),
-    keyTraceInComponents = getKeyInComponents(nodeTrace, componentKey, version, commonPathFromData);
+    parentNodeKey = nodeContext.parent.key,
+    keyTraceInComponents = getKeyInComponents(
+      nodeTrace,
+      componentKey,
+      version,
+      commonPathFromData,
+      parentNodeKey
+    );
   return keyTraceInComponents;
 }
 
@@ -507,14 +514,18 @@ function generateComponentsObject (documentContext, rootContent, refTypeResolver
 /**
  * Generates the components object wrapper
  * @param {object} parsedOasObject The parsed root
- * @param {string} version - The current version
+ * @param {string} nodesContent - The content from all nodes
  * @returns {object} The components object wrapper
  */
-function generateComponentsWrapper(parsedOasObject) {
-  let components = {};
+function generateComponentsWrapper(parsedOasObject, nodesContent = {}) {
+  let components = _.isNil(parsedOasObject.components) ?
+      {} :
+      parsedOasObject.components,
+    componentsAreReferenced = components.$ref !== undefined && !_.isEmpty(nodesContent);
 
-  if (parsedOasObject.hasOwnProperty('components')) {
-    components = parsedOasObject.components;
+  if (componentsAreReferenced) {
+    components = _.merge(parsedOasObject.components, nodesContent[components.$ref]);
+    delete components.$ref;
   }
 
   return components;
@@ -572,7 +583,9 @@ module.exports = {
     if (origin === BROWSER) {
       path = pathBrowserify;
     }
-    const initialComponents = generateComponentsWrapper(specRoot.parsed.oasObject, version),
+    const initialComponents = generateComponentsWrapper(
+        specRoot.parsed.oasObject
+      ),
       initialMainKeys = getMainKeysFromComponents(initialComponents, version);
     let algorithm = new DFS(),
       components = {},
@@ -584,7 +597,10 @@ module.exports = {
     rootContextData = algorithm.traverseAndBundle(specRoot, (currentNode) => {
       return getNodeContentAndReferences(currentNode, allData, specRoot, version, initialMainKeys, commonPathFromData);
     });
-    components = generateComponentsWrapper(specRoot.parsed.oasObject, version);
+    components = generateComponentsWrapper(
+      specRoot.parsed.oasObject,
+      rootContextData.nodeContents
+    );
     generateComponentsObject(
       rootContextData,
       rootContextData.nodeContents[specRoot.fileName],

--- a/lib/jsonPointer.js
+++ b/lib/jsonPointer.js
@@ -52,9 +52,10 @@ function generateObjectName(filePathName, hash = '') {
 * @param {string} mainKey - The generated mainKey for the components
 * @param {string} version - The current spec version
 * @param {string} commonPathFromData - The common path in the file's paths
+* @param {string} parentNodeKey - The parent key before the trace
 * @returns {Array} - the calculated keys in an array representing each nesting property name
 */
-function getKeyInComponents(traceFromParent, mainKey, version, commonPathFromData) {
+function getKeyInComponents(traceFromParent, mainKey, version, commonPathFromData, parentNodeKey = undefined) {
   const {
     CONTAINERS,
     DEFINITIONS,
@@ -70,9 +71,11 @@ function getKeyInComponents(traceFromParent, mainKey, version, commonPathFromDat
     ].reverse(),
     traceToKey = [],
     matchFound = false,
-    isRootAndReusableItemsContainer = ROOT_CONTAINERS_KEYS.includes(traceFromParent[0]);
+    hasNotParent = parentNodeKey === undefined,
+    isRootAndReusableItemsContainer = ROOT_CONTAINERS_KEYS.includes(traceFromParent[0]),
+    isAComponentKeyReferenced = COMPONENTS_KEYS.includes(traceFromParent[0]) && hasNotParent;
 
-  if (isRootAndReusableItemsContainer) {
+  if (isRootAndReusableItemsContainer || isAComponentKeyReferenced) {
     return [];
   }
 

--- a/test/data/toBundleExamples/referenced_components/components.yaml
+++ b/test/data/toBundleExamples/referenced_components/components.yaml
@@ -1,0 +1,4 @@
+responses:
+  $ref: './responses.yaml'
+schemas:
+  $ref: './schemas.yaml'

--- a/test/data/toBundleExamples/referenced_components/expected.json
+++ b/test/data/toBundleExamples/referenced_components/expected.json
@@ -1,0 +1,82 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Sample API",
+    "description": "Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.",
+    "version": "0.1.9"
+  },
+  "paths": {
+    "/hello": {
+      "get": {
+        "description": "Returns all pets alesuada ac...",
+        "operationId": "findPets",
+        "responses": {
+          "$ref": "#/components/responses/responseA"
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "200": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "address": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "responseA": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/_schemaA.yaml"
+            }
+          }
+        }
+      },
+      "responseB": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "fromB": {
+                  "type": "string"
+                },
+                "addressFromB": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "_schemaA.yaml": {
+        "type": "object",
+        "properties": {
+          "fromA": {
+            "type": "string"
+          },
+          "addressFromA": {
+            "type": "string"
+          }
+        }
+      },
+      "schemaB": {
+        "type": "integer"
+      }
+    }
+  }
+}

--- a/test/data/toBundleExamples/referenced_components/responses.yaml
+++ b/test/data/toBundleExamples/referenced_components/responses.yaml
@@ -1,0 +1,25 @@
+"200":
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          name:
+            type: string
+          address:
+            type: string
+"responseA":
+  content:
+    application/json:
+      schema:
+        $ref: './schemaA.yaml'
+"responseB":
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          fromB:
+            type: string
+          addressFromB:
+            type: string

--- a/test/data/toBundleExamples/referenced_components/root.yaml
+++ b/test/data/toBundleExamples/referenced_components/root.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+  version: 0.1.9
+paths:
+  /hello:
+    get:
+      description: Returns all pets alesuada ac...
+      operationId: findPets
+      responses:
+        $ref: '#/components/responses/responseA'
+
+components:
+  $ref: './components.yaml'

--- a/test/data/toBundleExamples/referenced_components/schemaA.yaml
+++ b/test/data/toBundleExamples/referenced_components/schemaA.yaml
@@ -1,0 +1,6 @@
+type: object
+properties:
+  fromA:
+    type: string
+  addressFromA:
+    type: string

--- a/test/data/toBundleExamples/referenced_components/schemas.yaml
+++ b/test/data/toBundleExamples/referenced_components/schemas.yaml
@@ -1,0 +1,2 @@
+schemaB:
+  type: integer

--- a/test/unit/bundle.test.js
+++ b/test/unit/bundle.test.js
@@ -43,7 +43,7 @@ let expect = require('chai').expect,
   schemaCollisionWRootComponent = path.join(__dirname, BUNDLES_FOLDER + '/schema_collision_w_root_components'),
   referencedProperties = path.join(__dirname, BUNDLES_FOLDER + '/referenced_properties'),
   nestedExamplesAsValue = path.join(__dirname, BUNDLES_FOLDER + '/nested_examples_as_value'),
-referencedComponents = path.join(__dirname, BUNDLES_FOLDER + '/referenced_components'),
+  referencedComponents = path.join(__dirname, BUNDLES_FOLDER + '/referenced_components'),
   referencedPath = path.join(__dirname, BUNDLES_FOLDER + '/referenced_path');
 
 describe('bundle files method - 3.0', function () {

--- a/test/unit/bundle.test.js
+++ b/test/unit/bundle.test.js
@@ -41,8 +41,9 @@ let expect = require('chai').expect,
   longPath = path.join(__dirname, BUNDLES_FOLDER + '/longPath'),
   schemaCollision = path.join(__dirname, BUNDLES_FOLDER + '/schema_collision_from_responses'),
   schemaCollisionWRootComponent = path.join(__dirname, BUNDLES_FOLDER + '/schema_collision_w_root_components'),
+  referencedProperties = path.join(__dirname, BUNDLES_FOLDER + '/referenced_properties'),
   nestedExamplesAsValue = path.join(__dirname, BUNDLES_FOLDER + '/nested_examples_as_value'),
-  referencedProperties = path.join(__dirname, BUNDLES_FOLDER + '/referenced_properties');
+  referencedComponents = path.join(__dirname, BUNDLES_FOLDER + '/referenced_components');
 
 describe('bundle files method - 3.0', function () {
   it('Should return bundled file as json - schema_from_response', async function () {
@@ -2357,6 +2358,54 @@ describe('bundle files method - 3.0', function () {
 
     expect(res).to.not.be.empty;
     expect(res.result).to.be.true;
+    expect(JSON.stringify(JSON.parse(res.output.data[0].bundledContent), null, 2)).to.be.equal(expected);
+  });
+
+  it('Should return bundled file - referenced-components', async function () {
+    let contentRootFile = fs.readFileSync(referencedComponents + '/root.yaml', 'utf8'),
+      components = fs.readFileSync(referencedComponents + '/components.yaml', 'utf8'),
+      responses = fs.readFileSync(referencedComponents + '/responses.yaml', 'utf8'),
+      schemas = fs.readFileSync(referencedComponents + '/schemas.yaml', 'utf8'),
+      schemaA = fs.readFileSync(referencedComponents + '/schemaA.yaml', 'utf8'),
+      expected = fs.readFileSync(referencedComponents + '/expected.json', 'utf8'),
+      input = {
+        type: 'multiFile',
+        specificationVersion: '3.0',
+        rootFiles: [
+          {
+            path: '/root.yaml'
+          }
+        ],
+        data: [
+          {
+            path: '/root.yaml',
+            content: contentRootFile
+          },
+          {
+            path: '/components.yaml',
+            content: components
+          },
+          {
+            path: '/responses.yaml',
+            content: responses
+          },
+          {
+            path: '/schemas.yaml',
+            content: schemas
+          },
+          {
+            path: '/schemaA.yaml',
+            content: schemaA
+          }
+        ],
+        options: {},
+        bundleFormat: 'JSON'
+      };
+    const res = await Converter.bundle(input);
+
+    expect(res).to.not.be.empty;
+    expect(res.result).to.be.true;
+    expect(res.output.specification.version).to.equal('3.0');
     expect(JSON.stringify(JSON.parse(res.output.data[0].bundledContent), null, 2)).to.be.equal(expected);
   });
 });


### PR DESCRIPTION
Fix referenced key components
- Adding a rule that resolves when the spec references the components object or the components keys objects (schemas, responses, parameters ... etc)
- Resolving the components object before the generateComponentsObject method when the components object is referenced from an external file. 