### PR TITLE
Resolve example inline

### DIFF
--- a/lib/bundleRules/spec30.js
+++ b/lib/bundleRules/spec30.js
@@ -8,7 +8,6 @@ const SCHEMA_CONTAINERS = [
     'schema'
   ],
   EXAMPLE_CONTAINERS = [
-    'example'
   ],
   REQUEST_BODY_CONTAINER = [
     'requestBody'
@@ -27,7 +26,8 @@ const SCHEMA_CONTAINERS = [
   },
   INLINE = [
     'properties',
-    'value'
+    'value',
+    'example'
   ],
   ROOT_CONTAINERS_KEYS = [
     'components'

--- a/lib/bundleRules/spec31.js
+++ b/lib/bundleRules/spec31.js
@@ -28,7 +28,8 @@ const SCHEMA_CONTAINERS = [
   },
   INLINE = [
     'properties',
-    'value'
+    'value',
+    'example'
   ],
   ROOT_CONTAINERS_KEYS = [
     'components'

--- a/lib/bundleRules/spec31.js
+++ b/lib/bundleRules/spec31.js
@@ -8,7 +8,6 @@ const SCHEMA_CONTAINERS = [
     'schema'
   ],
   EXAMPLE_CONTAINERS = [
-    'example'
   ],
   REQUEST_BODY_CONTAINER = [
     'requestBody'

--- a/test/data/toBundleExamples/referenced_examples/expected.json
+++ b/test/data/toBundleExamples/referenced_examples/expected.json
@@ -32,7 +32,11 @@
                   }
                 },
                 "example": {
-                  "$ref": "#/components/examples/_examples.yaml-_foo"
+                  "summary": "sum",
+                  "value": {
+                    "code": 1,
+                    "message": "test error message"
+                  }
                 }
               }
             }
@@ -84,15 +88,6 @@
           "message": {
             "type": "string"
           }
-        }
-      }
-    },
-    "examples": {
-      "_examples.yaml-_foo": {
-        "summary": "sum",
-        "value": {
-          "code": 1,
-          "message": "test error message"
         }
       }
     }


### PR DESCRIPTION
Force example to be solved inline because the validator throws error when example is under components.examples and does not have a value.

For avoiding these errors for now we are always resolving inline.