### PR TITLE
Fix resolveRefs method

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -33,7 +33,7 @@ const _ = require('lodash'),
 /**
    * @param {*} currentNode - the object from which you're trying to find references
    * @param {*} seenRef References that are repeated. Used to identify circular references.
-   * @returns {boolean} - whether the object has references
+   * @returns {boolean} - Whether the object has circular references
    */
 function hasReference(currentNode, seenRef) {
   let hasRef = false;

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -27,7 +27,33 @@ const _ = require('lodash'),
     'float',
     'double'
   ],
-  DEFAULT_SCHEMA_UTILS = require('./30XUtils/schemaUtils30X');
+  DEFAULT_SCHEMA_UTILS = require('./30XUtils/schemaUtils30X'),
+  traverseUtility = require('traverse');
+
+/**
+   * @param {*} currentNode - the object from which you're trying to find references
+   * @param {*} seenRef References that are repeated. Used to identify circular references.
+   * @returns {boolean} - whether the object has references
+   */
+function hasReference(currentNode, seenRef) {
+  let hasRef = false;
+
+  traverseUtility(currentNode).forEach(function (property) {
+    if (property) {
+      let hasReferenceTypeKey;
+      hasReferenceTypeKey = Object.keys(property)
+        .find(
+          (key) => {
+            return key === '$ref';
+          }
+        );
+      if (hasReferenceTypeKey && seenRef[property.$ref]) {
+        hasRef = true;
+      }
+    }
+  });
+  return hasRef;
+}
 
 module.exports = {
   /**
@@ -167,13 +193,6 @@ module.exports = {
       let refKey = schema.$ref,
         outerProperties = concreteUtils.getOuterPropsIfIsSupported(schema);
 
-      // if this reference is seen before, ignore and move on.
-      if (seenRef[refKey]) {
-        return { value: '<Circular reference to ' + refKey + ' detected>' };
-      }
-      // add to seen array if not encountered before.
-      seenRef[refKey] = stack;
-
       // points to an existing location
       // .split will return [#, components, schemas, schemaName]
       splitRef = refKey.split('/');
@@ -199,6 +218,12 @@ module.exports = {
       });
 
       resolvedSchema = this._getEscaped(components, splitRef);
+      // if this reference is seen before, ignore and move on.
+      if (seenRef[refKey] && hasReference(resolvedSchema, seenRef)) {
+        return { value: '<Circular reference to ' + refKey + ' detected>' };
+      }
+      // add to seen array if not encountered before.
+      seenRef[refKey] = stack;
       if (outerProperties) {
         resolvedSchema = concreteUtils.addOuterPropsToRefSchemaIfIsSupported(resolvedSchema, outerProperties);
       }

--- a/test/data/valid_openapi/all_of_properties.json
+++ b/test/data/valid_openapi/all_of_properties.json
@@ -1,0 +1,89 @@
+{
+  "info": {
+    "title": "Inheritance test API",
+    "version": "v1.0"
+  },
+  "openapi": "3.0.1",
+  "paths": {
+    "/api/inheritancetest": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page"
+                }
+              }
+            },
+            "description": "The page data including metadata and content"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "SpecificType": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ParentType"
+          },
+          {
+            "properties": {
+              "specificTypeData": {
+                "type": "string"
+              }
+            },
+            "required": ["specificTypeData"]
+          }
+        ]
+      },
+      "ParentType": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GrandParentType"
+          },
+          {
+            "properties": {
+              "parentTypeData": {
+                "type": "string"
+              }
+            },
+            "required": ["parentTypeData"]
+          }
+        ]
+      },
+      "GrandParentType": {
+        "properties": {
+          "grandParentTypeData": {
+            "type": "string"
+          }
+        },
+        "required": ["grandParentTypeData"]
+      },
+      "Page": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GrandParentType"
+          },
+          {
+            "properties": {
+              "specificType": {
+                "$ref": "#/components/schemas/SpecificType"
+              }
+            },
+            "required": ["specificType"]
+          }
+        ]
+      }
+    },
+    "securitySchemes": {
+      "basic": {
+        "description": "Basic HTTP Authentication",
+        "scheme": "basic",
+        "type": "http"
+      }
+    }
+  }
+}

--- a/test/data/validationData/invalid_response_body_all_of_properties_collection.json
+++ b/test/data/validationData/invalid_response_body_all_of_properties_collection.json
@@ -1,0 +1,84 @@
+{
+  "item": [
+    {
+      "id": "d8bfb088-d251-4ecf-bb48-915eebcccbb7",
+      "name": "/api/inheritancetest",
+      "request": {
+        "name": "/api/inheritancetest",
+        "description": {},
+        "url": {
+          "path": [
+            "api",
+            "inheritancetest"
+          ],
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "query": [],
+          "variable": []
+        },
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
+        "method": "GET",
+        "auth": null
+      },
+      "response": [
+        {
+          "id": "c1e63b4e-1f73-487f-b214-5962ba3b2164",
+          "name": "The page data including metadata and content",
+          "originalRequest": {
+            "url": {
+              "path": [
+                "api",
+                "inheritancetest"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "body": {}
+          },
+          "status": "OK",
+          "code": 200,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "body": "{\n  \"grandParentTypeData\": \"repreh\",\n  \"specificType\": {\n    \"parentTypeData\": \"sunt mollit sed Ut\",\n    \"specificTypeData\": \"commod\"\n  }\n}",
+          "cookie": [],
+          "_postman_previewlanguage": "json"
+        }
+      ],
+      "event": [],
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      }
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "type": "string",
+      "value": "/",
+      "key": "baseUrl"
+    }
+  ],
+  "info": {
+    "_postman_id": "cc7d1e25-6930-4263-8147-2d67439b453b",
+    "name": "Inheritance test API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "",
+      "type": "text/plain"
+    }
+  }
+}

--- a/test/data/validationData/invalid_response_body_all_of_properties_spec.json
+++ b/test/data/validationData/invalid_response_body_all_of_properties_spec.json
@@ -1,0 +1,89 @@
+{
+  "info": {
+    "title": "Inheritance test API",
+    "version": "v1.0"
+  },
+  "openapi": "3.0.1",
+  "paths": {
+    "/api/inheritancetest": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page"
+                }
+              }
+            },
+            "description": "The page data including metadata and content"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "SpecificType": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ParentType"
+          },
+          {
+            "properties": {
+              "specificTypeData": {
+                "type": "string"
+              }
+            },
+            "required": ["specificTypeData"]
+          }
+        ]
+      },
+      "ParentType": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GrandParentType"
+          },
+          {
+            "properties": {
+              "parentTypeData": {
+                "type": "string"
+              }
+            },
+            "required": ["parentTypeData"]
+          }
+        ]
+      },
+      "GrandParentType": {
+        "properties": {
+          "grandParentTypeData": {
+            "type": "string"
+          }
+        },
+        "required": ["grandParentTypeData"]
+      },
+      "Page": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GrandParentType"
+          },
+          {
+            "properties": {
+              "specificType": {
+                "$ref": "#/components/schemas/SpecificType"
+              }
+            },
+            "required": ["specificType"]
+          }
+        ]
+      }
+    },
+    "securitySchemes": {
+      "basic": {
+        "description": "Basic HTTP Authentication",
+        "scheme": "basic",
+        "type": "http"
+      }
+    }
+  }
+}

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -1174,6 +1174,20 @@ describe('CONVERT FUNCTION TESTS ', function() {
           done();
         });
     });
+
+    it('[GITHUB #597] - should convert file with all of merging properties', function() {
+      const fileSource = path.join(__dirname, VALID_OPENAPI_PATH, 'all_of_properties.json'),
+        fileData = fs.readFileSync(fileSource, 'utf8'),
+        input = {
+          type: 'string',
+          data: fileData
+        };
+
+      Converter.convert(input, { optimizeConversion: false, stackLimit: 50 }, (err, result) => {
+        expect(err).to.be.null;
+        expect(result.result).to.be.true;
+      });
+    });
   });
 
   describe('Converting swagger 2.0 files', function() {

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -1226,8 +1226,17 @@ describe('CONVERT FUNCTION TESTS ', function() {
         };
 
       Converter.convert(input, { optimizeConversion: false, stackLimit: 50 }, (err, result) => {
+        let responseBody = JSON.parse(result.output[0].data.item[0].response[0].body);
         expect(err).to.be.null;
         expect(result.result).to.be.true;
+        expect(responseBody)
+          .to.have.all.keys('grandParentTypeData', 'specificType');
+        expect(responseBody.specificType)
+          .to.have.all.keys(
+            'grandParentTypeData',
+            'parentTypeData',
+            'specificTypeData'
+          );
       });
     });
 

--- a/test/unit/validator.test.js
+++ b/test/unit/validator.test.js
@@ -1270,6 +1270,32 @@ describe('VALIDATE FUNCTION TESTS ', function () {
     });
   });
 
+  it('Should report a mismatch when the response body is not valid', function (done) {
+    let allOfExample = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
+      '/invalid_response_body_all_of_properties_spec.json'), 'utf-8'),
+      allOfCollection = fs.readFileSync(path.join(__dirname, VALIDATION_DATA_FOLDER_PATH +
+        '/invalid_response_body_all_of_properties_collection.json'), 'utf-8'),
+      historyRequest = [],
+      schemaPack = new Converter.SchemaPack({ type: 'string', data: allOfExample },
+        { suggestAvailableFixes: true, showMissingInSchemaErrors: true });
+
+    getAllTransactions(JSON.parse(allOfCollection), historyRequest);
+
+    schemaPack.validateTransaction(historyRequest, (err, result) => {
+      const requestId = historyRequest[0].id,
+        request = result.requests[requestId],
+        responseId = historyRequest[0].response[0].id,
+        response = request.endpoints[0].responses[responseId];
+      expect(err).to.be.null;
+      expect(request.endpoints[0].matched).to.equal(false);
+      expect(response.matched).to.equal(false);
+      expect(response.mismatches).to.have.length(1);
+      expect(response.mismatches[0].reason)
+        .to.equal('The response body didn\'t match the specified schema');
+      done();
+    });
+  });
+
   describe('findMatchingRequestFromSchema function', function () {
     it('#GITHUB-9396 Should maintain correct order of matched endpoint', function (done) {
       let schema = {


### PR DESCRIPTION
Fixing **resolveRefs** method:
It resolves the issue #597 
### Current behavior:
- While it was dereferencing the schemas it was taking the repeated keys as circular refs and it was removing them from the schema before the validation process. So the validate transaction method returns the response as a valid one.

### Expected behavior:
- It should report a mismatch when the response body is not compliant with the schema.

### Issue causes:
- During the **validateTransaction** process, when the process finds an **allOf** property it uses the **resolveRefs** method from the **deref** module. 
- This method has a condition used to avoid circular references.
  It processes the provided schema and if it finds a previously seen reference it skips it and continues with the next element in the schema.
    <img width="756" alt="image" src="https://user-images.githubusercontent.com/19155973/179806892-269dfb66-a078-418d-9382-22ce0fb686e1.png">
    This was causing that a compliant value with the schema was: 
    <img width="473" alt="image" src="https://user-images.githubusercontent.com/19155973/179811155-90bdeb34-7a94-492d-a53f-af19be0461eb.png">
    instead of :
    <img width="476" alt="image" src="https://user-images.githubusercontent.com/19155973/179811223-7d7ce6b9-8020-4750-af3a-757d9e641697.png">
    This is because the process was detecting the **grandParentTypeData** as a circular ref, so it skips it.
    That's why it does not report a mismatch when the body does not contain the **grandParentTypeData** property.

### The way we resolve:
- We improved the way to detect a circular reference by adding a new condition there:
    <img width="762" alt="image" src="https://user-images.githubusercontent.com/19155973/179812714-52582c0b-cd59-4c47-977d-724c572f0c36.png">
    Here, the **hasReference** method validates if the current node contains any **$ref** element and if this **$ref** element value has been seen before. This increase the precision of detecting those circular reference scenarios.
    Whit this approach the schema is not modified by a false circular reference and We can validate the response body correctly.
    So, when the user provides a body like this:
   <img width="464" alt="image" src="https://user-images.githubusercontent.com/19155973/179813551-4b511e74-0fbd-416f-ad14-aa42274174a4.png">
    The result will report a mismatch with the reason: **'The response body didn\'t match the specified schema'**

