### PR TITLE
Fixed issue where collection folder name for paths were having extra spaces.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -990,7 +990,7 @@ module.exports = {
       // only return a Postman folder if this folder has>1 children in its subtree
       // otherwise we can end up with 10 levels of folders with 1 request in the end
       itemGroup = new sdk.ItemGroup({
-        name: utils.insertSpacesInName(resource.name)
+        name: resource.name
         // TODO: have to add auth here (but first, auth to be put into the openapi tree)
       });
       // If a folder has only one child which is a folder then we collapsed the child folder

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -1287,8 +1287,7 @@ describe('CONVERT FUNCTION TESTS ', function() {
         expect(conversionResult.output[0].data).to.have.property('info');
         expect(conversionResult.output[0].data).to.have.property('item');
         expect(conversionResult.output[0].data.item.length).to.equal(2);
-        expect(_.map(conversionResult.output[0].data.item, 'name')).to.include('pets');
-        expect(_.map(conversionResult.output[0].data.item, 'name')).to.include('pet/{petId}');
+        expect(_.map(conversionResult.output[0].data.item, 'name')).to.include.members(['pets', 'pet/{petId}']);
         done();
       });
     });

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -1275,6 +1275,23 @@ describe('CONVERT FUNCTION TESTS ', function() {
           done();
         });
     });
+
+    it('Should generate collection where folder name doesn\'t contain spaces when ' +
+      'not present in operation path', function (done) {
+      var openapi = fs.readFileSync(testSpec, 'utf8');
+      Converter.convert({ type: 'string', data: openapi }, { schemaFaker: true }, (err, conversionResult) => {
+        expect(err).to.be.null;
+        expect(conversionResult.result).to.equal(true);
+        expect(conversionResult.output.length).to.equal(1);
+        expect(conversionResult.output[0].type).to.equal('collection');
+        expect(conversionResult.output[0].data).to.have.property('info');
+        expect(conversionResult.output[0].data).to.have.property('item');
+        expect(conversionResult.output[0].data.item.length).to.equal(2);
+        expect(_.map(conversionResult.output[0].data.item, 'name')).to.include('pets');
+        expect(_.map(conversionResult.output[0].data.item, 'name')).to.include('pet/{petId}');
+        done();
+      });
+    });
   });
 
   describe('Converting swagger 2.0 files', function() {


### PR DESCRIPTION
## Issue:

In cases when for `folderStrategy` option, if value is set as `Paths`, corresponding generated folder names were containing extra spaces whenever camel cases were used in path. With this PR we'll be fixing it and making sure we're setting path name as is.

## RCA:
While generating collection folders in such case, we were using the utility function `insertSpacesInName()` to add names. This is not needed anymore in case of generating folder name. There are other usecases where it's still used like naming collection request from operationId etc.

## Fix:
Instead of using named utility function, we'll be directly using the path name/segment depending upon case.