### PR TITLE
Avoiding to set type as object when property's schema is an empty object

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -256,8 +256,10 @@ module.exports = {
               continue;
             }
             /* eslint-enable */
-            tempSchema.properties[prop] = this.resolveRefs(property, parameterSourceOption, components,
-              schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
+            tempSchema.properties[prop] = _.isEmpty(property) ?
+              {} :
+              this.resolveRefs(property, parameterSourceOption, components,
+                schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
           }
         }
         return tempSchema;

--- a/test/data/valid_swagger/yaml/allOfConflicted.yaml
+++ b/test/data/valid_swagger/yaml/allOfConflicted.yaml
@@ -1,0 +1,160 @@
+basePath: /api/v1
+definitions:
+  comm.TestGroupRequest:
+    properties:
+      groupNm:
+        type: string
+      user:
+        $ref: '#/definitions/user.User'
+    type: object
+  comm.TestGroupResponse:
+    properties:
+      groupCode:
+        type: integer
+    type: object
+  comm.TestRequest:
+    properties:
+      codeNm:
+        type: string
+      user:
+        $ref: '#/definitions/user.User'
+    type: object
+  comm.TestResponse:
+    properties:
+      testCode:
+        type: string
+      creDate:
+        type: string
+      creId:
+        type: string
+    type: object
+  comm.Request:
+    properties:
+      user:
+        $ref: '#/definitions/user.User'
+    type: object
+  pagination.Page:
+    properties:
+      limit:
+        type: integer
+      next_page:
+        type: integer
+      offset:
+        type: integer
+      page:
+        type: integer
+      prev_page:
+        type: integer
+      total_page:
+        type: integer
+      total_record:
+        type: integer
+    type: object
+  pagination.Paginator:
+    properties:
+      content: {}
+      paging:
+        $ref: '#/definitions/pagination.Page'
+    type: object
+  response.Header:
+    properties:
+      resultCode:
+        type: string
+      resultMessage:
+        type: string
+      success:
+        type: boolean
+    type: object
+  response.Response:
+    properties:
+      header:
+        $ref: '#/definitions/response.Header'
+      payload: {}
+    type: object
+  user.User:
+    properties:
+      userId:
+        type: string
+    type: object
+info:
+  contact: {}
+  description: test
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  termsOfService: http://swagger.io/terms/
+  title: TEST API
+  version: "1.0"
+paths:
+  /comm/test/duplicate/{id}:
+    get:
+      consumes:
+      - application/json
+      description: duplicate check
+      parameters:
+      - description: id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/response.Response'
+            - properties:
+                payload:
+                  type: boolean
+              type: object
+      security:
+      - ApiKeyAuth: []
+      summary: duplicate check
+      tags:
+      - test1
+  /comm/test/page:
+    get:
+      consumes:
+      - application/json
+      description: list (paging)
+      parameters:
+      - description: page
+        in: query
+        name: page
+        type: integer
+      - description: limit
+        in: query
+        name: pageSize
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/response.Response'
+            - properties:
+                payload:
+                  allOf:
+                  - $ref: '#/definitions/pagination.Paginator'
+                  - properties:
+                      content:
+                        items:
+                          $ref: '#/definitions/comm.TestResponse'
+                        type: array
+                    type: object
+              type: object
+      security:
+      - ApiKeyAuth: []
+      summary: list
+      tags:
+      - test2
+securityDefinitions:
+  ApiKeyAuth:
+    in: header
+    name: Authorization
+    type: apiKey
+swagger: "2.0"

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -1367,6 +1367,30 @@ describe('CONVERT FUNCTION TESTS ', function() {
         done();
       });
     });
+
+    it('[GITHUB #10710] - should convert file with all of merging properties. ' +
+      'One ocurrence is an empty object and the other is a boolean type', function() {
+      const fileSource = path.join(__dirname, SWAGGER_20_FOLDER_YAML, 'allOfConflicted.yaml'),
+        fileData = fs.readFileSync(fileSource, 'utf8'),
+        input = {
+          type: 'string',
+          data: fileData
+        };
+
+      Converter.convert(input, { optimizeConversion: false, stackLimit: 50 }, (err, result) => {
+        const expectedResponseBody1 = JSON.parse(
+            result.output[0].data.item[0].item[0].response[0].body
+          ),
+          expectedResponseBody2 = JSON.parse(
+            result.output[0].data.item[0].item[1].response[0].body
+          );
+        expect(err).to.be.null;
+        expect(result.result).to.be.true;
+        expect(expectedResponseBody1.payload).to.be.a('boolean');
+        expect(expectedResponseBody2.payload).to.be.an('object')
+          .and.to.have.all.keys('content', 'paging');
+      });
+    });
   });
 
   describe('requestNameSource option', function() {


### PR DESCRIPTION
### Current behavior
When the user provides a composite schema like this:
![image](https://user-images.githubusercontent.com/19155973/180118132-576a3e8a-a19b-4551-bfea-accb30af096d.png)
 
This schema is generating a non expected body:
   <img width="384" alt="image" src="https://user-images.githubusercontent.com/19155973/180118591-b779299f-2091-46dd-b320-6959c2ae02fb.png">

### The expected behavior:
The body response should be processed correctly and it should return a response body as:
   <img width="239" alt="image" src="https://user-images.githubusercontent.com/19155973/180118748-4761e33d-f159-48eb-893d-cc450c056256.png">

### Issue cause:
- The provided schema contains a property defined as an empty object ({}) 
   So, the converting process adds the type 'object' by default to the first payload property. It's because it does not have 
   any type defined.
- So when the process tries to merge both schemas it finds that the first one is an object and the second one is a boolean 
   and it generate an error, which is reported instead of the expected response body.

### The way we resolve it
- The method resolveAllOf is executed when the current node is an allOf element.
- Inner this method, it the elements in the allOf are resolved using the resolveRefs method (This method I where the type object is set into the empty schema).
- This process was modified, in a way that, while we are reading the properties of provided schemas, if the current property is defined as empty object, it does not run the resolveRefs method (from deref.js) (because there is nothing to resolve).
   ![image](https://user-images.githubusercontent.com/19155973/180121569-d7404bb8-a1cc-43a5-b600-8cf181849298.png)
- Following this approach the empty schema does not get the object type, so, the merge will finish correctly. 
