### PR TITLE
Fix error in ref map with inline - swagger 20 support

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -347,7 +347,6 @@ function getReferences (currentNode, isOutOfRoot, pathSolver, parentFilename, ve
 
         if (nodeTrace.length === 0) {
           inline = true;
-          newRefInDoc = localPointer + jsonPointerLevelSeparator + traceToParent.join(jsonPointerLevelSeparator);
         }
 
         nodeReferenceDirectory[tempRef] = {
@@ -433,6 +432,30 @@ function getNodeContentAndReferences (currentNode, allData, specRoot, version, r
   return { graphAdj, missingNodes, nodeContent, nodeReferenceDirectory, nodeName: currentNode.fileName };
 }
 
+
+/**
+   * Maps the output from get root files to detect root files
+   * @param {array} parents - current { path, content} object
+   * @param {string} key -  array of { path, content} objects
+   * @returns {object} - Detect root files result object
+   */
+function resolveJsonPointerInlineNodes(parents, key) {
+  let pointer = parents.filter((parent) => {
+    return parent !== undefined;
+  }).map((parent) => {
+    return parent.key;
+  }).join(jsonPointerLevelSeparator);
+  if (pointer) {
+    pointer = localPointer + pointer;
+  }
+  else {
+    pointer += localPointer;
+  }
+  pointer += jsonPointerLevelSeparator + key;
+
+  return pointer;
+}
+
 /**
  * Generates the components object from the documentContext data
  * @param {object} documentContext The document context from root
@@ -503,6 +526,8 @@ function generateComponentsObject (documentContext, rootContent, refTypeResolver
             refData.node = hasSiblings ?
               _.merge(referenceSiblings, refData.nodeContent) :
               refData.nodeContent;
+            documentContext.globalReferences[property.$ref].reference =
+              resolveJsonPointerInlineNodes(this.parents, this.key);
           }
           this.update(refData.node);
           if (!refData.inline) {

--- a/test/data/toBundleExamples/paths_schema/ErrorResponse.yml
+++ b/test/data/toBundleExamples/paths_schema/ErrorResponse.yml
@@ -1,0 +1,20 @@
+type: object
+title: ErrorResponse
+description: In the case of an error, a standard format error r
+required: [error]
+properties:
+  error:
+    description: An error return by the server.
+    type: object
+    title: ErrorObject
+    required: [code, message, errors]
+    properties:
+      code:
+        description: This is the same as the HTTP status of the response.
+        type: number
+      message:
+        description: A short description of the error.
+        type: string
+      status:
+        description: A status code that indicates the error type.
+        type: string

--- a/test/data/toBundleExamples/paths_schema/GeolocationRequest.yml
+++ b/test/data/toBundleExamples/paths_schema/GeolocationRequest.yml
@@ -1,0 +1,26 @@
+
+type: object
+title: GeolocationRequest
+description: The request body must be formatted as JSON. The following fields are supported, and all fields are optional.
+properties:
+  homeMobileCountryCode:
+    type: integer
+    description: The cell tower's Mobile Country Code (MCC).
+  homeMobileNetworkCode:
+    type: integer
+    description:
+      The cell
+  radioType:
+    type: string
+    description: The mobile radio type. Supported values are lte, gsm, cdma, and wcdma. While this field is optional, it should be included if a value is available, for more accurate results.
+  carrier:
+    type: string
+    description: The carrier name.
+  considerIp:
+    type: string
+    description: Specifies whether to fall back to IP geolocation if wifi and cell tower signals are not available. Defaults to true. Set considerIp to false to disable fall back.
+  cellTowers:
+    type: array
+    description: The request body's cellTowers array contains zero or more cell tower objects.
+    items:
+      $ref: "./CellTower.yml"

--- a/test/data/toBundleExamples/paths_schema/GeolocationResponse.yml
+++ b/test/data/toBundleExamples/paths_schema/GeolocationResponse.yml
@@ -1,0 +1,8 @@
+type: object
+title: GeolocationResponse
+description: A successful geolocation request will return a JSON-formatted response defining a location and radius.
+required: [location, accuracy]
+properties:
+  accuracy:
+    description: The accuracy of the estimated location, in meters. This represents the radius of a circle around the given `location`. If your Geolocation response shows a very high value in the `accuracy` field, the service may be geolocating based on the  request IP, instead of WiFi points or cell towers. This can happen if no cell towers or access points are valid or recognized. To confirm that this is the issue, set `considerIp` to `false` in your request. If the response is a `404`, you've confirmed that your `wifiAccessPoints` and `cellTowers` objects could not be geolocated.
+    type: number

--- a/test/data/toBundleExamples/paths_schema/geolocate.yml
+++ b/test/data/toBundleExamples/paths_schema/geolocate.yml
@@ -1,0 +1,33 @@
+
+servers:
+  - url: https://www.server.com
+tags:
+  - Geolocation API
+description: |-
+  Geolocation API returns a location and accuracy
+requestBody:
+  description: The request body must be formatted as JSON.
+  content:
+    "application/json":
+      schema:
+         $ref: "./GeolocationRequest.yml"
+  required: false
+responses:
+  "200":
+    description: 200 OK
+    content:
+      application/json:
+        schema:
+          $ref: "./GeolocationResponse.yml"
+  "400":
+    description: 400 BAD REQUEST
+    content:
+      application/json:
+        schema:
+          $ref: "./ErrorResponse.yml"
+  "404":
+    description: 404 NOT FOUND
+    content:
+      application/json:
+        schema:
+          $ref: "./ErrorResponse.yml"

--- a/test/data/toBundleExamples/paths_schema/index.yml
+++ b/test/data/toBundleExamples/paths_schema/index.yml
@@ -1,0 +1,9 @@
+openapi: 3.0.3
+info:
+  title: Maps Platform
+  description: API Specification for Maps Platform
+  version: 1.17.16
+servers:
+  - url: "https://www.server.com"
+paths:
+  $ref: "./paths.yml"

--- a/test/data/toBundleExamples/paths_schema/paths.yml
+++ b/test/data/toBundleExamples/paths_schema/paths.yml
@@ -1,0 +1,4 @@
+/geolocation/v1/geolocate:
+  post:
+    operationId: geolocate
+    $ref: "./geolocate.yml"

--- a/test/data/toBundleExamples/referenced_path/expected.json
+++ b/test/data/toBundleExamples/referenced_path/expected.json
@@ -1,0 +1,98 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "email": "apiteam@swagger.io",
+      "url": "http://swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets alesuada ac...",
+        "operationId": "findPets",
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_pet.yaml"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cat": {
+      "get": {
+        "description": "Returns one cat",
+        "operationId": "findcat",
+        "responses": {
+          "200": {
+            "description": "cat response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_cat.yaml"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "_cat.yaml": {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "favFood": {
+            "type": "string"
+          }
+        }
+      },
+      "_pet.yaml": {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/data/toBundleExamples/referenced_path/path.yaml
+++ b/test/data/toBundleExamples/referenced_path/path.yaml
@@ -1,9 +1,9 @@
 description: Returns all pets alesuada ac...
-  operationId: findPets
-  responses:
-    "200":
-      description: pet response
-      content:
-        application/json:
-          schema:
-            $ref: "./pet.yaml"
+operationId: findPets
+responses:
+  "200":
+    description: pet response
+    content:
+      application/json:
+        schema:
+          $ref: "./pet.yaml"

--- a/test/unit/bundle.test.js
+++ b/test/unit/bundle.test.js
@@ -44,7 +44,8 @@ let expect = require('chai').expect,
   nestedExamplesAsValue = path.join(__dirname, BUNDLES_FOLDER + '/nested_examples_as_value'),
   referencedProperties = path.join(__dirname, BUNDLES_FOLDER + '/referenced_properties'),
   referencedComponents = path.join(__dirname, BUNDLES_FOLDER + '/referenced_components'),
-  referencedPath = path.join(__dirname, BUNDLES_FOLDER + '/referenced_path');
+  referencedPath = path.join(__dirname, BUNDLES_FOLDER + '/referenced_path'),
+  referencedPathSchema = path.join(__dirname, BUNDLES_FOLDER + '/paths_schema');
 
 describe('bundle files method - 3.0', function () {
   it('Should return bundled file as json - schema_from_response', async function () {
@@ -774,6 +775,16 @@ describe('bundle files method - 3.0', function () {
       paths = fs.readFileSync(refPaths + '/paths/paths.yaml', 'utf8'),
       path = fs.readFileSync(refPaths + '/paths/path.yaml', 'utf8'),
       expected = fs.readFileSync(refPaths + '/expected.json', 'utf8'),
+      expectedMap = {
+        '#/paths': {
+          path: '/paths/paths.yaml',
+          type: 'inline'
+        },
+        '#/paths//pets/get': {
+          path: '/paths/path.yaml',
+          type: 'inline'
+        }
+      },
       input = {
         type: 'multiFile',
         specificationVersion: '3.0',
@@ -796,13 +807,14 @@ describe('bundle files method - 3.0', function () {
             content: path
           }
         ],
-        options: {},
+        options: { includeReferenceMap: true },
         bundleFormat: 'JSON'
       };
     const res = await Converter.bundle(input);
 
     expect(res).to.not.be.empty;
     expect(res.result).to.be.true;
+    expect(res.output.data[0].referenceMap).to.deep.equal(expectedMap);
     expect(JSON.stringify(JSON.parse(res.output.data[0].bundledContent), null, 2)).to.be.equal(expected);
   });
 
@@ -2358,6 +2370,7 @@ describe('bundle files method - 3.0', function () {
       path = fs.readFileSync(referencedPath + '/path.yaml', 'utf8'),
       pet = fs.readFileSync(referencedPath + '/pet.yaml', 'utf8'),
       cat = fs.readFileSync(referencedPath + '/cat.yaml', 'utf8'),
+      expectedBundled = fs.readFileSync(referencedPath + '/expected.json', 'utf8'),
       expected = {
         '#/paths//pets/get': {
           path: '/path.yaml',
@@ -2365,6 +2378,10 @@ describe('bundle files method - 3.0', function () {
         },
         '#/components/schemas/_cat.yaml': {
           path: '/cat.yaml',
+          type: 'component'
+        },
+        '#/components/schemas/_pet.yaml': {
+          path: '/pet.yaml',
           type: 'component'
         }
       },
@@ -2402,6 +2419,7 @@ describe('bundle files method - 3.0', function () {
     expect(res).to.not.be.empty;
     expect(res.result).to.be.true;
     expect(res.output.data[0].referenceMap).to.deep.equal(expected);
+    expect(JSON.stringify(JSON.parse(res.output.data[0].bundledContent), null, 2)).to.be.equal(expectedBundled);
   });
 
   it('Should return bundled file - referenced-components', async function () {
@@ -2450,6 +2468,83 @@ describe('bundle files method - 3.0', function () {
     expect(res.result).to.be.true;
     expect(res.output.specification.version).to.equal('3.0');
     expect(JSON.stringify(JSON.parse(res.output.data[0].bundledContent), null, 2)).to.be.equal(expected);
+  });
+
+  it('Should return bundled file with referenced paths from roots', async function () {
+    let contentRootFile = fs.readFileSync(referencedPathSchema + '/index.yml', 'utf8'),
+      paths = fs.readFileSync(referencedPathSchema + '/paths.yml', 'utf8'),
+      errorResponse = fs.readFileSync(referencedPathSchema + '/ErrorResponse.yml', 'utf8'),
+      geolocationResponse = fs.readFileSync(referencedPathSchema + '/GeolocationResponse.yml', 'utf8'),
+      geolocationRequest = fs.readFileSync(referencedPathSchema + '/GeolocationRequest.yml', 'utf8'),
+      geolocate = fs.readFileSync(referencedPathSchema + '/geolocate.yml', 'utf8'),
+      expectedMap = {
+        '#/paths': {
+          path: '/paths.yml',
+          type: 'inline'
+        },
+        '#/paths//geolocation/v1/geolocate/post': {
+          path: '/geolocate.yml',
+          type: 'inline'
+        },
+        '#/components/schemas/_GeolocationRequest.yml': {
+          path: '/GeolocationRequest.yml',
+          type: 'component'
+        },
+        '#/components/schemas/_GeolocationResponse.yml': {
+          path: '/GeolocationResponse.yml',
+          type: 'component'
+        },
+        '#/components/schemas/_ErrorResponse.yml': {
+          path: '/ErrorResponse.yml',
+          type: 'component'
+        },
+        '#/components/schemas/_CellTower.yml': {
+          path: '/CellTower.yml',
+          type: 'component'
+        }
+      },
+      input = {
+        type: 'multiFile',
+        specificationVersion: '3.0',
+        rootFiles: [
+          {
+            path: '/index.yml'
+          }
+        ],
+        data: [
+          {
+            path: '/index.yml',
+            content: contentRootFile
+          },
+          {
+            path: '/paths.yml',
+            content: paths
+          },
+          {
+            path: '/ErrorResponse.yml',
+            content: errorResponse
+          },
+          {
+            path: '/GeolocationResponse.yml',
+            content: geolocationResponse
+          },
+          {
+            path: '/GeolocationRequest.yml',
+            content: geolocationRequest
+          },
+          {
+            path: '/geolocate.yml',
+            content: geolocate
+          }
+        ],
+        options: { includeReferenceMap: true },
+        bundleFormat: 'JSON'
+      };
+    const res = await Converter.bundle(input);
+
+    expect(res).to.not.be.empty;
+    expect(res.result).to.be.true;
+    expect(res.output.data[0].referenceMap).to.deep.equal(expectedMap);
   });
 });
 


### PR DESCRIPTION
Fix error while resolving to map for inline elements. swagger 20 branch support
We are taking only the reference to the parent, but in nested references (more than one file in deepness) we should be taking all the trace to the root.

current result:

```

        '#/paths': {
          path: '/paths.yml',
          type: 'inline'
        },
        '#//geolocation/v1/geolocate/post': {
          path: '/geolocate.yml',
          type: 'inline'
        },
```

and if you look at the second element in the map the pointer is related to the parent (paths) no the bundled

we should be getting instead:
```
        '#/paths': {
          path: '/paths.yml',
          type: 'inline'
        },
        '#/paths//geolocation/v1/geolocate/post': {
          path: '/geolocate.yml',
          type: 'inline'
        },
```
So the second element has a pointer related to the bundled file.

Change the way we calculate the ref, to be relative to the root (or new bundle file) instead of the parent file.