### PR TITLE
Released v4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # OpenAPI-Postman Changelog
 
+#### v4.3.0 (October 17, 2022)
+* Fixed issue with nullable keywords getting validated incorrectly.
+
 #### v4.2.0 (August 10, 2022)
 * Improved the way to detect a circular reference by adding a new condition
 * A schema that comes from an allOf parent then we now return the same schema instead of defaulting to a schema with type as object, and no other properties

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-to-postmanv2",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-to-postmanv2",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Convert a given OpenAPI specification to Postman Collection v2.0",
   "homepage": "https://github.com/postmanlabs/openapi-to-postman",
   "bugs": "https://github.com/postmanlabs/openapi-to-postman/issues",


### PR DESCRIPTION

#### v4.3.0 (October 17, 2022)
* Fixed issue with nullable keywords getting validated incorrectly.