### PR TITLE
Fixing issue#11519 : imported OpenAPI yaml is missing properties

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -248,18 +248,6 @@ module.exports = {
       return { value: 'reference ' + schema.$ref + ' not found in the OpenAPI spec' };
     }
 
-    const getAdditionalProperties = (schema) => {
-      let additionalProperties;
-      if (_.isBoolean(schema.additionalProperties)) {
-        additionalProperties = schema.additionalProperties;
-      }
-      else {
-        additionalProperties = this.resolveRefs(schema.additionalProperties, parameterSourceOption,
-          components, schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
-      }
-      return additionalProperties;
-    };
-
     if (
       concreteUtils.compareTypes(schema.type, SCHEMA_TYPES.object) ||
       schema.hasOwnProperty('properties') ||
@@ -273,7 +261,13 @@ module.exports = {
         // shallow cloning schema object except properties object
 
         if (_.has(schema, 'additionalProperties')) {
-          tempSchema.additionalProperties = getAdditionalProperties(schema);
+          if (_.isBoolean(schema.additionalProperties)) {
+            tempSchema.additionalProperties = schema.additionalProperties;
+          }
+          else {
+            tempSchema.additionalProperties = this.resolveRefs(schema.additionalProperties, parameterSourceOption,
+              components, schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
+          }
         }
 
         !_.isEmpty(schema.properties) && (tempSchema.properties = {});
@@ -343,10 +337,6 @@ module.exports = {
       // so that the original schema.items object will not change
       // without this, schemas with circular references aren't faked correctly
       let tempSchema = _.omit(schema, ['items', 'additionalProperties']);
-
-      if (_.has(schema, 'additionalProperties')) {
-        tempSchema.additionalProperties = getAdditionalProperties(schema);
-      }
 
       tempSchema.items = this.resolveRefs(schema.items, parameterSourceOption,
         components, schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef), stackLimit);

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -247,23 +247,29 @@ module.exports = {
       }
       return { value: 'reference ' + schema.$ref + ' not found in the OpenAPI spec' };
     }
-    if (concreteUtils.compareTypes(schema.type, SCHEMA_TYPES.object) || schema.hasOwnProperty('properties') ||
-      schema.hasOwnProperty('additionalProperties')) {
+
+    const getAdditionalProperties = (schema) => {
+      let additionalProperties;
+      if (_.isBoolean(schema.additionalProperties)) {
+        additionalProperties = schema.additionalProperties;
+      }
+      else {
+        additionalProperties = this.resolveRefs(schema.additionalProperties, parameterSourceOption,
+          components, schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
+      }
+      return additionalProperties;
+    };
+
+    if (concreteUtils.compareTypes(schema.type, SCHEMA_TYPES.object) || schema.hasOwnProperty('properties')) {
       // go through all props
       schema.type = SCHEMA_TYPES.object;
-      if (_.has(schema, 'properties') || _.has(schema, 'additionalProperties')) {
-        // shallow cloning schema object except properties object
+
+      if (_.has(schema, 'properties')) {
         let tempSchema = _.omit(schema, ['properties', 'additionalProperties']);
+        // shallow cloning schema object except properties object
 
         if (_.has(schema, 'additionalProperties')) {
-          // don't resolve boolean values
-          if (_.isBoolean(schema.additionalProperties)) {
-            tempSchema.additionalProperties = schema.additionalProperties;
-          }
-          else {
-            tempSchema.additionalProperties = this.resolveRefs(schema.additionalProperties, parameterSourceOption,
-              components, schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
-          }
+          tempSchema.additionalProperties = getAdditionalProperties(schema);
         }
 
         !_.isEmpty(schema.properties) && (tempSchema.properties = {});
@@ -332,7 +338,12 @@ module.exports = {
       // have to create a shallow clone of schema object,
       // so that the original schema.items object will not change
       // without this, schemas with circular references aren't faked correctly
-      let tempSchema = _.omit(schema, 'items');
+      let tempSchema = _.omit(schema, ['items', 'additionalProperties']);
+
+      if (_.has(schema, 'additionalProperties')) {
+        tempSchema.additionalProperties = getAdditionalProperties(schema);
+      }
+
       tempSchema.items = this.resolveRefs(schema.items, parameterSourceOption,
         components, schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
       return tempSchema;

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -260,11 +260,15 @@ module.exports = {
       return additionalProperties;
     };
 
-    if (concreteUtils.compareTypes(schema.type, SCHEMA_TYPES.object) || schema.hasOwnProperty('properties')) {
+    if (
+      concreteUtils.compareTypes(schema.type, SCHEMA_TYPES.object) ||
+      schema.hasOwnProperty('properties') ||
+      (schema.hasOwnProperty('additionalProperties') && !schema.hasOwnProperty('type'))
+    ) {
       // go through all props
       schema.type = SCHEMA_TYPES.object;
 
-      if (_.has(schema, 'properties')) {
+      if (_.has(schema, 'properties') || _.has(schema, 'additionalProperties')) {
         let tempSchema = _.omit(schema, ['properties', 'additionalProperties']);
         // shallow cloning schema object except properties object
 

--- a/test/data/valid_openapi/schemaWithAdditionalProperties.yaml
+++ b/test/data/valid_openapi/schemaWithAdditionalProperties.yaml
@@ -1,0 +1,50 @@
+openapi: "3.0.0"
+info:
+  version: "1.0.0"
+  title: Pet Service
+servers:
+  - url: "http://localhost:3006"
+
+paths:
+  /v1/listPets:
+    post:
+      summary: Get Pets
+      description: Retrieve the list of Pets
+      operationId: listPets
+      x-rpc-controller: pets
+      tags:
+        - Pets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                test:
+                  type: string
+              additionalProperties: false
+      responses:
+        "200":
+          description: A list of Pets
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StringResponse1"
+        "201":
+          description: A list of Pets
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StringResponse2"
+components:
+  schemas:
+    StringResponse1:
+      additionalProperties:
+        type: string
+    StringResponse2:
+      type: object
+      properties:
+        test1:
+          type: string
+      additionalProperties:
+        type: string

--- a/test/data/valid_openapi/schemaWithArrayTypeAndAdditionalProperties.yaml
+++ b/test/data/valid_openapi/schemaWithArrayTypeAndAdditionalProperties.yaml
@@ -1,0 +1,71 @@
+openapi: "3.0.0"
+info:
+  version: "1.0.0"
+  title: Pet Service
+servers:
+  - url: "http://localhost:3006"
+
+paths:
+  /v1/listPets:
+    post:
+      summary: Get Pets
+      description: Retrieve the list of Pets
+      operationId: listPets
+      x-rpc-controller: pets
+      tags:
+        - Pets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/JsonRpcResponse"
+                - type: object
+                  properties:
+                    result:
+                      $ref: "#/components/schemas/ListPetResponse"
+      responses:
+        "200":
+          description: A list of Pets
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonRpcResponse"
+                  - type: object
+                    properties:
+                      result:
+                        $ref: "#/components/schemas/ListPetResponse"
+
+components:
+  schemas:
+
+    JsonRpcResponse:
+      required:
+        - jsonrpc
+      additionalProperties: true
+      properties:
+        jsonrpc:
+          type: string
+          default: "2.0"
+          example: "2.0"
+          nullable: false
+
+    Pet:
+      required:
+        - id
+        - name
+      additionalProperties: false
+      nullable: true
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+
+    ListPetResponse:
+      type: array
+      additionalProperties: false
+      items:
+        $ref: "#/components/schemas/Pet"

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -84,7 +84,9 @@ describe('CONVERT FUNCTION TESTS ', function() {
       xmlRequestAndResponseBodyArrayTypeNoPrefix =
         path.join(__dirname, VALID_OPENAPI_PATH, '/xmlRequestAndResponseBodyArrayTypeNoPrefix.json'),
       xmlRequestAndResponseBodyArrayTypeWrapped =
-        path.join(__dirname, VALID_OPENAPI_PATH, '/xmlRequestAndResponseBodyArrayTypeWrapped.json');
+        path.join(__dirname, VALID_OPENAPI_PATH, '/xmlRequestAndResponseBodyArrayTypeWrapped.json'),
+      schemaWithAdditionalProperties =
+        path.join(__dirname, VALID_OPENAPI_PATH, '/schemaWithAdditionalProperties.yaml');
 
 
     it('Should add collection level auth with type as `bearer`' +
@@ -1568,33 +1570,6 @@ describe('CONVERT FUNCTION TESTS ', function() {
       });
     });
 
-    it('Should fake correctly the body when schema has array type and additionalProperties', function(done) {
-      var openapi = fs.readFileSync(schemaWithArrayTypeAndAdditionalProperties, 'utf8');
-      Converter.convert({ type: 'string', data: openapi }, { schemaFaker: true }, (err, conversionResult) => {
-        const resultantResponseBody = JSON.parse(
-            conversionResult.output[0].data.item[0].response[0].body
-          ),
-          resultantRequestBody = JSON.parse(
-            conversionResult.output[0].data.item[0].request.body.raw
-          );
-        expect(err).to.be.null;
-        expect(conversionResult.result).to.equal(true);
-        expect(conversionResult.output.length).to.equal(1);
-        expect(conversionResult.output[0].type).to.equal('collection');
-        expect(conversionResult.output[0].data).to.have.property('info');
-        expect(conversionResult.output[0].data).to.have.property('item');
-        expect(resultantResponseBody.result).to.be.an('array')
-          .with.length(2);
-        expect(resultantResponseBody.result[0]).to.include.all.keys('id', 'name');
-        expect(resultantResponseBody.result[1]).to.include.all.keys('id', 'name');
-        expect(resultantRequestBody.result).to.be.an('array')
-          .with.length(2);
-        expect(resultantRequestBody.result[0]).to.include.all.keys('id', 'name');
-        expect(resultantRequestBody.result[1]).to.include.all.keys('id', 'name');
-        done();
-      });
-    });
-
     it('Should convert and resolve xml bodies correctly when prefix is provided', function(done) {
       var openapi = fs.readFileSync(xmlRequestAndResponseBody, 'utf8');
       Converter.convert(
@@ -1774,6 +1749,74 @@ describe('CONVERT FUNCTION TESTS ', function() {
           done();
         }
       );
+    });
+
+    it('Should fake correctly the body when schema has array type and additionalProperties', function(done) {
+      var openapi = fs.readFileSync(schemaWithArrayTypeAndAdditionalProperties, 'utf8');
+      Converter.convert({ type: 'string', data: openapi }, { schemaFaker: true }, (err, conversionResult) => {
+        const resultantResponseBody = JSON.parse(
+            conversionResult.output[0].data.item[0].response[0].body
+          ),
+          resultantRequestBody = JSON.parse(
+            conversionResult.output[0].data.item[0].request.body.raw
+          );
+        expect(err).to.be.null;
+        expect(conversionResult.result).to.equal(true);
+        expect(conversionResult.output.length).to.equal(1);
+        expect(conversionResult.output[0].type).to.equal('collection');
+        expect(conversionResult.output[0].data).to.have.property('info');
+        expect(conversionResult.output[0].data).to.have.property('item');
+        expect(resultantResponseBody.result).to.be.an('array')
+          .with.length(2);
+        expect(resultantResponseBody.result[0]).to.include.all.keys('id', 'name');
+        expect(resultantResponseBody.result[1]).to.include.all.keys('id', 'name');
+        expect(resultantRequestBody.result).to.be.an('array')
+          .with.length(2);
+        expect(resultantRequestBody.result[0]).to.include.all.keys('id', 'name');
+        expect(resultantRequestBody.result[1]).to.include.all.keys('id', 'name');
+        done();
+      });
+    });
+
+    it('Should resolve correctly schemas with additionalProperties as false', function(done) {
+      var openapi = fs.readFileSync(schemaWithAdditionalProperties, 'utf8');
+      Converter.convert(
+        { type: 'string', data: openapi },
+        { schemaFaker: true },
+        (err, conversionResult) => {
+          const requestBodyWithAdditionalPropertiesAsFalse =
+            JSON.parse(conversionResult.output[0].data.item[0].request.body.raw);
+          expect(requestBodyWithAdditionalPropertiesAsFalse).to.include.keys('test');
+          expect(Object.keys(requestBodyWithAdditionalPropertiesAsFalse)).to.have.length(1);
+          done();
+        });
+    });
+
+    it('Should resolve correctly schemas with ONLY additionalProperties', function(done) {
+      var openapi = fs.readFileSync(schemaWithAdditionalProperties, 'utf8');
+      Converter.convert(
+        { type: 'string', data: openapi },
+        { schemaFaker: true },
+        (err, conversionResult) => {
+          const responseBodyWithOnlyAdditionalProperties =
+            JSON.parse(conversionResult.output[0].data.item[0].response[0].body);
+          expect(Object.keys(responseBodyWithOnlyAdditionalProperties).length).to.be.greaterThan(0);
+          done();
+        });
+    });
+
+    it('Should resolve correctly schemas with additionalProperties', function(done) {
+      var openapi = fs.readFileSync(schemaWithAdditionalProperties, 'utf8');
+      Converter.convert(
+        { type: 'string', data: openapi },
+        { schemaFaker: true },
+        (err, conversionResult) => {
+          const responseBodyWithAdditionalProperties =
+            JSON.parse(conversionResult.output[0].data.item[0].response[1].body);
+          expect(responseBodyWithAdditionalProperties).to.include.keys('test1');
+          expect(Object.keys(responseBodyWithAdditionalProperties).length).to.be.greaterThan(1);
+          done();
+        });
     });
   });
 

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -63,7 +63,9 @@ describe('CONVERT FUNCTION TESTS ', function() {
       specWithAuthApiKey = path.join(__dirname, VALID_OPENAPI_PATH + '/specWithAuthApiKey.yaml'),
       specWithAuthDigest = path.join(__dirname, VALID_OPENAPI_PATH + '/specWithAuthDigest.yaml'),
       specWithAuthOauth1 = path.join(__dirname, VALID_OPENAPI_PATH + '/specWithAuthOauth1.yaml'),
-      specWithAuthBasic = path.join(__dirname, VALID_OPENAPI_PATH + '/specWithAuthBasic.yaml');
+      specWithAuthBasic = path.join(__dirname, VALID_OPENAPI_PATH + '/specWithAuthBasic.yaml'),
+      schemaWithArrayTypeAndAdditionalProperties =
+        path.join(__dirname, VALID_OPENAPI_PATH + '/schemaWithArrayTypeAndAdditionalProperties.yaml');
 
 
     it('Should add collection level auth with type as `bearer`' +
@@ -1378,6 +1380,29 @@ describe('CONVERT FUNCTION TESTS ', function() {
           expect(conversionResult.output[0].data.auth.apikey[1].value).to.equal('{{apiKey}}');
           done();
         });
+      });
+    });
+
+    it('Should fake correctly the body when schema has array type and additionalProperties', function(done) {
+      var openapi = fs.readFileSync(schemaWithArrayTypeAndAdditionalProperties, 'utf8');
+      Converter.convert({ type: 'string', data: openapi }, { schemaFaker: true }, (err, conversionResult) => {
+        const resultantResponseBody = JSON.parse(
+            conversionResult.output[0].data.item[0].response[0].body
+          ),
+          resultantRequestBody = JSON.parse(
+            conversionResult.output[0].data.item[0].request.body.raw
+          );
+        expect(err).to.be.null;
+        expect(conversionResult.result).to.equal(true);
+        expect(conversionResult.output.length).to.equal(1);
+        expect(conversionResult.output[0].type).to.equal('collection');
+        expect(conversionResult.output[0].data).to.have.property('info');
+        expect(conversionResult.output[0].data).to.have.property('item');
+        expect(resultantResponseBody.result).to.be.an('array')
+          .with.length(2);
+        expect(resultantRequestBody.result).to.be.an('array')
+          .with.length(2);
+        done();
       });
     });
   });

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -1400,8 +1400,12 @@ describe('CONVERT FUNCTION TESTS ', function() {
         expect(conversionResult.output[0].data).to.have.property('item');
         expect(resultantResponseBody.result).to.be.an('array')
           .with.length(2);
+        expect(resultantResponseBody.result[0]).to.include.all.keys('id', 'name');
+        expect(resultantResponseBody.result[1]).to.include.all.keys('id', 'name');
         expect(resultantRequestBody.result).to.be.an('array')
           .with.length(2);
+        expect(resultantRequestBody.result[0]).to.include.all.keys('id', 'name');
+        expect(resultantRequestBody.result[1]).to.include.all.keys('id', 'name');
         done();
       });
     });


### PR DESCRIPTION
It fixes[ issue#11519](https://github.com/postmanlabs/postman-app-support/issues/11519)

Issue cause:
- The provided specification references a schema with 'type: array' and 'additionalProperties' property. But, the current implementation of resolveRefs method does not support 'additionalProperties' into an array-typed schema, and it was changing the type to object. So, the items schema was not processed correctly.

Solution:
- It was added support to additional properties into array-types schemas. Now when the schema is an array the process uses the items element instead of properties to resolve the references.