### PR TITLE
Feat/example in line20

### DIFF
--- a/lib/bundleRules/spec20.js
+++ b/lib/bundleRules/spec20.js
@@ -13,7 +13,8 @@ const SCHEMA_CONTAINERS = [
   },
   INLINE = [
     'examples',
-    'value'
+    'value',
+    'example'
   ],
   COMPONENTS_KEYS = [
     'definitions',

--- a/lib/bundleRules/spec30.js
+++ b/lib/bundleRules/spec30.js
@@ -8,7 +8,6 @@ const SCHEMA_CONTAINERS = [
     'schema'
   ],
   EXAMPLE_CONTAINERS = [
-    'example'
   ],
   REQUEST_BODY_CONTAINER = [
     'requestBody'
@@ -23,11 +22,13 @@ const SCHEMA_CONTAINERS = [
     responses: 'responses',
     callbacks: 'callbacks',
     properties: 'schemas',
-    links: 'links'
+    links: 'links',
+    examples: 'examples'
   },
   INLINE = [
     'properties',
-    'value'
+    'value',
+    'example'
   ],
   ROOT_CONTAINERS_KEYS = [
     'components'

--- a/lib/bundleRules/spec31.js
+++ b/lib/bundleRules/spec31.js
@@ -8,7 +8,6 @@ const SCHEMA_CONTAINERS = [
     'schema'
   ],
   EXAMPLE_CONTAINERS = [
-    'example'
   ],
   REQUEST_BODY_CONTAINER = [
     'requestBody'
@@ -24,11 +23,13 @@ const SCHEMA_CONTAINERS = [
     callbacks: 'callbacks',
     properties: 'schemas',
     links: 'links',
-    paths: 'pathItems'
+    paths: 'pathItems',
+    examples: 'examples'
   },
   INLINE = [
     'properties',
-    'value'
+    'value',
+    'example'
   ],
   ROOT_CONTAINERS_KEYS = [
     'components'

--- a/lib/jsonPointer.js
+++ b/lib/jsonPointer.js
@@ -88,7 +88,7 @@ function getKeyInComponents(traceFromParent, mainKey, version, commonPathFromDat
     }
     item = resolveFirstLevelChild(item, CONTAINERS);
     resolveSecondLevelChild(trace, index, DEFINITIONS);
-    traceToKey.push(item);
+    traceToKey.push(item.replace(/\s/g, ''));
     if (COMPONENTS_KEYS.includes(item)) {
       matchFound = true;
       break;

--- a/test/data/toBundleExamples/example2/another.yml
+++ b/test/data/toBundleExamples/example2/another.yml
@@ -1,0 +1,106 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.10
+  title: Petstore 224
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Postman
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  x-postman-projectname: PostmanPetstore
+
+paths:
+  /pets:
+    parameters:
+      - name: GlobalParam
+        in: query
+        schema:
+          type: string
+      - name: GlobalCookie
+        in: cookie
+        schema:
+          type: string
+    post:
+      description: Creates a new pet in the store. Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                Single Droplet Create Request:
+                  $ref: "./example2.yaml#/droplet_create_request"
+components:
+  schemas:
+    Pet:
+      type: object
+      description: A pet
+      required:
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        typeOf:
+          type: string
+          enum: [Cat, Dog, Bird, Reptile]
+        tag:
+          type: string
+
+    Pets:
+      type: object
+      properties:
+        id:
+            type: integer
+
+    StoreItem:
+      description: Single store item
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        typeOf:
+          type: string
+          enum: [ Cat, Dog, Bird, Reptile ]
+        tag:
+          type: string
+        value:
+          type: number
+          format: float
+          description: price
+        saleValue:
+          type: number
+          format: float
+          description: price if on sale
+        onSale:
+          type: boolean
+          default: false
+          description: True if item is on sale, false if not.
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/test/data/toBundleExamples/example2/example2.yaml
+++ b/test/data/toBundleExamples/example2/example2.yaml
@@ -1,0 +1,17 @@
+droplet_create_request:
+  value:
+    name: example.com
+    region: nyc3
+    size: s-1vcpu-1gb
+    image: ubuntu-20-04-x64
+    ssh_keys:
+    - 289794
+    - 3b:16:e4:bf:8b:00:8b:b8:59:8c:a9:d3:f0:19:fa:45
+    backups: true
+    ipv6: true
+    monitoring: true
+    tags:
+    - env:prod
+    - web
+    user_data: "#cloud-config\nruncmd:\n  - touch /test.txt\n"
+    vpc_uuid: 760e09ef-dc84-11e8-981e-3cfdfeaae000

--- a/test/data/toBundleExamples/example2/expected.json
+++ b/test/data/toBundleExamples/example2/expected.json
@@ -1,0 +1,187 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.10",
+    "title": "Petstore 224",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Postman"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "x-postman-projectname": "PostmanPetstore"
+  },
+  "paths": {
+    "/pets": {
+      "parameters": [
+        {
+          "name": "GlobalParam",
+          "in": "query",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "GlobalCookie",
+          "in": "cookie",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "description": "Creates a new pet in the store. Duplicates are allowed",
+        "operationId": "addPet",
+        "requestBody": {
+          "description": "Pet to add to the store",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "Single Droplet Create Request": {
+                    "$ref": "#/components/examples/_example2.yaml-_droplet_create_request"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "description": "A pet",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "typeOf": {
+            "type": "string",
+            "enum": [
+              "Cat",
+              "Dog",
+              "Bird",
+              "Reptile"
+            ]
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      },
+      "Pets": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          }
+        }
+      },
+      "StoreItem": {
+        "description": "Single store item",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "typeOf": {
+            "type": "string",
+            "enum": [
+              "Cat",
+              "Dog",
+              "Bird",
+              "Reptile"
+            ]
+          },
+          "tag": {
+            "type": "string"
+          },
+          "value": {
+            "type": "number",
+            "format": "float",
+            "description": "price"
+          },
+          "saleValue": {
+            "type": "number",
+            "format": "float",
+            "description": "price if on sale"
+          },
+          "onSale": {
+            "type": "boolean",
+            "default": false,
+            "description": "True if item is on sale, false if not."
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "examples": {
+      "_example2.yaml-_droplet_create_request": {
+        "value": {
+          "name": "example.com",
+          "region": "nyc3",
+          "size": "s-1vcpu-1gb",
+          "image": "ubuntu-20-04-x64",
+          "ssh_keys": [
+            289794,
+            "3b:16:e4:bf:8b:00:8b:b8:59:8c:a9:d3:f0:19:fa:45"
+          ],
+          "backups": true,
+          "ipv6": true,
+          "monitoring": true,
+          "tags": [
+            "env:prod",
+            "web"
+          ],
+          "user_data": "#cloud-config\nruncmd:\n  - touch /test.txt\n",
+          "vpc_uuid": "760e09ef-dc84-11e8-981e-3cfdfeaae000"
+        }
+      }
+    }
+  }
+}

--- a/test/data/toBundleExamples/referenced_examples/expected.json
+++ b/test/data/toBundleExamples/referenced_examples/expected.json
@@ -32,7 +32,11 @@
                   }
                 },
                 "example": {
-                  "$ref": "#/components/examples/_examples.yaml-_foo"
+                  "summary": "sum",
+                  "value": {
+                    "code": 1,
+                    "message": "test error message"
+                  }
                 }
               }
             }
@@ -84,15 +88,6 @@
           "message": {
             "type": "string"
           }
-        }
-      }
-    },
-    "examples": {
-      "_examples.yaml-_foo": {
-        "summary": "sum",
-        "value": {
-          "code": 1,
-          "message": "test error message"
         }
       }
     }

--- a/test/data/toBundleExamples/swagger20/referenced_example_key/example.yaml
+++ b/test/data/toBundleExamples/swagger20/referenced_example_key/example.yaml
@@ -1,0 +1,3 @@
+id: 1
+name: Puma
+tag: Test

--- a/test/data/toBundleExamples/swagger20/referenced_example_key/expected.json
+++ b/test/data/toBundleExamples/swagger20/referenced_example_key/expected.json
@@ -1,0 +1,83 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "email": "apiteam@swagger.io",
+      "url": "http://swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets alesuada ac...",
+        "operationId": "findPets",
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            },
+            "example": {
+              "id": 1,
+              "name": "Puma",
+              "tag": "Test"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Error": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/test/data/toBundleExamples/swagger20/referenced_example_key/expected.json
+++ b/test/data/toBundleExamples/swagger20/referenced_example_key/expected.json
@@ -27,12 +27,12 @@
               "type": "array",
               "items": {
                 "$ref": "#/definitions/Pet"
+              },
+              "example": {
+                "id": 1,
+                "name": "Puma",
+                "tag": "Test"
               }
-            },
-            "example": {
-              "id": 1,
-              "name": "Puma",
-              "tag": "Test"
             }
           },
           "default": {

--- a/test/data/toBundleExamples/swagger20/referenced_example_key/root.yaml
+++ b/test/data/toBundleExamples/swagger20/referenced_example_key/root.yaml
@@ -1,0 +1,54 @@
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+paths:
+  /pets:
+    get:
+      description: Returns all pets alesuada ac...
+      operationId: findPets
+      responses:
+        '200':
+          description: pet response
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Pet'
+          example:
+            $ref: "example.yaml"
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Pet:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string
+  Error:
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string

--- a/test/data/toBundleExamples/swagger20/referenced_example_key/root.yaml
+++ b/test/data/toBundleExamples/swagger20/referenced_example_key/root.yaml
@@ -23,8 +23,8 @@ paths:
             type: array
             items:
               $ref: '#/definitions/Pet'
-          example:
-            $ref: "example.yaml"
+            example:
+              $ref: "example.yaml"
         default:
           description: unexpected error
           schema:

--- a/test/unit/bundle.test.js
+++ b/test/unit/bundle.test.js
@@ -46,7 +46,8 @@ let expect = require('chai').expect,
   referencedComponents = path.join(__dirname, BUNDLES_FOLDER + '/referenced_components'),
   referencedPath = path.join(__dirname, BUNDLES_FOLDER + '/referenced_path'),
   referencedPathSchema = path.join(__dirname, BUNDLES_FOLDER + '/paths_schema'),
-  exampleValue = path.join(__dirname, BUNDLES_FOLDER + '/example_value');
+  exampleValue = path.join(__dirname, BUNDLES_FOLDER + '/example_value'),
+  example2 = path.join(__dirname, BUNDLES_FOLDER + '/example2');
 
 describe('bundle files method - 3.0', function () {
   it('Should return bundled file as json - schema_from_response', async function () {
@@ -2575,6 +2576,37 @@ describe('bundle files method - 3.0', function () {
       };
     const res = await Converter.bundle(input);
 
+    expect(res).to.not.be.empty;
+    expect(res.result).to.be.true;
+    expect(res.output.specification.version).to.equal('3.0');
+    expect(JSON.stringify(JSON.parse(res.output.data[0].bundledContent), null, 2)).to.be.equal(expected);
+  });
+  it('Should resolve examples correctly', async function () {
+    let contentRootFile = fs.readFileSync(example2 + '/another.yml', 'utf8'),
+      example = fs.readFileSync(example2 + '/example2.yaml', 'utf8'),
+      expected = fs.readFileSync(example2 + '/expected.json', 'utf8'),
+      input = {
+        type: 'multiFile',
+        specificationVersion: '3.0',
+        rootFiles: [
+          {
+            path: '/another.yml'
+          }
+        ],
+        data: [
+          {
+            path: '/another.yml',
+            content: contentRootFile
+          },
+          {
+            path: '/example2.yaml',
+            content: example
+          }
+        ],
+        options: {},
+        bundleFormat: 'JSON'
+      };
+    const res = await Converter.bundle(input);
     expect(res).to.not.be.empty;
     expect(res.result).to.be.true;
     expect(res.output.specification.version).to.equal('3.0');

--- a/test/unit/bundle20.test.js
+++ b/test/unit/bundle20.test.js
@@ -29,7 +29,9 @@ let expect = require('chai').expect,
   schemaCollisionWRootComponent = path.join(__dirname, SWAGGER_MULTIFILE_FOLDER +
       '/schema_collision_w_root_components'),
   referencedRootComponents = path.join(__dirname, SWAGGER_MULTIFILE_FOLDER +
-    '/referenced_root_components');
+    '/referenced_root_components'),
+  referencedExampleKey = path.join(__dirname, SWAGGER_MULTIFILE_FOLDER +
+    '/referenced_example_key');
 
 describe('bundle files method - 2.0', function() {
   it('Should return bundled result from - nestedProperties20', async function() {
@@ -959,6 +961,39 @@ describe('bundle files method - 2.0', function() {
           {
             path: '/paths/path.yaml',
             content: singlePath
+          }
+        ],
+        options: {},
+        bundleFormat: 'JSON'
+      };
+    const res = await Converter.bundle(input);
+
+    expect(res).to.not.be.empty;
+    expect(res.result).to.be.true;
+    expect(res.output.specification.version).to.equal('2.0');
+    expect(JSON.stringify(JSON.parse(res.output.data[0].bundledContent), null, 2)).to.be.equal(expected);
+  });
+
+  it('Should return bundled file as json - referenced_example_key', async function () {
+    let contentRootFile = fs.readFileSync(referencedExampleKey + '/root.yaml', 'utf8'),
+      example = fs.readFileSync(referencedExampleKey + '/example.yaml', 'utf8'),
+      expected = fs.readFileSync(referencedExampleKey + '/expected.json', 'utf8'),
+      input = {
+        type: 'multiFile',
+        specificationVersion: '2.0',
+        rootFiles: [
+          {
+            path: '/root.yaml'
+          }
+        ],
+        data: [
+          {
+            path: '/root.yaml',
+            content: contentRootFile
+          },
+          {
+            path: '/example.yaml',
+            content: example
           }
         ],
         options: {},


### PR DESCRIPTION
Force example to be solved inline because the validator throws error when example is under components.examples and does not have a value.

For avoiding these errors for now we are always resolving inline.

Resolve correctly examples

same as https://github.com/postmanlabs/openapi-to-postman/pull/590 but for swagger 20