### PR TITLE
Remove support for swagger 2.0

### DIFF
--- a/lib/common/versionUtils.js
+++ b/lib/common/versionUtils.js
@@ -285,7 +285,7 @@ function validateSupportedVersion(version) {
   if (!version) {
     return false;
   }
-  let isValid = [DEFAULT_SPEC_VERSION, SWAGGER_VERSION, VERSION_3_1].find((supportedVersion) => {
+  let isValid = [DEFAULT_SPEC_VERSION, VERSION_3_1].find((supportedVersion) => {
     return compareVersion(version, supportedVersion);
   });
   return isValid !== undefined;

--- a/test/unit/versionUtils.test.js
+++ b/test/unit/versionUtils.test.js
@@ -340,9 +340,9 @@ describe('validateSupportedVersion method', function () {
     expect(result).to.be.true;
   });
 
-  it('should return true with version 2.0', function () {
+  it('should return false with version 2.0', function () {
     const result = validateSupportedVersion('2.0');
-    expect(result).to.be.true;
+    expect(result).to.be.false;
   });
 
   it('should return true with version 3.1', function () {


### PR DESCRIPTION
avoid converting files with version 2.0

Avoid the bundling process to bundle files with version 2.0