### PR TITLE
Fixed issue where for some of request bodies with JSON family content type were not generated correctly.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2015,26 +2015,28 @@ module.exports = {
       }
       else {
         let getXmlVersionContent = (bodyContent) => {
-          const regExp = new RegExp('([<\\?xml]+[\\s{1,}]+[version="\\d.\\d"]+[\\sencoding="]+.{1,15}"\\?>)');
-          let xmlBody = bodyContent;
+            const regExp = new RegExp('([<\\?xml]+[\\s{1,}]+[version="\\d.\\d"]+[\\sencoding="]+.{1,15}"\\?>)');
+            let xmlBody = bodyContent;
 
-          if (!bodyContent.match(regExp)) {
-            const versionContent = '<?xml version="1.0" encoding="UTF-8"?>\n';
-            xmlBody = versionContent + xmlBody;
-          }
-          return xmlBody;
-        };
+            if (!bodyContent.match(regExp)) {
+              const versionContent = '<?xml version="1.0" encoding="UTF-8"?>\n';
+              xmlBody = versionContent + xmlBody;
+            }
+            return xmlBody;
+          },
+          headerFamily;
 
         bodyData = this.convertToPmBodyData(contentObj[bodyType], requestType, bodyType,
           PARAMETER_SOURCE.REQUEST, options.indentCharacter, components, options, schemaCache);
 
-        bodyData = (bodyType === TEXT_XML || bodyType === APP_XML) ?
+        headerFamily = this.getHeaderFamily(bodyType);
+        bodyData = (bodyType === TEXT_XML || bodyType === APP_XML || headerFamily === HEADER_TYPE.XML) ?
           getXmlVersionContent(bodyData) :
           bodyData;
 
         updateOptions = {
           mode: rDataMode,
-          raw: bodyType !== APP_JSON ?
+          raw: !_.isObject(bodyData) && _.isFunction(_.get(bodyData, 'toString')) ?
             bodyData.toString() :
             JSON.stringify(bodyData, null, options.indentCharacter)
         };

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -1928,6 +1928,70 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         expect(result.body.mode).to.equal('file');
         done();
       });
+      it(' application/vnd.api+json (headers with different structure but still of JSON family)', function(done) {
+        var requestBody = {
+            description: 'body description',
+            content: {
+              'application/vnd.api+json': {
+                'schema': {
+                  type: 'object',
+                  required: [
+                    'id',
+                    'name'
+                  ],
+                  properties: {
+                    id: {
+                      type: 'integer',
+                      format: 'int64'
+                    },
+                    name: {
+                      type: 'string'
+                    },
+                    neglect: { // this will be neglected since schemaFaker does not process
+                      type: 'string',
+                      format: 'binary'
+                    }
+                  }
+                }
+              }
+            }
+          },
+          result, resultBody;
+        result = SchemaUtils.convertToPmBody(requestBody);
+        resultBody = JSON.parse(result.body.raw);
+        expect(resultBody.id).to.equal('<long>');
+        expect(resultBody.name).to.equal('<string>');
+        expect(result.contentHeader).to.deep.include({ key: 'Content-Type', value: 'application/vnd.api+json' });
+        expect(result.body.options.raw.language).to.equal('json');
+        done();
+      });
+      it(' application/vnd.api+xml (headers with different structure but still of XML family)', function(done) {
+        var requestBody = {
+            description: 'body description',
+            content: {
+              'application/vnd.api+xml': {
+                examples: {
+                  xml: {
+                    summary: 'A list containing two items',
+                    value: '<AnXMLObject>test</AnXMLObject>'
+                  }
+                }
+              }
+            }
+          },
+          result, resultBody;
+        result = SchemaUtils.convertToPmBody(requestBody, 'ROOT', {}, {
+          requestParametersResolution: 'example'
+        });
+        resultBody = (result.body.raw);
+        expect(resultBody).to.equal(
+          '<?xml version="1.0" encoding="UTF-8"?>\n<AnXMLObject>test</AnXMLObject>'
+        );
+        expect(result.contentHeader).to.deep.include(
+          { key: 'Content-Type', value: 'application/vnd.api+xml' });
+        expect(result.body.options.raw.language).to.equal('xml');
+        done();
+      });
       // things remaining : application/xml
     });
   });


### PR DESCRIPTION
Fixes issue : https://github.com/postmanlabs/postman-app-support/issues/11300

## Root cause:

As part of fix we did in this PR: https://github.com/postmanlabs/openapi-to-postman/pull/600. We introduced flow where for non-JSON body types we would not `JSON.stringify()` the bodyData anymore and use `toString()`.

This scenario doesn't handle the bodies with content type like `application/vnd.api+json` (content-type with a different structure but still of JSON family).

## Solution:

We'll be always stringifying any JSON we'll have as part of the request body that's generated if detected and using `toString` in only cases when we don't have JSON object available.
