### PR TITLE
Add missing description to request name as wrote in Documentation

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -3636,7 +3636,7 @@ module.exports = {
     switch (options.requestNameSource) {
       case 'fallback' : {
         // operationId is usually camelcase or snake case
-        expectedReqName = schemaPath.summary || utils.insertSpacesInName(schemaPath.operationId) || reqUrl;
+        expectedReqName = schemaPath.description || schemaPath.summary || utils.insertSpacesInName(schemaPath.operationId) || reqUrl;
         expectedReqName = utils.trimRequestName(expectedReqName);
         reqNameMismatch = (trimmedReqName !== expectedReqName);
         break;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31892489/195306184-4e928c5f-32cc-4b0b-95d9-f6e59bbec2d1.png)
Docs says it's using description, but in code, it's not