### PR TITLE
Fix error in ref map with inline

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -348,7 +348,6 @@ function getReferences (currentNode, isOutOfRoot, pathSolver, parentFilename, ve
 
         if (nodeTrace.length === 0) {
           inline = true;
-          newRefInDoc = localPointer + jsonPointerLevelSeparator + traceToParent.join(jsonPointerLevelSeparator);
         }
 
         nodeReferenceDirectory[tempRef] = {
@@ -434,6 +433,30 @@ function getNodeContentAndReferences (currentNode, allData, specRoot, version, r
   return { graphAdj, missingNodes, nodeContent, nodeReferenceDirectory, nodeName: currentNode.fileName };
 }
 
+
+/**
+   * Maps the output from get root files to detect root files
+   * @param {array} parents - current { path, content} object
+   * @param {string} key -  array of { path, content} objects
+   * @returns {object} - Detect root files result object
+   */
+function resolveJsonPointerInlineNodes(parents, key) {
+  let pointer = parents.filter((parent) => {
+    return parent !== undefined;
+  }).map((parent) => {
+    return parent.key;
+  }).join(jsonPointerLevelSeparator);
+  if (pointer) {
+    pointer = localPointer + pointer;
+  }
+  else {
+    pointer += localPointer;
+  }
+  pointer += jsonPointerLevelSeparator + key;
+
+  return pointer;
+}
+
 /**
  * Generates the components object from the documentContext data
  * @param {object} documentContext The document context from root
@@ -503,6 +526,8 @@ function generateComponentsObject (documentContext, rootContent, refTypeResolver
             refData.node = hasSiblings ?
               _.merge(referenceSiblings, refData.nodeContent) :
               refData.nodeContent;
+            documentContext.globalReferences[property.$ref].reference =
+               resolveJsonPointerInlineNodes(this.parents, this.key);
           }
           this.update(refData.node);
           if (!refData.inline) {

--- a/test/data/toBundleExamples/paths_schema/ErrorResponse.yml
+++ b/test/data/toBundleExamples/paths_schema/ErrorResponse.yml
@@ -1,0 +1,34 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+type: object
+title: ErrorResponse
+description: In the case of an error, a standard format error response body will be returned and the HTTP status code will be set to an error status. The response contains an object with a single error object.
+required: [error]
+properties:
+  error:
+    description: An error return by the server.
+    type: object
+    title: ErrorObject
+    required: [code, message, errors]
+    properties:
+      code:
+        description: This is the same as the HTTP status of the response.
+        type: number
+      message:
+        description: A short description of the error.
+        type: string
+      status:
+        description: A status code that indicates the error type.
+        type: string

--- a/test/data/toBundleExamples/paths_schema/ErrorResponse.yml
+++ b/test/data/toBundleExamples/paths_schema/ErrorResponse.yml
@@ -1,20 +1,6 @@
-# Copyright 2021 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 type: object
 title: ErrorResponse
-description: In the case of an error, a standard format error response body will be returned and the HTTP status code will be set to an error status. The response contains an object with a single error object.
+description: In the case of an error, a standard format error r
 required: [error]
 properties:
   error:

--- a/test/data/toBundleExamples/paths_schema/GeolocationRequest.yml
+++ b/test/data/toBundleExamples/paths_schema/GeolocationRequest.yml
@@ -1,0 +1,40 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+type: object
+title: GeolocationRequest
+description: The request body must be formatted as JSON. The following fields are supported, and all fields are optional.
+properties:
+  homeMobileCountryCode:
+    type: integer
+    description: The cell tower's Mobile Country Code (MCC).
+  homeMobileNetworkCode:
+    type: integer
+    description:
+      The cell tower's Mobile Network Code. This is the MNC for GSM and
+      WCDMA; CDMA uses the System ID (SID).
+  radioType:
+    type: string
+    description: The mobile radio type. Supported values are lte, gsm, cdma, and wcdma. While this field is optional, it should be included if a value is available, for more accurate results.
+  carrier:
+    type: string
+    description: The carrier name.
+  considerIp:
+    type: string
+    description: Specifies whether to fall back to IP geolocation if wifi and cell tower signals are not available. Defaults to true. Set considerIp to false to disable fall back.
+  cellTowers:
+    type: array
+    description: The request body's cellTowers array contains zero or more cell tower objects.
+    items:
+      $ref: "./CellTower.yml"

--- a/test/data/toBundleExamples/paths_schema/GeolocationRequest.yml
+++ b/test/data/toBundleExamples/paths_schema/GeolocationRequest.yml
@@ -1,16 +1,3 @@
-# Copyright 2020 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 type: object
 title: GeolocationRequest
@@ -22,8 +9,7 @@ properties:
   homeMobileNetworkCode:
     type: integer
     description:
-      The cell tower's Mobile Network Code. This is the MNC for GSM and
-      WCDMA; CDMA uses the System ID (SID).
+      The cell
   radioType:
     type: string
     description: The mobile radio type. Supported values are lte, gsm, cdma, and wcdma. While this field is optional, it should be included if a value is available, for more accurate results.

--- a/test/data/toBundleExamples/paths_schema/GeolocationResponse.yml
+++ b/test/data/toBundleExamples/paths_schema/GeolocationResponse.yml
@@ -1,0 +1,8 @@
+type: object
+title: GeolocationResponse
+description: A successful geolocation request will return a JSON-formatted response defining a location and radius.
+required: [location, accuracy]
+properties:
+  accuracy:
+    description: The accuracy of the estimated location, in meters. This represents the radius of a circle around the given `location`. If your Geolocation response shows a very high value in the `accuracy` field, the service may be geolocating based on the  request IP, instead of WiFi points or cell towers. This can happen if no cell towers or access points are valid or recognized. To confirm that this is the issue, set `considerIp` to `false` in your request. If the response is a `404`, you've confirmed that your `wifiAccessPoints` and `cellTowers` objects could not be geolocated.
+    type: number

--- a/test/data/toBundleExamples/paths_schema/geolocate.yml
+++ b/test/data/toBundleExamples/paths_schema/geolocate.yml
@@ -1,0 +1,50 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+servers:
+  - url: https://www.googleapis.com
+tags:
+  - Geolocation API
+description: |-
+  Geolocation API returns a location and accuracy radius based on information about cell towers and WiFi nodes that the mobile client can detect. This document describes the protocol used to send this data to the server and to return a response to the client.
+
+  Communication is done over HTTPS using POST. Both request and response are formatted as JSON, and the content type of both is `application/json`.
+
+  You must specify a key in your request, included as the value of a`key` parameter. A `key` is your application's  API key. This key identifies your application for purposes of quota management. Learn how to [get a key](https://developers.google.com/maps/documentation/geolocation/get-api-key).
+requestBody:
+  description: The request body must be formatted as JSON.
+  content:
+    "application/json":
+      schema:
+         $ref: "./GeolocationRequest.yml"
+  required: false
+responses:
+  "200":
+    description: 200 OK
+    content:
+      application/json:
+        schema:
+          $ref: "./GeolocationResponse.yml"
+  "400":
+    description: 400 BAD REQUEST
+    content:
+      application/json:
+        schema:
+          $ref: "./ErrorResponse.yml"
+  "404":
+    description: 404 NOT FOUND
+    content:
+      application/json:
+        schema:
+          $ref: "./ErrorResponse.yml"

--- a/test/data/toBundleExamples/paths_schema/geolocate.yml
+++ b/test/data/toBundleExamples/paths_schema/geolocate.yml
@@ -1,27 +1,10 @@
-# Copyright 2020 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 servers:
-  - url: https://www.googleapis.com
+  - url: https://www.server.com
 tags:
   - Geolocation API
 description: |-
-  Geolocation API returns a location and accuracy radius based on information about cell towers and WiFi nodes that the mobile client can detect. This document describes the protocol used to send this data to the server and to return a response to the client.
-
-  Communication is done over HTTPS using POST. Both request and response are formatted as JSON, and the content type of both is `application/json`.
-
-  You must specify a key in your request, included as the value of a`key` parameter. A `key` is your application's  API key. This key identifies your application for purposes of quota management. Learn how to [get a key](https://developers.google.com/maps/documentation/geolocation/get-api-key).
+  Geolocation API returns a location and accuracy
 requestBody:
   description: The request body must be formatted as JSON.
   content:

--- a/test/data/toBundleExamples/paths_schema/index.yml
+++ b/test/data/toBundleExamples/paths_schema/index.yml
@@ -1,0 +1,9 @@
+openapi: 3.0.3
+info:
+  title: Google Maps Platform
+  description: API Specification for Google Maps Platform
+  version: 1.17.16
+servers:
+  - url: "https://www.googleapis.com"
+paths:
+  $ref: "./paths.yml"

--- a/test/data/toBundleExamples/paths_schema/index.yml
+++ b/test/data/toBundleExamples/paths_schema/index.yml
@@ -1,9 +1,9 @@
 openapi: 3.0.3
 info:
-  title: Google Maps Platform
-  description: API Specification for Google Maps Platform
+  title: Maps Platform
+  description: API Specification for Maps Platform
   version: 1.17.16
 servers:
-  - url: "https://www.googleapis.com"
+  - url: "https://www.server.com"
 paths:
   $ref: "./paths.yml"

--- a/test/data/toBundleExamples/paths_schema/paths.yml
+++ b/test/data/toBundleExamples/paths_schema/paths.yml
@@ -1,0 +1,4 @@
+/geolocation/v1/geolocate:
+  post:
+    operationId: geolocate
+    $ref: "./geolocate.yml"

--- a/test/data/toBundleExamples/referenced_path/expected.json
+++ b/test/data/toBundleExamples/referenced_path/expected.json
@@ -1,0 +1,98 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "email": "apiteam@swagger.io",
+      "url": "http://swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets alesuada ac...",
+        "operationId": "findPets",
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_pet.yaml"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cat": {
+      "get": {
+        "description": "Returns one cat",
+        "operationId": "findcat",
+        "responses": {
+          "200": {
+            "description": "cat response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_cat.yaml"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "_cat.yaml": {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "favFood": {
+            "type": "string"
+          }
+        }
+      },
+      "_pet.yaml": {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/data/toBundleExamples/referenced_path/path.yaml
+++ b/test/data/toBundleExamples/referenced_path/path.yaml
@@ -1,9 +1,9 @@
 description: Returns all pets alesuada ac...
-  operationId: findPets
-  responses:
-    "200":
-      description: pet response
-      content:
-        application/json:
-          schema:
-            $ref: "./pet.yaml"
+operationId: findPets
+responses:
+  "200":
+    description: pet response
+    content:
+      application/json:
+        schema:
+          $ref: "./pet.yaml"


### PR DESCRIPTION
Fix error while resolving to map for inline elements.
We are taking only the reference to the parent, but in nested references (more than one file in deepness) we should be taking all the trace to the root.

Change the way we calculate the ref, to be relative to the root (or new bundle file) instead of the parent file.