### PR TITLE
Fix for conversion taking a long time in case of schema with example

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -8,7 +8,7 @@ requestParametersResolution|enum|Example, Schema|Schema|Select whether to genera
 exampleParametersResolution|enum|Example, Schema|Example|Select whether to generate the response parameters based on the [schema](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schemaObject) or the [example](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#exampleObject) in the schema.|CONVERSION
 folderStrategy|enum|Paths, Tags|Paths|Select whether to create folders according to the spec’s paths or tags.|CONVERSION
 schemaFaker|boolean|-|true|Whether or not schemas should be faked.|CONVERSION
-stackLimit|integer|-|8|Number of nesting limit till which schema resolution will happen. Increasing this limit may result in more time to convert collection depending on complexity of specification. (To make sure this option works correctly "optimizeConversion" option needs to be disabled)|CONVERSION
+stackLimit|integer|-|10|Number of nesting limit till which schema resolution will happen. Increasing this limit may result in more time to convert collection depending on complexity of specification. (To make sure this option works correctly "optimizeConversion" option needs to be disabled)|CONVERSION
 includeAuthInfoInExample|boolean|-|true|Select whether to include authentication parameters in the example request|CONVERSION
 shortValidationErrors|boolean|-|false|Whether detailed error messages are required for request <> schema validation operations.|VALIDATION
 validationPropertiesToIgnore|array|-|[]|Specific properties (parts of a request/response pair) to ignore during validation. Must be sent as an array of strings. Valid inputs in the array: PATHVARIABLE, QUERYPARAM, HEADER, BODY, RESPONSE_HEADER, RESPONSE_BODY|VALIDATION

--- a/assets/json-schema-faker.js
+++ b/assets/json-schema-faker.js
@@ -24674,11 +24674,11 @@ function extend() {
       if (optionAPI('useExamplesValue') && 'example' in schema) {
         var clonedSchema,
           result,
-          finalResult,
+          isExampleValid,
           hashSchema = hash(schema);
 
         if(seenSchemaMap.has(hashSchema)) {
-          finalResult = seenSchemaMap.get(hashSchema);
+          isExampleValid = seenSchemaMap.get(hashSchema);
         }
         else {
           // avoid minItems and maxItems while checking for valid examples
@@ -24696,12 +24696,12 @@ function extend() {
           }
 
           // Store the final result that needs to be used in the seen map
-          finalResult = result && result.length === 0;
-          seenSchemaMap.set(hashSchema, finalResult);
+          isExampleValid = result && result.length === 0;
+          seenSchemaMap.set(hashSchema, isExampleValid);
         }
 
         // Use example only if valid
-        if (finalResult) {
+        if (isExampleValid) {
           return schema.example;
         }
       }

--- a/assets/json-schema-faker.js
+++ b/assets/json-schema-faker.js
@@ -24694,11 +24694,12 @@ function extend() {
             // avoid validation of values that are in pm variable format (i.e. '{{userId}}')
             result = validateSchema(schema, schema.example, { ignoreUnresolvedVariables: true });
           }
+
+          // Store the final result that needs to be used in the seen map
+          finalResult = result && result.length === 0;
+          seenSchemaMap.set(hashSchema, finalResult);
         }
 
-        finalResult = result && result.length === 0;
-
-        seenSchemaMap.set(hashSchema, finalResult);
         // Use example only if valid
         if (finalResult) {
           return schema.example;

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -149,7 +149,7 @@ module.exports = {
    */
 
   resolveRefs: function (schema, parameterSourceOption, components, schemaResolutionCache,
-    resolveFor = 'CONVERSION', resolveTo = 'schema', stack = 0, seenRef = {}, stackLimit = 8, isAllOf = false) {
+    resolveFor = 'CONVERSION', resolveTo = 'schema', stack = 0, seenRef = {}, stackLimit = 10, isAllOf = false) {
     var resolvedSchema, prop, splitRef,
       ERR_TOO_MANY_LEVELS = '<Error: Too many levels of nesting to fake this schema>';
     let concreteUtils = components && components.hasOwnProperty('concreteUtils') ?

--- a/lib/options.js
+++ b/lib/options.js
@@ -155,7 +155,7 @@ module.exports = {
         name: 'Schema resolution nesting limit',
         id: 'stackLimit',
         type: 'integer',
-        default: 8,
+        default: 10,
         description: 'Number of nesting limit till which schema resolution will happen. Increasing this limit may' +
           ' result in more time to convert collection depending on complexity of specification. (To make sure this' +
           ' option works correctly "optimizeConversion" option needs to be disabled)',

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -273,7 +273,7 @@ module.exports = {
 
     var computedOptions = _.clone(options);
 
-    computedOptions.stackLimit = 8;
+    computedOptions.stackLimit = 10;
     // This is the score that is given to each spec on the basis of the
     // number of references present in spec and the number of requests that will be generated.
     // This ranges from 0-10.

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -197,7 +197,7 @@ function safeSchemaFaker(oldSchema, resolveTo, resolveFor, parameterSourceOption
       return fakedSchema;
     }
     // for JSON, the indentCharacter will be applied in the JSON.stringify step later on
-    fakedSchema = schemaFaker(resolvedSchema);
+    fakedSchema = schemaFaker(resolvedSchema, null, _.get(schemaCache, 'schemaValidationCache'));
     schemaFakerCache[key] = fakedSchema;
     return fakedSchema;
   }

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -46,6 +46,7 @@ class SchemaPack {
     this.computedOptions = null;
     this.schemaFakerCache = {};
     this.schemaResolutionCache = {};
+    this.schemaValidationCache = new Map();
 
     this.computedOptions = utils.mergeOptions(
       // predefined options
@@ -260,7 +261,8 @@ class SchemaPack {
       authHelper,
       schemaCache = {
         schemaResolutionCache: this.schemaResolutionCache,
-        schemaFakerCache: this.schemaFakerCache
+        schemaFakerCache: this.schemaFakerCache,
+        schemaValidationCache: this.schemaValidationCache
       };
 
     if (!this.validated) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -464,7 +464,7 @@
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -627,7 +627,7 @@
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "chokidar": {
@@ -681,7 +681,7 @@
     "cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha1-UR1wLAxOQcoVbX0OlgIfI+EyJbE=",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "dev": true,
       "requires": {
         "string-width": "^4.2.0",
@@ -703,7 +703,7 @@
         "strip-ansi": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
@@ -1150,7 +1150,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.0.1",
@@ -1242,7 +1242,7 @@
     "file-type": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-      "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA=="
+      "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -1267,7 +1267,7 @@
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
       "requires": {
         "locate-path": "^5.0.0",
@@ -1398,7 +1398,7 @@
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-intrinsic": {
@@ -1530,7 +1530,7 @@
     "http-reasons": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/http-reasons/-/http-reasons-0.1.0.tgz",
-      "integrity": "sha512-P6kYh0lKZ+y29T2Gqz+RlC9WBLhKe8kDmcJ+A+611jFfxdPsbMRQ5aNmFRM3lENqFkK+HTTL+tlQviAiv0AbLQ=="
+      "integrity": "sha1-qVPKZwB4Zp3eFCzomUAbnW6F07Q="
     },
     "http2-client": {
       "version": "1.3.5",
@@ -1964,7 +1964,7 @@
     "json-schema-merge-allof": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.8.1.tgz",
-      "integrity": "sha512-CTUKmIlPJbsWfzRRnOXz+0MjIqvnleIXwFTzz+t9T86HnYX/Rozria6ZVGLktAU9e+NygNljveP+yxqtQp/Q4w==",
+      "integrity": "sha1-7SgozdlYYW/3T5MoMKJikXieqvI=",
       "requires": {
         "compute-lcm": "^1.1.2",
         "json-schema-compare": "^0.2.2",
@@ -2012,12 +2012,12 @@
     "liquid-json": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/liquid-json/-/liquid-json-0.3.1.tgz",
-      "integrity": "sha512-wUayTU8MS827Dam6MxgD72Ui+KOSF+u/eIqpatOtjnvgJ0+mnDq33uC2M7J0tPK+upe/DpUAuK4JUU89iBoNKQ=="
+      "integrity": "sha1-kVWhgTbYprJhXl8W+aJEira1Duo="
     },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
       "requires": {
         "p-locate": "^4.1.0"
@@ -2730,6 +2730,11 @@
         }
       }
     },
+    "object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
+    },
     "object-inspect": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
@@ -2815,7 +2820,7 @@
     "p-locate": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
       "requires": {
         "p-limit": "^2.2.0"
@@ -2875,7 +2880,7 @@
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true
     },
     "path-is-absolute": {
@@ -3793,7 +3798,7 @@
     "wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
@@ -3813,7 +3818,7 @@
         "color-convert": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
             "color-name": "~1.1.4"
@@ -3822,13 +3827,13 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "strip-ansi": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
@@ -3924,7 +3929,7 @@
     "yargs-parser": {
       "version": "18.1.3",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha1-vmjEl1xrKr9GkjawyHA2L6sJp7A=",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "json-schema-merge-allof": "0.8.1",
     "lodash": "4.17.21",
     "oas-resolver-browser": "2.5.6",
+    "object-hash": "3.0.0",
     "path-browserify": "1.0.1",
     "postman-collection": "4.1.5",
     "swagger2openapi": "7.0.8",

--- a/test/system/structure.test.js
+++ b/test/system/structure.test.js
@@ -96,7 +96,7 @@ const optionIds = [
     stackLimit: {
       name: 'Schema resolution nesting limit',
       type: 'integer',
-      default: 8,
+      default: 10,
       description: 'Number of nesting limit till which schema resolution will happen. Increasing this limit may' +
         ' result in more time to convert collection depending on complexity of specification. (To make sure this' +
         ' option works correctly "optimizeConversion" option needs to be disabled)'

--- a/test/unit/validator.test.js
+++ b/test/unit/validator.test.js
@@ -1349,7 +1349,7 @@ describe('VALIDATE FUNCTION TESTS ', function () {
         '/invalid_response_body_all_of_properties_collection.json'), 'utf-8'),
       historyRequest = [],
       schemaPack = new Converter.SchemaPack({ type: 'string', data: allOfExample },
-        { suggestAvailableFixes: true, showMissingInSchemaErrors: true, optimizeConversion: false, stackLimit: 10 });
+        { suggestAvailableFixes: true, showMissingInSchemaErrors: true });
 
     getAllTransactions(JSON.parse(allOfCollection), historyRequest);
 


### PR DESCRIPTION
This PR fixes an issue with how validateSchema was being used inside `json-schema-faker` 

When validating any schema against its example, we used to keep validating the same schema again and again even if it was validated before. This PR uses a Map to store the hash of the schema <> and its result (valid or not) in boolen as its value in the map. This map is looked up each time a schema has to be validated against its example and only done if we encounter a new schema else we simply use the result from the map.

This PR also reverts the default stack limit made from 10 to 8 back to 10. 