### PR TITLE
Fix/issue#11227

### DIFF
--- a/lib/xmlSchemaFaker.js
+++ b/lib/xmlSchemaFaker.js
@@ -1,9 +1,9 @@
 /* eslint-disable */
 const _ = require('lodash');
 
-function convertSchemaToXML(name, schema, attribute, indentChar, inden) {
+function convertSchemaToXML(name, schema, attribute, indentChar, indent) {
   var tagPrefix = '',
-    cInden = _.times(inden, _.constant(indentChar)).join('');
+    cIndent = _.times(indent, _.constant(indentChar)).join('');
   name = _.get(schema, 'xml.name', name || 'element');
   if (_.get(schema, 'xml.prefix')) {
     tagPrefix = schema.xml.prefix ? `${schema.xml.prefix}:` : '';
@@ -25,16 +25,16 @@ function convertSchemaToXML(name, schema, attribute, indentChar, inden) {
       return actualValue;
     }
     else {
-      var retVal = '\n' + cInden + '<' + tagPrefix+name;
+      var retVal = `\n${cIndent}<${tagPrefix+name}`;
       if (_.get(schema, 'xml.namespace')) {
-        retVal += ' xmlns:' + tagPrefix.slice(0,-1) + '="'+schema.xml.namespace+'"'
+        retVal += ` xmlns:${tagPrefix.slice(0,-1)}="${schema.xml.namespace}"`
       }
-      retVal += '>' + actualValue + '</' + tagPrefix+name + '>';
+      retVal += `>${actualValue}</${tagPrefix}${name}>`;
     }
   }
   else if (schema.type === 'object') {
     // go through all properties
-    var retVal = '\n' + cInden + `<${tagPrefix}${name}`, propVal, attributes = [], childNodes = '';
+    var retVal = '\n' + cIndent + `<${tagPrefix}${name}`, propVal, attributes = [], childNodes = '';
     if (_.get(schema, 'xml.namespace')) {
       let formattedTagPrefix = tagPrefix ?
         `:${tagPrefix.slice(0,-1)}` :
@@ -42,9 +42,9 @@ function convertSchemaToXML(name, schema, attribute, indentChar, inden) {
       retVal += ` xmlns${formattedTagPrefix}="${schema.xml.namespace}"`
     }
     _.forOwn(schema.properties, (value, key) => {
-      propVal = convertSchemaToXML(key, value, _.get(value, 'xml.attribute'), indentChar, inden + 1);
+      propVal = convertSchemaToXML(key, value, _.get(value, 'xml.attribute'), indentChar, indent + 1);
       if (_.get(value, 'xml.attribute')) {
-        attributes.push(key + '="' + propVal + '"');
+        attributes.push(`${key}="${propVal}"`);
       }
       else {
         childNodes += propVal;
@@ -55,19 +55,21 @@ function convertSchemaToXML(name, schema, attribute, indentChar, inden) {
     }
     retVal += '>';
     retVal += childNodes;
-    retVal += `\n${cInden}</${tagPrefix+name}>`;
+    retVal += `\n${cIndent}</${tagPrefix}${name}>`;
   }
   else if (schema.type === 'array') {
     // schema.items must be an object
     var isWrapped = _.get(schema, 'xml.wrapped'),
-      extraIndent = isWrapped ? 1 : 0;
-    var arrayElemName = _.get(schema, 'items.xml.name', name, 'arrayItem');
-    var schemaItemsWithXmlProps = _.cloneDeep(schema.items);
+      extraIndent = isWrapped ? 1 : 0,
+      arrayElemName = _.get(schema, 'items.xml.name', name, 'arrayItem'),
+      schemaItemsWithXmlProps = _.cloneDeep(schema.items),
+      contents;
+
     schemaItemsWithXmlProps.xml = schema.xml;
-    var contents = convertSchemaToXML(arrayElemName, schemaItemsWithXmlProps, false, indentChar, inden + extraIndent) + 
-      convertSchemaToXML(arrayElemName, schemaItemsWithXmlProps, false, indentChar, inden + extraIndent);
+    contents = convertSchemaToXML(arrayElemName, schemaItemsWithXmlProps, false, indentChar, indent + extraIndent) + 
+      convertSchemaToXML(arrayElemName, schemaItemsWithXmlProps, false, indentChar, indent + extraIndent);
     if (isWrapped) {
-      return `\n${cInden}<${tagPrefix}${name}>${contents}\n${cInden}</${tagPrefix}${name}>`;
+      return `\n${cIndent}<${tagPrefix}${name}>${contents}\n${cIndent}</${tagPrefix}${name}>`;
     }
     else {
       return contents;

--- a/lib/xmlSchemaFaker.js
+++ b/lib/xmlSchemaFaker.js
@@ -8,12 +8,15 @@ function convertSchemaToXML(name, schema, attribute, indentChar, inden) {
   if (_.get(schema, 'xml.prefix')) {
     tagPrefix = schema.xml.prefix + ':';
   }
-  if (['integer','string'].includes(schema.type)) {
+  if (['integer','string', 'boolean'].includes(schema.type)) {
     if (schema.type === 'integer') {
       actualValue = '(integer)';
     }
     else if (schema.type === 'string') {
       actualValue = '(string)';
+    }
+    else if (schema.type === 'boolean') {
+      actualValue = '(boolean)';
     }
     if (attribute) {
       return actualValue;
@@ -30,7 +33,10 @@ function convertSchemaToXML(name, schema, attribute, indentChar, inden) {
     // go through all properties
     var retVal = '\n' + cInden + `<${tagPrefix+name}`, propVal, attributes = [], childNodes = '';
     if (_.get(schema, 'xml.namespace')) {
-      retVal += ' xmlns:' + tagPrefix.slice(0,-1) + '="'+schema.xml.namespace+'"'
+      let formattedTagPrefix = tagPrefix ?
+        `:${tagPrefix.slice(0,-1)}` :
+        '';
+      retVal += ` xmlns${formattedTagPrefix}="${schema.xml.namespace}"`
     }
     _.forOwn(schema.properties, (value, key) => {
       propVal = convertSchemaToXML(key, value, _.get(value, 'xml.attribute'), indentChar, inden + 1);
@@ -46,7 +52,7 @@ function convertSchemaToXML(name, schema, attribute, indentChar, inden) {
     }
     retVal += '>';
     retVal += childNodes;
-    retVal += '\n</' + name + '>';
+    retVal += `\n</${tagPrefix+name}>`;
   }
   else if (schema.type === 'array') {
     // schema.items must be an object

--- a/lib/xmlSchemaFaker.js
+++ b/lib/xmlSchemaFaker.js
@@ -8,7 +8,7 @@ function convertSchemaToXML(name, schema, attribute, indentChar, inden) {
   if (_.get(schema, 'xml.prefix')) {
     tagPrefix = schema.xml.prefix ? `${schema.xml.prefix}:` : '';
   }
-  if (['integer','string', 'boolean'].includes(schema.type)) {
+  if (['integer','string', 'boolean', 'number'].includes(schema.type)) {
     if (schema.type === 'integer') {
       actualValue = '(integer)';
     }
@@ -17,6 +17,9 @@ function convertSchemaToXML(name, schema, attribute, indentChar, inden) {
     }
     else if (schema.type === 'boolean') {
       actualValue = '(boolean)';
+    }
+    else if (schema.type === 'number') {
+      actualValue = '(number)';
     }
     if (attribute) {
       return actualValue;

--- a/lib/xmlSchemaFaker.js
+++ b/lib/xmlSchemaFaker.js
@@ -6,7 +6,7 @@ function convertSchemaToXML(name, schema, attribute, indentChar, inden) {
     cInden = _.times(inden, _.constant(indentChar)).join('');
   name = _.get(schema, 'xml.name', name || 'element');
   if (_.get(schema, 'xml.prefix')) {
-    tagPrefix = schema.xml.prefix + ':';
+    tagPrefix = schema.xml.prefix ? `${schema.xml.prefix}:` : '';
   }
   if (['integer','string', 'boolean'].includes(schema.type)) {
     if (schema.type === 'integer') {
@@ -31,7 +31,7 @@ function convertSchemaToXML(name, schema, attribute, indentChar, inden) {
   }
   else if (schema.type === 'object') {
     // go through all properties
-    var retVal = '\n' + cInden + `<${tagPrefix+name}`, propVal, attributes = [], childNodes = '';
+    var retVal = '\n' + cInden + `<${tagPrefix}${name}`, propVal, attributes = [], childNodes = '';
     if (_.get(schema, 'xml.namespace')) {
       let formattedTagPrefix = tagPrefix ?
         `:${tagPrefix.slice(0,-1)}` :
@@ -52,17 +52,19 @@ function convertSchemaToXML(name, schema, attribute, indentChar, inden) {
     }
     retVal += '>';
     retVal += childNodes;
-    retVal += `\n</${tagPrefix+name}>`;
+    retVal += `\n${cInden}</${tagPrefix+name}>`;
   }
   else if (schema.type === 'array') {
     // schema.items must be an object
     var isWrapped = _.get(schema, 'xml.wrapped'),
       extraIndent = isWrapped ? 1 : 0;
     var arrayElemName = _.get(schema, 'items.xml.name', name, 'arrayItem');
-    var contents = convertSchemaToXML(arrayElemName, schema.items, false, indentChar, inden + extraIndent) + 
-      convertSchemaToXML(arrayElemName, schema.items, false, indentChar, inden + extraIndent);
+    var schemaItemsWithXmlProps = _.cloneDeep(schema.items);
+    schemaItemsWithXmlProps.xml = schema.xml;
+    var contents = convertSchemaToXML(arrayElemName, schemaItemsWithXmlProps, false, indentChar, inden + extraIndent) + 
+      convertSchemaToXML(arrayElemName, schemaItemsWithXmlProps, false, indentChar, inden + extraIndent);
     if (isWrapped) {
-      return '\n' + cInden + '<' + name + '>' + contents + '\n' + cInden + '</' + name + '>';
+      return `\n${cInden}<${tagPrefix}${name}>${contents}\n${cInden}</${tagPrefix}${name}>`;
     }
     else {
       return contents;

--- a/test/data/valid_openapi/xmlRequestAndResponseBody.json
+++ b/test/data/valid_openapi/xmlRequestAndResponseBody.json
@@ -1,0 +1,103 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+      "version": "1.0.0",
+      "title": "Example REST Service with XML Payloads"
+  },
+  "servers": [
+      {
+          "url": "localhost:3000"
+      }
+  ],
+  "paths": {
+      "/example": {
+          "post": {
+              "responses": {
+                  "200": {
+                      "content": {
+                          "application/xml": {
+                              "schema": {
+                                  "$ref": "#/components/schemas/ExampleResponse"
+                              }
+                          }
+                      },
+                      "description": "An example REST service with XML payloads response"
+                  }
+              },
+              "description": "An example REST service with XML payloads",
+              "requestBody": {
+                  "content": {
+                      "application/xml": {
+                          "schema": {
+                              "$ref": "#/components/schemas/ExampleRequest"
+                          }
+                      }
+                  }
+              }
+          }
+      }
+  },
+  "components": {
+      "schemas": {
+          "ExampleRequest": {
+              "type": "object",
+              "required": [
+                  "requestInteger",
+                  "requestString",
+                  "requestBoolean"
+              ],
+              "properties": {
+                  "requestInteger": {
+                      "type": "integer"
+                  },
+                  "requestString": {
+                      "type": "string"
+                  },
+                  "requestBoolean": {
+                      "type": "boolean"
+                  }
+              },
+              "xml": {
+                  "name": "ExampleXMLRequest",
+                  "prefix": "ex",
+                  "namespace": "urn:ExampleXML"
+              }
+          },
+          "ExampleResponse": {
+              "type": "object",
+              "required": [
+                  "responseInteger",
+                  "responseString",
+                  "responseBoolean"
+              ],
+              "properties": {
+                  "responseInteger": {
+                      "type": "integer"
+                  },
+                  "responseString": {
+                      "type": "string"
+                  },
+                  "responseBoolean": {
+                      "type": "boolean"
+                  }
+              },
+              "xml": {
+                  "name": "ExampleXMLResponse",
+                  "prefix": "ex",
+                  "namespace": "urn:ExampleXML"
+              }
+          }
+      },
+      "securitySchemes": {
+          "BasicAuth": {
+              "type": "http",
+              "scheme": "basic"
+          }
+      }
+  },
+  "security": [
+      {
+          "BasicAuth": []
+      }
+  ]
+}

--- a/test/data/valid_openapi/xmlRequestAndResponseBody.json
+++ b/test/data/valid_openapi/xmlRequestAndResponseBody.json
@@ -55,6 +55,9 @@
                   },
                   "requestBoolean": {
                       "type": "boolean"
+                  },
+                  "requestNumber": {
+                      "type": "number"
                   }
               },
               "xml": {
@@ -79,6 +82,9 @@
                   },
                   "responseBoolean": {
                       "type": "boolean"
+                  },
+                  "responseNumber": {
+                      "type": "number"
                   }
               },
               "xml": {

--- a/test/data/valid_openapi/xmlRequestAndResponseBodyArrayType.json
+++ b/test/data/valid_openapi/xmlRequestAndResponseBodyArrayType.json
@@ -1,0 +1,100 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Example REST Service with XML Payloads"
+    },
+    "servers": [
+        {
+            "url": "localhost:3000"
+        }
+    ],
+    "paths": {
+        "/example": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ExampleResponse"
+                                }
+                            }
+                        },
+                        "description": "An example REST service with XML payloads response"
+                    }
+                },
+                "description": "An example REST service with XML payloads",
+                "requestBody": {
+                    "content": {
+                        "application/xml": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ExampleRequest"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "ExampleRequest": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                      "requestInteger": {
+                          "type": "integer"
+                      },
+                      "requestString": {
+                          "type": "string"
+                      },
+                      "requestBoolean": {
+                          "type": "boolean"
+                      }
+                  }
+                },
+                "xml": {
+                    "name": "ExampleXMLRequest",
+                    "prefix": "ex",
+                    "namespace": "urn:ExampleXML"
+                }
+            },
+            "ExampleResponse": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "requestInteger": {
+                            "type": "integer"
+                        },
+                        "requestString": {
+                            "type": "string"
+                        },
+                        "requestBoolean": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "xml": {
+                    "name": "ExampleXMLResponse",
+                    "prefix": "ex",
+                    "namespace": "urn:ExampleXML"
+                }
+            }
+        },
+        "securitySchemes": {
+            "BasicAuth": {
+                "type": "http",
+                "scheme": "basic"
+            }
+        }
+    },
+    "security": [
+        {
+            "BasicAuth": []
+        }
+    ]
+  }
+  

--- a/test/data/valid_openapi/xmlRequestAndResponseBodyArrayTypeNoPrefix.json
+++ b/test/data/valid_openapi/xmlRequestAndResponseBodyArrayTypeNoPrefix.json
@@ -1,0 +1,98 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Example REST Service with XML Payloads"
+    },
+    "servers": [
+        {
+            "url": "localhost:3000"
+        }
+    ],
+    "paths": {
+        "/example": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ExampleResponse"
+                                }
+                            }
+                        },
+                        "description": "An example REST service with XML payloads response"
+                    }
+                },
+                "description": "An example REST service with XML payloads",
+                "requestBody": {
+                    "content": {
+                        "application/xml": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ExampleRequest"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "ExampleRequest": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                      "requestInteger": {
+                          "type": "integer"
+                      },
+                      "requestString": {
+                          "type": "string"
+                      },
+                      "requestBoolean": {
+                          "type": "boolean"
+                      }
+                  }
+                },
+                "xml": {
+                    "name": "ExampleXMLRequest",
+                    "namespace": "urn:ExampleXML"
+                }
+            },
+            "ExampleResponse": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "requestInteger": {
+                            "type": "integer"
+                        },
+                        "requestString": {
+                            "type": "string"
+                        },
+                        "requestBoolean": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "xml": {
+                    "name": "ExampleXMLResponse",
+                    "namespace": "urn:ExampleXML"
+                }
+            }
+        },
+        "securitySchemes": {
+            "BasicAuth": {
+                "type": "http",
+                "scheme": "basic"
+            }
+        }
+    },
+    "security": [
+        {
+            "BasicAuth": []
+        }
+    ]
+  }
+  

--- a/test/data/valid_openapi/xmlRequestAndResponseBodyArrayTypeWrapped.json
+++ b/test/data/valid_openapi/xmlRequestAndResponseBodyArrayTypeWrapped.json
@@ -1,0 +1,102 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Example REST Service with XML Payloads"
+    },
+    "servers": [
+        {
+            "url": "localhost:3000"
+        }
+    ],
+    "paths": {
+        "/example": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ExampleResponse"
+                                }
+                            }
+                        },
+                        "description": "An example REST service with XML payloads response"
+                    }
+                },
+                "description": "An example REST service with XML payloads",
+                "requestBody": {
+                    "content": {
+                        "application/xml": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ExampleRequest"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "ExampleRequest": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                      "requestInteger": {
+                          "type": "integer"
+                      },
+                      "requestString": {
+                          "type": "string"
+                      },
+                      "requestBoolean": {
+                          "type": "boolean"
+                      }
+                  }
+                },
+                "xml": {
+                    "name": "ExampleXMLRequest",
+                    "prefix": "ex",
+                    "wrapped": true,
+                    "namespace": "urn:ExampleXML"
+                }
+            },
+            "ExampleResponse": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "requestInteger": {
+                            "type": "integer"
+                        },
+                        "requestString": {
+                            "type": "string"
+                        },
+                        "requestBoolean": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "xml": {
+                    "name": "ExampleXMLResponse",
+                    "prefix": "ex",
+                    "wrapped": true,
+                    "namespace": "urn:ExampleXML"
+                }
+            }
+        },
+        "securitySchemes": {
+            "BasicAuth": {
+                "type": "http",
+                "scheme": "basic"
+            }
+        }
+    },
+    "security": [
+        {
+            "BasicAuth": []
+        }
+    ]
+  }
+  

--- a/test/data/valid_openapi/xmlRequestAndResponseBodyNoPrefix.json
+++ b/test/data/valid_openapi/xmlRequestAndResponseBodyNoPrefix.json
@@ -1,0 +1,101 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+      "version": "1.0.0",
+      "title": "Example REST Service with XML Payloads"
+  },
+  "servers": [
+      {
+          "url": "localhost:3000"
+      }
+  ],
+  "paths": {
+      "/example": {
+          "post": {
+              "responses": {
+                  "200": {
+                      "content": {
+                          "application/xml": {
+                              "schema": {
+                                  "$ref": "#/components/schemas/ExampleResponse"
+                              }
+                          }
+                      },
+                      "description": "An example REST service with XML payloads response"
+                  }
+              },
+              "description": "An example REST service with XML payloads",
+              "requestBody": {
+                  "content": {
+                      "application/xml": {
+                          "schema": {
+                              "$ref": "#/components/schemas/ExampleRequest"
+                          }
+                      }
+                  }
+              }
+          }
+      }
+  },
+  "components": {
+      "schemas": {
+          "ExampleRequest": {
+              "type": "object",
+              "required": [
+                  "requestInteger",
+                  "requestString",
+                  "requestBoolean"
+              ],
+              "properties": {
+                  "requestInteger": {
+                      "type": "integer"
+                  },
+                  "requestString": {
+                      "type": "string"
+                  },
+                  "requestBoolean": {
+                      "type": "boolean"
+                  }
+              },
+              "xml": {
+                  "name": "ExampleXMLRequest",
+                  "namespace": "urn:ExampleXML"
+              }
+          },
+          "ExampleResponse": {
+              "type": "object",
+              "required": [
+                  "responseInteger",
+                  "responseString",
+                  "responseBoolean"
+              ],
+              "properties": {
+                  "responseInteger": {
+                      "type": "integer"
+                  },
+                  "responseString": {
+                      "type": "string"
+                  },
+                  "responseBoolean": {
+                      "type": "boolean"
+                  }
+              },
+              "xml": {
+                  "name": "ExampleXMLResponse",
+                  "namespace": "urn:ExampleXML"
+              }
+          }
+      },
+      "securitySchemes": {
+          "BasicAuth": {
+              "type": "http",
+              "scheme": "basic"
+          }
+      }
+  },
+  "security": [
+      {
+          "BasicAuth": []
+      }
+  ]
+}

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -63,7 +63,10 @@ describe('CONVERT FUNCTION TESTS ', function() {
       specWithAuthApiKey = path.join(__dirname, VALID_OPENAPI_PATH + '/specWithAuthApiKey.yaml'),
       specWithAuthDigest = path.join(__dirname, VALID_OPENAPI_PATH + '/specWithAuthDigest.yaml'),
       specWithAuthOauth1 = path.join(__dirname, VALID_OPENAPI_PATH + '/specWithAuthOauth1.yaml'),
-      specWithAuthBasic = path.join(__dirname, VALID_OPENAPI_PATH + '/specWithAuthBasic.yaml');
+      specWithAuthBasic = path.join(__dirname, VALID_OPENAPI_PATH + '/specWithAuthBasic.yaml'),
+      xmlRequestAndResponseBody = path.join(__dirname, VALID_OPENAPI_PATH, '/xmlRequestAndResponseBody.json'),
+      xmlRequestAndResponseBodyNoPrefix =
+        path.join(__dirname, VALID_OPENAPI_PATH, '/xmlRequestAndResponseBodyNoPrefix.json');
 
 
     it('Should add collection level auth with type as `bearer`' +
@@ -1379,6 +1382,64 @@ describe('CONVERT FUNCTION TESTS ', function() {
           done();
         });
       });
+    });
+
+    it('Should convert and resolve xml bodies correctly when prefix is provided', function(done) {
+      var openapi = fs.readFileSync(xmlRequestAndResponseBody, 'utf8');
+      Converter.convert(
+        { type: 'string', data: openapi },
+        { schemaFaker: true },
+        (err, conversionResult) => {
+          const resultantRequestBody = conversionResult.output[0].data.item[0].request.body.raw,
+            resultantResponseBody = conversionResult.output[0].data.item[0].response[0].body,
+            expectedRequestBody = '<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n' +
+              '<ex:ExampleXMLRequest xmlns:ex=\"urn:ExampleXML\">\n' +
+              '  <requestInteger>(integer)</requestInteger>\n' +
+              '  <requestString>(string)</requestString>\n' +
+              '  <requestBoolean>(boolean)</requestBoolean>\n' +
+              '</ex:ExampleXMLRequest>',
+            expectedResponseBody = '<ex:ExampleXMLResponse xmlns:ex=\"urn:ExampleXML\">\n' +
+              '  <responseInteger>(integer)</responseInteger>\n' +
+              '  <responseString>(string)</responseString>\n' +
+              '  <responseBoolean>(boolean)</responseBoolean>\n' +
+              '</ex:ExampleXMLResponse>';
+          expect(err).to.be.null;
+          expect(conversionResult.result).to.equal(true);
+          expect(conversionResult.output.length).to.equal(1);
+          expect(resultantRequestBody).to.equal(expectedRequestBody);
+          expect(resultantResponseBody).to.equal(expectedResponseBody);
+          done();
+        }
+      );
+    });
+
+    it('Should convert and resolve xml bodies correctly when prefix is not provided', function(done) {
+      var openapi = fs.readFileSync(xmlRequestAndResponseBodyNoPrefix, 'utf8');
+      Converter.convert(
+        { type: 'string', data: openapi },
+        { schemaFaker: true },
+        (err, conversionResult) => {
+          const resultantRequestBody = conversionResult.output[0].data.item[0].request.body.raw,
+            resultantResponseBody = conversionResult.output[0].data.item[0].response[0].body,
+            expectedRequestBody = '<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n' +
+              '<ExampleXMLRequest xmlns=\"urn:ExampleXML\">\n' +
+              '  <requestInteger>(integer)</requestInteger>\n' +
+              '  <requestString>(string)</requestString>\n' +
+              '  <requestBoolean>(boolean)</requestBoolean>\n' +
+              '</ExampleXMLRequest>',
+            expectedResponseBody = '<ExampleXMLResponse xmlns=\"urn:ExampleXML\">\n' +
+              '  <responseInteger>(integer)</responseInteger>\n' +
+              '  <responseString>(string)</responseString>\n' +
+              '  <responseBoolean>(boolean)</responseBoolean>\n' +
+              '</ExampleXMLResponse>';
+          expect(err).to.be.null;
+          expect(conversionResult.result).to.equal(true);
+          expect(conversionResult.output.length).to.equal(1);
+          expect(resultantRequestBody).to.equal(expectedRequestBody);
+          expect(resultantResponseBody).to.equal(expectedResponseBody);
+          done();
+        }
+      );
     });
   });
 

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -66,7 +66,13 @@ describe('CONVERT FUNCTION TESTS ', function() {
       specWithAuthBasic = path.join(__dirname, VALID_OPENAPI_PATH + '/specWithAuthBasic.yaml'),
       xmlRequestAndResponseBody = path.join(__dirname, VALID_OPENAPI_PATH, '/xmlRequestAndResponseBody.json'),
       xmlRequestAndResponseBodyNoPrefix =
-        path.join(__dirname, VALID_OPENAPI_PATH, '/xmlRequestAndResponseBodyNoPrefix.json');
+        path.join(__dirname, VALID_OPENAPI_PATH, '/xmlRequestAndResponseBodyNoPrefix.json'),
+      xmlRequestAndResponseBodyArrayType =
+        path.join(__dirname, VALID_OPENAPI_PATH, '/xmlRequestAndResponseBodyArrayType.json'),
+      xmlRequestAndResponseBodyArrayTypeNoPrefix =
+        path.join(__dirname, VALID_OPENAPI_PATH, '/xmlRequestAndResponseBodyArrayTypeNoPrefix.json'),
+      xmlRequestAndResponseBodyArrayTypeWrapped =
+        path.join(__dirname, VALID_OPENAPI_PATH, '/xmlRequestAndResponseBodyArrayTypeWrapped.json');
 
 
     it('Should add collection level auth with type as `bearer`' +
@@ -1432,6 +1438,127 @@ describe('CONVERT FUNCTION TESTS ', function() {
               '  <responseString>(string)</responseString>\n' +
               '  <responseBoolean>(boolean)</responseBoolean>\n' +
               '</ExampleXMLResponse>';
+          expect(err).to.be.null;
+          expect(conversionResult.result).to.equal(true);
+          expect(conversionResult.output.length).to.equal(1);
+          expect(resultantRequestBody).to.equal(expectedRequestBody);
+          expect(resultantResponseBody).to.equal(expectedResponseBody);
+          done();
+        }
+      );
+    });
+
+    it('Should convert and resolve xml bodies correctly when type is array', function(done) {
+      var openapi = fs.readFileSync(xmlRequestAndResponseBodyArrayType, 'utf8');
+      Converter.convert(
+        { type: 'string', data: openapi },
+        { schemaFaker: true },
+        (err, conversionResult) => {
+          const resultantRequestBody = conversionResult.output[0].data.item[0].request.body.raw,
+            resultantResponseBody = conversionResult.output[0].data.item[0].response[0].body,
+            expectedRequestBody = '<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n' +
+              '<ex:ExampleXMLRequest xmlns:ex=\"urn:ExampleXML\">\n' +
+              '  <requestInteger>(integer)</requestInteger>\n' +
+              '  <requestString>(string)</requestString>\n' +
+              '  <requestBoolean>(boolean)</requestBoolean>\n' +
+              '</ex:ExampleXMLRequest>\n' +
+              '<ex:ExampleXMLRequest xmlns:ex=\"urn:ExampleXML\">\n' +
+              '  <requestInteger>(integer)</requestInteger>\n' +
+              '  <requestString>(string)</requestString>\n' +
+              '  <requestBoolean>(boolean)</requestBoolean>\n' +
+              '</ex:ExampleXMLRequest>',
+            expectedResponseBody = '<ex:ExampleXMLResponse xmlns:ex=\"urn:ExampleXML\">\n' +
+              '  <requestInteger>(integer)</requestInteger>\n' +
+              '  <requestString>(string)</requestString>\n' +
+              '  <requestBoolean>(boolean)</requestBoolean>\n' +
+              '</ex:ExampleXMLResponse>\n' +
+              '<ex:ExampleXMLResponse xmlns:ex=\"urn:ExampleXML\">\n' +
+              '  <requestInteger>(integer)</requestInteger>\n' +
+              '  <requestString>(string)</requestString>\n' +
+              '  <requestBoolean>(boolean)</requestBoolean>\n' +
+              '</ex:ExampleXMLResponse>';
+          expect(err).to.be.null;
+          expect(conversionResult.result).to.equal(true);
+          expect(conversionResult.output.length).to.equal(1);
+          expect(resultantRequestBody).to.equal(expectedRequestBody);
+          expect(resultantResponseBody).to.equal(expectedResponseBody);
+          done();
+        }
+      );
+    });
+
+    it('Should convert and resolve xml bodies correctly when type is array and prefix is not provided', function(done) {
+      var openapi = fs.readFileSync(xmlRequestAndResponseBodyArrayTypeNoPrefix, 'utf8');
+      Converter.convert(
+        { type: 'string', data: openapi },
+        { schemaFaker: true },
+        (err, conversionResult) => {
+          const resultantRequestBody = conversionResult.output[0].data.item[0].request.body.raw,
+            resultantResponseBody = conversionResult.output[0].data.item[0].response[0].body,
+            expectedRequestBody = '<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n' +
+              '<ExampleXMLRequest xmlns=\"urn:ExampleXML\">\n' +
+              '  <requestInteger>(integer)</requestInteger>\n' +
+              '  <requestString>(string)</requestString>\n' +
+              '  <requestBoolean>(boolean)</requestBoolean>\n' +
+              '</ExampleXMLRequest>\n' +
+              '<ExampleXMLRequest xmlns=\"urn:ExampleXML\">\n' +
+              '  <requestInteger>(integer)</requestInteger>\n' +
+              '  <requestString>(string)</requestString>\n' +
+              '  <requestBoolean>(boolean)</requestBoolean>\n' +
+              '</ExampleXMLRequest>',
+            expectedResponseBody = '<ExampleXMLResponse xmlns=\"urn:ExampleXML\">\n' +
+              '  <requestInteger>(integer)</requestInteger>\n' +
+              '  <requestString>(string)</requestString>\n' +
+              '  <requestBoolean>(boolean)</requestBoolean>\n' +
+              '</ExampleXMLResponse>\n' +
+              '<ExampleXMLResponse xmlns=\"urn:ExampleXML\">\n' +
+              '  <requestInteger>(integer)</requestInteger>\n' +
+              '  <requestString>(string)</requestString>\n' +
+              '  <requestBoolean>(boolean)</requestBoolean>\n' +
+              '</ExampleXMLResponse>';
+          expect(err).to.be.null;
+          expect(conversionResult.result).to.equal(true);
+          expect(conversionResult.output.length).to.equal(1);
+          expect(resultantRequestBody).to.equal(expectedRequestBody);
+          expect(resultantResponseBody).to.equal(expectedResponseBody);
+          done();
+        }
+      );
+    });
+
+    it('Should convert and resolve xml bodies correctly when type is array and xml has wrapped', function(done) {
+      var openapi = fs.readFileSync(xmlRequestAndResponseBodyArrayTypeWrapped, 'utf8');
+      Converter.convert(
+        { type: 'string', data: openapi },
+        { schemaFaker: true },
+        (err, conversionResult) => {
+          const resultantRequestBody = conversionResult.output[0].data.item[0].request.body.raw,
+            resultantResponseBody = conversionResult.output[0].data.item[0].response[0].body,
+            expectedRequestBody = '<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n' +
+              '<ex:ExampleXMLRequest>\n' +
+              '  <ex:ExampleXMLRequest xmlns:ex=\"urn:ExampleXML\">\n' +
+              '    <requestInteger>(integer)</requestInteger>\n' +
+              '    <requestString>(string)</requestString>\n' +
+              '    <requestBoolean>(boolean)</requestBoolean>\n' +
+              '  </ex:ExampleXMLRequest>\n' +
+              '  <ex:ExampleXMLRequest xmlns:ex=\"urn:ExampleXML\">\n' +
+              '    <requestInteger>(integer)</requestInteger>\n' +
+              '    <requestString>(string)</requestString>\n' +
+              '    <requestBoolean>(boolean)</requestBoolean>\n' +
+              '  </ex:ExampleXMLRequest>\n' +
+              '</ex:ExampleXMLRequest>',
+            expectedResponseBody = '<ex:ExampleXMLResponse>\n' +
+            '  <ex:ExampleXMLResponse xmlns:ex=\"urn:ExampleXML\">\n' +
+            '    <requestInteger>(integer)</requestInteger>\n' +
+            '    <requestString>(string)</requestString>\n' +
+            '    <requestBoolean>(boolean)</requestBoolean>\n' +
+            '  </ex:ExampleXMLResponse>\n' +
+            '  <ex:ExampleXMLResponse xmlns:ex=\"urn:ExampleXML\">\n' +
+            '    <requestInteger>(integer)</requestInteger>\n' +
+            '    <requestString>(string)</requestString>\n' +
+            '    <requestBoolean>(boolean)</requestBoolean>\n' +
+            '  </ex:ExampleXMLResponse>\n' +
+            '</ex:ExampleXMLResponse>';
           expect(err).to.be.null;
           expect(conversionResult.result).to.equal(true);
           expect(conversionResult.output.length).to.equal(1);

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -1403,11 +1403,13 @@ describe('CONVERT FUNCTION TESTS ', function() {
               '  <requestInteger>(integer)</requestInteger>\n' +
               '  <requestString>(string)</requestString>\n' +
               '  <requestBoolean>(boolean)</requestBoolean>\n' +
+              '  <requestNumber>(number)</requestNumber>\n' +
               '</ex:ExampleXMLRequest>',
             expectedResponseBody = '<ex:ExampleXMLResponse xmlns:ex=\"urn:ExampleXML\">\n' +
               '  <responseInteger>(integer)</responseInteger>\n' +
               '  <responseString>(string)</responseString>\n' +
               '  <responseBoolean>(boolean)</responseBoolean>\n' +
+              '  <responseNumber>(number)</responseNumber>\n' +
               '</ex:ExampleXMLResponse>';
           expect(err).to.be.null;
           expect(conversionResult.result).to.equal(true);


### PR DESCRIPTION
Adding fix to [postmanlabs/postman-app-support/issues/11227](https://github.com/postmanlabs/postman-app-support/issues/11227)

- Adding scenarios for schema when it's object type
- Adding scenarios for schema when it's array type

Considered extra scenarios:
- When schema type is array:
  We considered this schema as example:
```
{
   "type": "array",
      "items": {
         "type": "object",
         "properties": {
            "requestInteger": {
               "type": "integer"
            },
            "requestString": {
               "type": "string"
            },
            "requestBoolean": {
               "type": "boolean"
            }
         }
      },
      "xml": {
         "name": "ExampleXMLResponse",
         "prefix": "ex",
         "namespace": "urn:ExampleXML"
      }
   }
```
Adn for this input we expect:
```
<ex:ExampleXMLResponse xmlns:ex=\"urn:ExampleXML\">\n
  <requestInteger>(integer)</requestInteger>\n
  <requestString>(string)</requestString>\n
  <requestBoolean>(boolean)</requestBoolean>\n
</ex:ExampleXMLResponse>\n
<ex:ExampleXMLResponse xmlns:ex=\"urn:ExampleXML\">\n
  <requestInteger>(integer)</requestInteger>\n
  <requestString>(string)</requestString>\n
  <requestBoolean>(boolean)</requestBoolean>\n
</ex:ExampleXMLResponse>
```

- When schema type is array and the xml.wrapped property is set as true:
```
"xml": {
  "name": "ExampleXMLResponse",
  "prefix": "ex",
  "wrapped": true,
  "namespace": "urn:ExampleXML"
}
```
We will expect:
```
<ex:ExampleXMLResponse>\n
  <ex:ExampleXMLResponse xmlns:ex=\"urn:ExampleXML\">\n
    <requestInteger>(integer)</requestInteger>\n
    <requestString>(string)</requestString>\n
    <requestBoolean>(boolean)</requestBoolean>\n
  </ex:ExampleXMLResponse>\n
  <ex:ExampleXMLResponse xmlns:ex=\"urn:ExampleXML\">\n
    <requestInteger>(integer)</requestInteger>\n
    <requestString>(string)</requestString>\n
    <requestBoolean>(boolean)</requestBoolean>\n
  </ex:ExampleXMLResponse>\n
</ex:ExampleXMLResponse>
```
Those expectations where resolved similar than in test in utils.test.js - Line 2142

- It was added support to schemas when type is 'boolean' and when type is 'number'.
we expect:
```
<responseBoolean>(boolean)</requestBoolean>\n -> For boolean type
<responseNumber>(number)</responseNumber>\n -> For number type
```
