### PR TITLE
Fix/validation input

### DIFF
--- a/lib/30XUtils/inputValidation.js
+++ b/lib/30XUtils/inputValidation.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 module.exports = {
 
   /**
@@ -7,37 +8,43 @@ module.exports = {
    * @return {Object} Validation result
    */
   validateSpec: function (spec) {
-
+    if (_.isNil(spec)) {
+      return {
+        result: false,
+        reason: 'The Specification is null or undefined'
+      };
+    }
     // Checking for the all the required properties in the specification
-    if (!spec.hasOwnProperty('openapi')) {
+    if (_.isNil(spec.openapi)) {
       return {
         result: false,
         reason: 'Specification must contain a semantic version number of the OAS specification'
       };
     }
 
-    if (!spec.hasOwnProperty('paths')) {
+    if (_.isNil(spec.paths)) {
       return {
         result: false,
         reason: 'Specification must contain Paths Object for the available operational paths'
       };
     }
 
-    if (!spec.hasOwnProperty('info')) {
+    if (_.isNil(spec.info)) {
       return {
         result: false,
         reason: 'Specification must contain an Info Object for the meta-data of the API'
       };
     }
+
     if (!spec.info.hasOwnProperty('$ref')) {
-      if (!spec.info.hasOwnProperty('title')) {
+      if (_.isNil(_.get(spec, 'info.title'))) {
         return {
           result: false,
           reason: 'Specification must contain a title in order to generate a collection'
         };
       }
 
-      if (!spec.info.hasOwnProperty('version')) {
+      if (_.isNil(_.get(spec, 'info.version'))) {
         return {
           result: false,
           reason: 'Specification must contain a semantic version number of the API in the Info Object'

--- a/lib/31XUtils/inputValidation31X.js
+++ b/lib/31XUtils/inputValidation31X.js
@@ -1,4 +1,4 @@
-
+const _ = require('lodash');
 module.exports = {
 
   /**

--- a/lib/31XUtils/inputValidation31X.js
+++ b/lib/31XUtils/inputValidation31X.js
@@ -17,29 +17,45 @@ module.exports = {
         reason: 'The Specification is null or undefined'
       };
     }
-    if (!spec.hasOwnProperty('openapi')) {
+    if (_.isNil(spec.openapi)) {
       return {
         result: false,
         reason: 'Specification must contain a semantic version number of the OAS specification'
       };
     }
 
-    if (!spec.hasOwnProperty('info')) {
+    if (_.isNil(spec.info)) {
       return {
         result: false,
         reason: 'Specification must contain an Info Object for the meta-data of the API'
       };
     }
 
-    if (!spec.hasOwnProperty('paths') && !includeWebhooksOption) {
+    if (!spec.info.hasOwnProperty('$ref')) {
+      if (_.isNil(_.get(spec, 'info.title'))) {
+        return {
+          result: false,
+          reason: 'Specification must contain a title in order to generate a collection'
+        };
+      }
+
+      if (_.isNil(_.get(spec, 'info.version'))) {
+        return {
+          result: false,
+          reason: 'Specification must contain a semantic version number of the API in the Info Object'
+        };
+      }
+    }
+
+    if (_.isNil(spec.paths) && !includeWebhooksOption) {
       return {
         result: false,
         reason: 'Specification must contain Paths Object for the available operational paths'
       };
     }
 
-    if (includeWebhooksOption && !spec.hasOwnProperty('paths') &&
-      !spec.hasOwnProperty('webhooks') && !spec.hasOwnProperty('components')) {
+    if (includeWebhooksOption && _.isNil(spec.paths) &&
+      _.isNil(spec.webhooks) && _.isNil(spec.components)) {
       return {
         result: false,
         reason: 'Specification must contain either Paths, Webhooks or Components sections'

--- a/lib/31XUtils/inputValidation31X.js
+++ b/lib/31XUtils/inputValidation31X.js
@@ -11,6 +11,12 @@ module.exports = {
    */
   validateSpec: function (spec, options) {
     const includeWebhooksOption = options.includeWebhooks;
+    if (_.isNil(spec)) {
+      return {
+        result: false,
+        reason: 'The Specification is null or undefined'
+      };
+    }
     if (!spec.hasOwnProperty('openapi')) {
       return {
         result: false,

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -710,9 +710,9 @@ class SchemaPack {
       if (rootFiles.output.data) {
         let inputContent = [];
         rootFiles.output.data.forEach((rootFile) => {
-          let founInData = input.data.find((dataFile) => { return dataFile.fileName === rootFile.path; });
-          if (founInData) {
-            inputContent.push({ fileName: founInData.fileName, content: founInData.content });
+          let foundInData = input.data.find((dataFile) => { return dataFile.fileName === rootFile.path; });
+          if (foundInData) {
+            inputContent.push({ fileName: foundInData.fileName, content: foundInData.content });
           }
         });
         input.rootFiles = inputContent;


### PR DESCRIPTION
avoid invalid objects to throw an error

While detecting roots input validation throws errors with invalid files.

