### PR TITLE
Fix/all of string prop

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -86,7 +86,7 @@ module.exports = {
       return mergeAllOf({
         allOf: schemaArr.map((schema) => {
           return this.resolveRefs(schema, parameterSourceOption, components, schemaResolutionCache, resolveFor,
-            resolveTo, stack, seenRef, stackLimit);
+            resolveTo, stack, seenRef, stackLimit, true);
         })
       }, {
         resolvers: {
@@ -122,7 +122,7 @@ module.exports = {
    */
 
   resolveRefs: function (schema, parameterSourceOption, components, schemaResolutionCache,
-    resolveFor = 'CONVERSION', resolveTo = 'schema', stack = 0, seenRef = {}, stackLimit = 10) {
+    resolveFor = 'CONVERSION', resolveTo = 'schema', stack = 0, seenRef = {}, stackLimit = 10, isAllOf = false) {
     var resolvedSchema, prop, splitRef,
       ERR_TOO_MANY_LEVELS = '<Error: Too many levels of nesting to fake this schema>';
     let concreteUtils = components && components.hasOwnProperty('concreteUtils') ?
@@ -324,6 +324,9 @@ module.exports = {
           type: (typeof (schema.enum[0])),
           value: schema.enum[0]
         };
+      }
+      else if (isAllOf) {
+        return schema;
       }
       else {
         return {

--- a/test/data/valid_openapi/all_of_property.json
+++ b/test/data/valid_openapi/all_of_property.json
@@ -1,0 +1,96 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Platform API",
+    "description": "[ Platform](https://server.dev) provides functionality to provide access to content stored within. It provides endpoints for basic manipulation of files and folder.",
+    "termsOfService": "https://server.com/s",
+    "contact": {
+      "name": "nc",
+      "url": "https://server.dev",
+      "email": "dev@server.com"
+    },
+    "license": {
+      "name": "Apache-2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    },
+    "version": "2.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://server.com/2.0",
+      "description": "Platform API server"
+    }
+  ],
+  "paths": {
+    "/files": {
+      "get": {
+        "operationId": "get_Files",
+        "summary": "List files ",
+        "tags": [
+          "Skills"
+        ],
+        "description": "List the files.",
+        "parameters": [
+          {
+            "name": "file_id",
+            "description": "The unique identifier",
+            "example": "12345",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns all the data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/File"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "File": {
+        "title": "File",
+        "type": "object",
+        "description": "A mini representation of a file",
+        "required": [
+          "id"
+        ],
+        "allOf": [
+          {
+            "properties": {
+              "id": {
+                "allOf": [
+                  {
+                    "type": "string",
+                    "example": "3",
+                    "nullable": false,
+                    "description": "A numeric identifier"
+                  },
+                  {
+                    "nullable": false
+                  }
+                ]
+              },
+              "name": {
+                "type": "string",
+                "description": "The name of the file",
+                "example": "Contract.pdf"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/unit/validator.test.js
+++ b/test/unit/validator.test.js
@@ -65,45 +65,6 @@ function getFoldersByVersion(folder30Path, folder31Path) {
 
 describe('Validate with servers', function () {
 
-  it('Should convert and validate allOf properties for string schema', function () {
-    const openAPI = path.join(__dirname, VALID_OPENAPI_FOLDER_PATH + '/all_of_property.json'),
-      openAPIData = fs.readFileSync(openAPI, 'utf8'),
-      expectedRequestBody = '{\n  "id": "3",\n  "name": "Contract.pdf"\n}',
-      options = {
-        requestParametersResolution: 'Example',
-        exampleParametersResolution: 'Example',
-        showMissingInSchemaErrors: true,
-        strictRequestMatching: true,
-        ignoreUnresolvedVariables: true,
-        validateMetadata: true,
-        suggestAvailableFixes: true,
-        detailedBlobValidation: false
-      },
-      schemaPack = new Converter.SchemaPack({ type: 'string', data: openAPIData }, options);
-    schemaPack.convert((err, conversionResult) => {
-      expect(err).to.be.null;
-      expect(conversionResult.result).to.equal(true);
-      expect(conversionResult.output[0].data.item[0].response[0].body).to.equal(expectedRequestBody);
-
-      let historyRequest = [];
-
-      getAllTransactions(conversionResult.output[0].data, historyRequest);
-
-      schemaPack.validateTransaction(historyRequest, (err, result) => {
-        expect(err).to.be.null;
-        expect(result).to.be.an('object');
-
-        let requestIds = Object.keys(result.requests);
-        expect(err).to.be.null;
-        expect(result.missingEndpoints.length).to.eq(0);
-        requestIds.forEach((requestId) => {
-          expect(result.requests[requestId].endpoints[0]).to.not.be.undefined;
-          expect(result.requests[requestId].endpoints[0].matched).to.be.true;
-        });
-      });
-    });
-  });
-
   it('Fix for GITHUB#496: Should identify url with fragment', function () {
     const openAPI = path.join(__dirname, VALID_OPENAPI_FOLDER_PATH + '/explicit_server_in_path.json'),
       openAPIData = fs.readFileSync(openAPI, 'utf8'),
@@ -1653,3 +1614,45 @@ describe('validateTransaction method. Path variables matching validation (issue 
     });
   });
 });
+
+describe('validateTransaction convert and validate schemas with allOf', function () {
+  it('Should convert and validate allOf properties for string schema', function () {
+    const openAPI = path.join(__dirname, VALID_OPENAPI_FOLDER_PATH + '/all_of_property.json'),
+      openAPIData = fs.readFileSync(openAPI, 'utf8'),
+      expectedRequestBody = '{\n  "id": "3",\n  "name": "Contract.pdf"\n}',
+      options = {
+        requestParametersResolution: 'Example',
+        exampleParametersResolution: 'Example',
+        showMissingInSchemaErrors: true,
+        strictRequestMatching: true,
+        ignoreUnresolvedVariables: true,
+        validateMetadata: true,
+        suggestAvailableFixes: true,
+        detailedBlobValidation: false
+      },
+      schemaPack = new Converter.SchemaPack({ type: 'string', data: openAPIData }, options);
+    schemaPack.convert((err, conversionResult) => {
+      expect(err).to.be.null;
+      expect(conversionResult.result).to.equal(true);
+      expect(conversionResult.output[0].data.item[0].response[0].body).to.equal(expectedRequestBody);
+
+      let historyRequest = [];
+
+      getAllTransactions(conversionResult.output[0].data, historyRequest);
+
+      schemaPack.validateTransaction(historyRequest, (err, result) => {
+        expect(err).to.be.null;
+        expect(result).to.be.an('object');
+
+        let requestIds = Object.keys(result.requests);
+        expect(err).to.be.null;
+        expect(result.missingEndpoints.length).to.eq(0);
+        requestIds.forEach((requestId) => {
+          expect(result.requests[requestId].endpoints[0]).to.not.be.undefined;
+          expect(result.requests[requestId].endpoints[0].matched).to.be.true;
+        });
+      });
+    });
+  });
+});
+

--- a/test/unit/validator.test.js
+++ b/test/unit/validator.test.js
@@ -64,6 +64,46 @@ function getFoldersByVersion(folder30Path, folder31Path) {
 }
 
 describe('Validate with servers', function () {
+
+  it('Should convert and validate allOf properties for string schema', function () {
+    const openAPI = path.join(__dirname, VALID_OPENAPI_FOLDER_PATH + '/all_of_property.json'),
+      openAPIData = fs.readFileSync(openAPI, 'utf8'),
+      expectedRequestBody = '{\n  "id": "3",\n  "name": "Contract.pdf"\n}',
+      options = {
+        requestParametersResolution: 'Example',
+        exampleParametersResolution: 'Example',
+        showMissingInSchemaErrors: true,
+        strictRequestMatching: true,
+        ignoreUnresolvedVariables: true,
+        validateMetadata: true,
+        suggestAvailableFixes: true,
+        detailedBlobValidation: false
+      },
+      schemaPack = new Converter.SchemaPack({ type: 'string', data: openAPIData }, options);
+    schemaPack.convert((err, conversionResult) => {
+      expect(err).to.be.null;
+      expect(conversionResult.result).to.equal(true);
+      expect(conversionResult.output[0].data.item[0].response[0].body).to.equal(expectedRequestBody);
+
+      let historyRequest = [];
+
+      getAllTransactions(conversionResult.output[0].data, historyRequest);
+
+      schemaPack.validateTransaction(historyRequest, (err, result) => {
+        expect(err).to.be.null;
+        expect(result).to.be.an('object');
+
+        let requestIds = Object.keys(result.requests);
+        expect(err).to.be.null;
+        expect(result.missingEndpoints.length).to.eq(0);
+        requestIds.forEach((requestId) => {
+          expect(result.requests[requestId].endpoints[0]).to.not.be.undefined;
+          expect(result.requests[requestId].endpoints[0].matched).to.be.true;
+        });
+      });
+    });
+  });
+
   it('Fix for GITHUB#496: Should identify url with fragment', function () {
     const openAPI = path.join(__dirname, VALID_OPENAPI_FOLDER_PATH + '/explicit_server_in_path.json'),
       openAPIData = fs.readFileSync(openAPI, 'utf8'),


### PR DESCRIPTION
**Current behavior**:
When in a defined spec you happen to have a schema defined like this

```
            "properties": {
              "id": {
                "allOf": [
                  {
                    "type": "string",
                    "example": "3",
                    "nullable": false,
                    "description": "A numeric identifier"
                  },
                  {
                    "nullable": false
                  }
                ]
              },
```
the conversion process generates a message like this
```
"{\n  \"id\": {\n    \"value\": \"<Error: Could not resolve allOf schema\"\n  },\n  \"name\": \"Contract.pdf\"\n}"
```
**Expected behavior:**
It should generate a message like this:

```
'{\n  "id": "3",\n  "name": "Contract.pdf"\n}'
```

**Issue causes:**
In resolveRefs method, we are trying to identify the type of the schema whether it is Array, object, a reference, etc.
But the default behavior is considering the schema as an object

```
      else {
        return {
          type: SCHEMA_TYPES.object
        };
      }
```
When we have a schema like the one mentioned before, the generated schema for
```             
{
  "nullable": false
}
```
was
```
{
  type: object
}
```
So the allOf merger was trying to merge a schema type object into a schema type string throwing an error and cached by the process adding the message in the result: Error: Could not resolve allOf schema.

**The way we resolve:**
If we know that we are processing a schema that comes from an allOf parent then we are returning the same schema instead of defaulting to a schema with type as object, and no other properties. So the result of the method is the same 
```             
{
  nullable: false
}
```
And the merger can merge the string with this sub-schema.



