### PR TITLE
[APIDES-1706] Update schemapack to return analytics from the module and refactor deref

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -27,6 +27,13 @@ const _ = require('lodash'),
     'float',
     'double'
   ],
+  RESOLVE_REF_DEFAULTS = {
+    resolveFor: 'CONVERSION',
+    resolveTo: 'schema',
+    stack: 0,
+    stackLimit: 10,
+    isAllOf: false
+  },
   DEFAULT_SCHEMA_UTILS = require('./30XUtils/schemaUtils30X'),
   traverseUtility = require('traverse'),
   PROPERTIES_TO_ASSIGN_ON_CASCADE = ['type', 'nullable'];
@@ -96,8 +103,14 @@ module.exports = {
    * @param {*} options.stackLimit Depth to which the schema should be resolved.
    * @returns {*} schema - schema that adheres to all individual schemas in schemaArr
    */
-  resolveAllOf: function (schemaArr, parameterSourceOption, components,
-    { resolveFor = 'CONVERSION', resolveTo = 'schema', stack = 0, seenRef = {}, stackLimit = 10, analytics = {} }) {
+  resolveAllOf: function (schemaArr, parameterSourceOption, components, {
+    resolveFor = RESOLVE_REF_DEFAULTS.resolveFor,
+    resolveTo = RESOLVE_REF_DEFAULTS.resolveTo,
+    stack = RESOLVE_REF_DEFAULTS.stack,
+    seenRef = {},
+    stackLimit = RESOLVE_REF_DEFAULTS.stackLimit,
+    analytics = {}
+  }) {
 
     if (!(schemaArr instanceof Array)) {
       return null;
@@ -146,8 +159,13 @@ module.exports = {
    */
 
   resolveRefs: function (schema, parameterSourceOption, components, {
-    resolveFor = 'CONVERSION', resolveTo = 'schema', stack = 0, seenRef = {}, stackLimit = 10,
-    isAllOf = false, analytics = {}
+    resolveFor = RESOLVE_REF_DEFAULTS.resolveFor,
+    resolveTo = RESOLVE_REF_DEFAULTS.resolveTo,
+    stack = RESOLVE_REF_DEFAULTS.stack,
+    seenRef = {},
+    stackLimit = RESOLVE_REF_DEFAULTS.stackLimit,
+    isAllOf = RESOLVE_REF_DEFAULTS.isAllOf,
+    analytics = {}
   }) {
     var resolvedSchema, prop, splitRef,
       ERR_TOO_MANY_LEVELS = '<Error: Too many levels of nesting to fake this schema>';

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -154,11 +154,12 @@ module.exports = {
     let concreteUtils = components && components.hasOwnProperty('concreteUtils') ?
       components.concreteUtils :
       DEFAULT_SCHEMA_UTILS;
-    stack++;
 
     if (analytics.actualStack < stack) {
       analytics.actualStack = stack;
     }
+
+    stack++;
 
     if (stack > stackLimit) {
       return { value: ERR_TOO_MANY_LEVELS };

--- a/lib/deref.js
+++ b/lib/deref.js
@@ -84,20 +84,20 @@ module.exports = {
   /**
    * Creates a schema that's a union of all input schemas (only type: object is supported)
    *
-   * @param {array} schemaArr - array of schemas, all of which must be valid in the returned object
-   * @param {string} parameterSourceOption tells that the schema object is of request or response
-   * @param {*} components components in openapi spec.
-   * @param {object} schemaResolutionCache stores already resolved references
-   * @param {*} resolveFor - resolve refs for validation/conversion (value to be one of VALIDATION/CONVERSION)
-   * @param {string} resolveTo The desired JSON-generation mechanism (schema: prefer using the JSONschema to
+   * @param {array} schemaArr REQUIRED - array of schemas, all of which must be valid in the returned object
+   * @param {string} parameterSourceOption REQUIRED tells that the schema object is of request or response
+   * @param {*} components REQUIRED components in openapi spec.
+   * @param {object} options - REQUIRED a list of options to indicate the type of resolution needed.
+   * @param {*} options.resolveFor - resolve refs for validation/conversion (value to be one of VALIDATION/CONVERSION)
+   * @param {string} options.resolveTo The desired JSON-generation mechanism (schema: prefer using the JSONschema to
      generate a fake object, example: use specified examples as-is). Default: schema
-   * @param {*} stack counter which keeps a tab on nested schemas
-   * @param {*} seenRef References that are repeated. Used to identify circular references.
-   * @param {*} stackLimit Depth to which the schema should be resolved.
+   * @param {*} options.stack counter which keeps a tab on nested schemas
+   * @param {*} options.seenRef References that are repeated. Used to identify circular references.
+   * @param {*} options.stackLimit Depth to which the schema should be resolved.
    * @returns {*} schema - schema that adheres to all individual schemas in schemaArr
    */
-  resolveAllOf: function (schemaArr, parameterSourceOption, components, schemaResolutionCache,
-    resolveFor = 'CONVERSION', resolveTo = 'schema', stack = 0, seenRef, stackLimit) {
+  resolveAllOf: function (schemaArr, parameterSourceOption, components,
+    { resolveFor = 'CONVERSION', resolveTo = 'schema', stack = 0, seenRef = {}, stackLimit = 10, analytics = {} }) {
 
     if (!(schemaArr instanceof Array)) {
       return null;
@@ -105,15 +105,15 @@ module.exports = {
 
     if (schemaArr.length === 1) {
       // for just one entry in allOf, don't need to enforce type: object restriction
-      return this.resolveRefs(schemaArr[0], parameterSourceOption, components, schemaResolutionCache, resolveFor,
-        resolveTo, stack, seenRef, stackLimit);
+      return this.resolveRefs(schemaArr[0], parameterSourceOption, components,
+        { stack, seenRef: _.cloneDeep(seenRef), resolveFor, resolveTo, stackLimit, analytics });
     }
 
     try {
       return mergeAllOf({
         allOf: schemaArr.map((schema) => {
-          return this.resolveRefs(schema, parameterSourceOption, components, schemaResolutionCache, resolveFor,
-            resolveTo, stack, seenRef, stackLimit, true);
+          return this.resolveRefs(schema, parameterSourceOption, components,
+            { stack, seenRef: _.cloneDeep(seenRef), resolveFor, resolveTo, stackLimit, isAllOf: true, analytics });
         })
       }, {
         resolvers: {
@@ -130,33 +130,35 @@ module.exports = {
 
   /**
    * Resolves references to components for a given schema.
-   * @param {*} schema (openapi) to resolve references.
-   * @param {string} parameterSourceOption tells that the schema object is of request or response
-   * @param {*} components components in openapi spec.
-   * @param {object} schemaResolutionCache stores already resolved references - more structure detail below
-   * {'schema reference key': {
-   *    maxStack {Integer} : Defined as how deep of nesting level we reached while resolving schema that's being cached
-   *    resLevel {Integer} : Defined as nesting level at which schema that's being cached was resolved
-   *    schema {Object} : resolved schema that will be cached
-   * }}
-   * @param {*} resolveFor - resolve refs for validation/conversion (value to be one of VALIDATION/CONVERSION)
-   * @param {string} resolveTo The desired JSON-generation mechanism (schema: prefer using the JSONschema to
+   * @param {*} schema REQUIRED (openapi) to resolve references.
+   * @param {string} parameterSourceOption REQUIRED tells that the schema object is of request or response
+   * @param {*} components REQUIRED components in openapi spec.
+   * @param {object} options REQUIRED a list of options to indicate the type of resolution needed
+   * @param {*} options.resolveFor - resolve refs for validation/conversion (value to be one of VALIDATION/CONVERSION)
+   * @param {string} options.resolveTo The desired JSON-generation mechanism (schema: prefer using the JSONschema to
     generate a fake object, example: use specified examples as-is). Default: schema
-   * @param {*} stack counter which keeps a tab on nested schemas
-   * @param {*} seenRef - References that are repeated. Used to identify circular references.
-   * @param {*} stackLimit Depth to which the schema should be resolved.
-   * @returns {*} schema satisfying JSON-schema-faker.
+   * @param {number} options.stack counter which keeps a tab on nested schemas
+   * @param {*} otions.seenRef - References that are repeated. Used to identify circular references.
+   * @param {number} options.stackLimit Depth to which the schema should be resolved.
+   * @param {Boolean} options.isAllOf
+   * @param {object} options.analytics
+    * @returns {*} schema satisfying JSON-schema-faker.
    */
 
-  resolveRefs: function (schema, parameterSourceOption, components, schemaResolutionCache,
-    resolveFor = 'CONVERSION', resolveTo = 'schema', stack = 0, seenRef = {}, stackLimit = 10, isAllOf = false) {
+  resolveRefs: function (schema, parameterSourceOption, components, {
+    resolveFor = 'CONVERSION', resolveTo = 'schema', stack = 0, seenRef = {}, stackLimit = 10,
+    isAllOf = false, analytics = {}
+  }) {
     var resolvedSchema, prop, splitRef,
       ERR_TOO_MANY_LEVELS = '<Error: Too many levels of nesting to fake this schema>';
     let concreteUtils = components && components.hasOwnProperty('concreteUtils') ?
       components.concreteUtils :
       DEFAULT_SCHEMA_UTILS;
     stack++;
-    schemaResolutionCache = schemaResolutionCache || {};
+
+    if (analytics.actualStack < stack) {
+      analytics.actualStack = stack;
+    }
 
     if (stack > stackLimit) {
       return { value: ERR_TOO_MANY_LEVELS };
@@ -168,8 +170,14 @@ module.exports = {
 
     if (schema.anyOf) {
       if (resolveFor === 'CONVERSION') {
-        return this.resolveRefs(schema.anyOf[0], parameterSourceOption, components, schemaResolutionCache, resolveFor,
-          resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
+        return this.resolveRefs(schema.anyOf[0], parameterSourceOption, components, {
+          resolveFor,
+          resolveTo,
+          stack,
+          seenRef: _.cloneDeep(seenRef),
+          stackLimit,
+          analytics
+        });
       }
       return { anyOf: _.map(schema.anyOf, (schemaElement) => {
         PROPERTIES_TO_ASSIGN_ON_CASCADE.forEach((prop) => {
@@ -177,14 +185,28 @@ module.exports = {
             schemaElement[prop] = schema[prop];
           }
         });
-        return this.resolveRefs(schemaElement, parameterSourceOption, components, schemaResolutionCache, resolveFor,
-          resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
+        return this.resolveRefs(schemaElement, parameterSourceOption, components,
+          {
+            resolveFor,
+            resolveTo,
+            stack,
+            seenRef: _.cloneDeep(seenRef),
+            stackLimit,
+            analytics
+          });
       }) };
     }
     if (schema.oneOf) {
       if (resolveFor === 'CONVERSION') {
-        return this.resolveRefs(schema.oneOf[0], parameterSourceOption, components, schemaResolutionCache, resolveFor,
-          resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
+        return this.resolveRefs(schema.oneOf[0], parameterSourceOption, components,
+          {
+            resolveFor,
+            resolveTo,
+            stack,
+            seenRef: _.cloneDeep(seenRef),
+            stackLimit,
+            analytics
+          });
       }
       return { oneOf: _.map(schema.oneOf, (schemaElement) => {
         PROPERTIES_TO_ASSIGN_ON_CASCADE.forEach((prop) => {
@@ -193,13 +215,27 @@ module.exports = {
           }
         });
 
-        return this.resolveRefs(schemaElement, parameterSourceOption, components, schemaResolutionCache,
-          resolveFor, resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
+        return this.resolveRefs(schemaElement, parameterSourceOption, components,
+          {
+            resolveFor,
+            resolveTo,
+            stack,
+            seenRef: _.cloneDeep(seenRef),
+            stackLimit,
+            analytics
+          });
       }) };
     }
     if (schema.allOf) {
-      return this.resolveAllOf(schema.allOf, parameterSourceOption, components, schemaResolutionCache, resolveFor,
-        resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
+      return this.resolveAllOf(schema.allOf, parameterSourceOption, components,
+        {
+          resolveFor,
+          resolveTo,
+          stack,
+          seenRef: _.cloneDeep(seenRef),
+          stackLimit,
+          analytics
+        });
     }
     if (schema.$ref && _.isFunction(schema.$ref.split)) {
       let refKey = schema.$ref,
@@ -241,7 +277,14 @@ module.exports = {
       }
       if (resolvedSchema) {
         let refResolvedSchema = this.resolveRefs(resolvedSchema, parameterSourceOption,
-          components, schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
+          components, {
+            resolveFor,
+            resolveTo,
+            stack,
+            seenRef: _.cloneDeep(seenRef),
+            stackLimit,
+            analytics
+          });
 
         return refResolvedSchema;
       }
@@ -266,7 +309,14 @@ module.exports = {
           }
           else {
             tempSchema.additionalProperties = this.resolveRefs(schema.additionalProperties, parameterSourceOption,
-              components, schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
+              components, {
+                resolveFor,
+                resolveTo,
+                stack,
+                seenRef: _.cloneDeep(seenRef),
+                stackLimit,
+                analytics
+              });
           }
         }
 
@@ -300,7 +350,14 @@ module.exports = {
             tempSchema.properties[prop] = _.isEmpty(property) ?
               {} :
               this.resolveRefs(property, parameterSourceOption, components,
-                schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
+                {
+                  resolveFor,
+                  resolveTo,
+                  stack,
+                  seenRef: _.cloneDeep(seenRef),
+                  stackLimit,
+                  analytics
+                });
           }
         }
         return tempSchema;
@@ -339,7 +396,14 @@ module.exports = {
       let tempSchema = _.omit(schema, ['items', 'additionalProperties']);
 
       tempSchema.items = this.resolveRefs(schema.items, parameterSourceOption,
-        components, schemaResolutionCache, resolveFor, resolveTo, stack, _.cloneDeep(seenRef), stackLimit);
+        components, {
+          resolveFor,
+          resolveTo,
+          stack,
+          seenRef: _.cloneDeep(seenRef),
+          stackLimit,
+          analytics
+        });
       return tempSchema;
     }
     else if (!schema.hasOwnProperty('default')) {

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -156,20 +156,23 @@ function verifyDeprecatedProperties(resolvedSchema, includeDeprecated) {
 * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
 * @returns {object} fakedObject
 */
-function safeSchemaFaker(oldSchema, resolveTo, resolveFor, parameterSourceOption, components,
+function safeSchemaFaker (oldSchema, resolveTo, resolveFor, parameterSourceOption, components,
   schemaFormat, schemaCache, options) {
   var prop, key, resolvedSchema, fakedSchema,
-    schemaResolutionCache = _.get(schemaCache, 'schemaResolutionCache', {}),
     schemaFakerCache = _.get(schemaCache, 'schemaFakerCache', {});
   let concreteUtils = components && components.hasOwnProperty('concreteUtils') ?
     components.concreteUtils :
     DEFAULT_SCHEMA_UTILS;
   const indentCharacter = options.indentCharacter,
-    stackLimit = options.stackLimit,
     includeDeprecated = options.includeDeprecated;
 
-  resolvedSchema = deref.resolveRefs(oldSchema, parameterSourceOption, components, schemaResolutionCache,
-    resolveFor, resolveTo, 0, {}, stackLimit);
+  resolvedSchema = deref.resolveRefs(oldSchema, parameterSourceOption, components, {
+    resolveFor,
+    resolveTo,
+    stackLimit: options.stackLimit,
+    analytics: _.get(schemaCache, 'analytics', {})
+  });
+
   resolvedSchema = concreteUtils.fixExamplesByVersion(resolvedSchema);
   key = JSON.stringify(resolvedSchema);
 
@@ -251,7 +254,8 @@ module.exports = {
 
   safeSchemaFaker: safeSchemaFaker,
 
-  /** Analyzes the spec to determine the size of the spec,
+  /**
+   * Analyzes the spec to determine the size of the spec,
    * number of request that will be generated out this spec, and
    * number or references present in the spec.
    *
@@ -262,6 +266,7 @@ module.exports = {
   analyzeSpec: function (spec) {
     var size,
       numberOfRefs = 0,
+      numberOfExamples = 0,
       specString,
       numberOfRequests = 0;
 
@@ -287,12 +292,16 @@ module.exports = {
 
       // Number of times the term $ref is repeated in the spec.
       numberOfRefs = (specString.match(/\$ref/g) || []).length;
+
+      // Number of times `example` is present
+      numberOfExamples = (specString.match(/\$example/g) || []).length;
     }
 
     return {
       size,
       numberOfRefs,
-      numberOfRequests
+      numberOfRequests,
+      numberOfExamples
     };
   },
 
@@ -1738,7 +1747,7 @@ module.exports = {
     }
 
     let { style, explode, startValue, propSeparator, keyValueSeparator, isExplodable } =
-      this.getParamSerialisationInfo(param, parameterSource, components, schemaCache);
+      this.getParamSerialisationInfo(param, parameterSource, components);
 
     if (options && options.disableOptionalParameters) {
       disabled = !param.required;
@@ -2992,10 +3001,9 @@ module.exports = {
    *  isExplodable - whether params can be exploded (serialised value can contain key and value)
    * }
    */
-  getParamSerialisationInfo: function (param, parameterSource, components, schemaCache) {
+  getParamSerialisationInfo: function (param, parameterSource, components) {
     var paramName = _.get(param, 'name'),
-      paramSchema = deref.resolveRefs(_.cloneDeep(param.schema), parameterSource, components,
-        _.get(schemaCache, 'schemaResolutionCache')),
+      paramSchema = deref.resolveRefs(_.cloneDeep(param.schema), parameterSource, components, {}),
       style, // style property defined/inferred from schema
       explode, // explode property defined/inferred from schema
       propSeparator, // separates two properties or values
@@ -3081,10 +3089,9 @@ module.exports = {
    * @param {Object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @returns {*} - deserialises parameter value
    */
-  deserialiseParamValue: function (param, paramValue, parameterSource, components, schemaCache) {
+  deserialiseParamValue: function (param, paramValue, parameterSource, components) {
     var constructedValue,
-      paramSchema = deref.resolveRefs(_.cloneDeep(param.schema), parameterSource, components,
-        _.get(schemaCache, 'schemaResolutionCache')),
+      paramSchema = deref.resolveRefs(_.cloneDeep(param.schema), parameterSource, components, {}),
       isEvenNumber = (num) => {
         return (num % 2 === 0);
       },
@@ -3103,7 +3110,7 @@ module.exports = {
     }
 
     let { startValue, propSeparator, keyValueSeparator, isExplodable } =
-      this.getParamSerialisationInfo(param, parameterSource, components, schemaCache);
+      this.getParamSerialisationInfo(param, parameterSource, components);
 
     // as query params are constructed from url, during conversion we use decodeURI which converts ('%20' into ' ')
     (keyValueSeparator === '%20') && (keyValueSeparator = ' ');
@@ -3261,8 +3268,11 @@ module.exports = {
       valueToUse = value,
 
       // This is dereferenced schema (converted to JSON schema for validation)
-      schema = deref.resolveRefs(openApiSchemaObj, parameterSourceOption, components,
-        schemaCache.schemaResolutionCache, PROCESSING_TYPE.VALIDATION, 'example', 0, {}, options.stackLimit),
+      schema = deref.resolveRefs(openApiSchemaObj, parameterSourceOption, components, {
+        resolveFor: PROCESSING_TYPE.VALIDATION,
+        resolveTo: 'example',
+        stackLimit: options.stackLimit
+      }),
       compositeSchema = schema.oneOf || schema.anyOf;
 
     if (needJsonMatching) {
@@ -3837,8 +3847,8 @@ module.exports = {
     // below will make sure for exploded params actual schema of property present in collection is present
     _.forEach(schemaParams, (param) => {
       let pathPrefix = param.pathPrefix,
-        paramSchema = deref.resolveRefs(_.cloneDeep(param.schema), PARAMETER_SOURCE.REQUEST, components, schemaCache),
-        { style, explode } = this.getParamSerialisationInfo(param, PARAMETER_SOURCE.REQUEST, components, schemaCache),
+        paramSchema = deref.resolveRefs(_.cloneDeep(param.schema), PARAMETER_SOURCE.REQUEST, components, {}),
+        { style, explode } = this.getParamSerialisationInfo(param, PARAMETER_SOURCE.REQUEST, components),
         isPropSeparable = _.includes(['form', 'deepObject'], style);
 
       if (isPropSeparable && paramSchema.type === 'array' && explode) {
@@ -4372,8 +4382,10 @@ module.exports = {
         resolvedSchemaParams = [],
         pathPrefix = `${schemaPathPrefix}.requestBody.content[${URLENCODED}].schema`;
 
-      urlencodedBodySchema = deref.resolveRefs(urlencodedBodySchema, PARAMETER_SOURCE.REQUEST, components,
-        schemaCache.schemaResolutionCache, PROCESSING_TYPE.VALIDATION, 'example', 0, {}, options.stackLimit);
+      urlencodedBodySchema = deref.resolveRefs(urlencodedBodySchema, PARAMETER_SOURCE.REQUEST, components, {
+        resolveFor: PROCESSING_TYPE.VALIDATION,
+        stackLimit: options.stackLimit
+      });
 
       // resolve each property as separate param similar to query parmas
       _.forEach(_.get(urlencodedBodySchema, 'properties'), (propSchema, propName) => {
@@ -4397,7 +4409,7 @@ module.exports = {
         }
 
         pSerialisationInfo = this.getParamSerialisationInfo(resolvedProp, PARAMETER_SOURCE.REQUEST,
-          components, schemaCache);
+          components);
         isPropSeparable = _.includes(['form', 'deepObject'], pSerialisationInfo.style);
 
         if (isPropSeparable && propSchema.type === 'array' && pSerialisationInfo.explode) {

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -45,8 +45,11 @@ class SchemaPack {
     this.definedOptions = getOptions();
     this.computedOptions = null;
     this.schemaFakerCache = {};
-    this.schemaResolutionCache = {};
     this.schemaValidationCache = new Map();
+    this.analytics = {
+      actualStack: 0,
+      numberOfRequests: 0
+    };
 
     this.computedOptions = utils.mergeOptions(
       // predefined options
@@ -260,9 +263,9 @@ class SchemaPack {
       specComponentsAndUtils,
       authHelper,
       schemaCache = {
-        schemaResolutionCache: this.schemaResolutionCache,
         schemaFakerCache: this.schemaFakerCache,
-        schemaValidationCache: this.schemaValidationCache
+        schemaValidationCache: this.schemaValidationCache,
+        analytics: this.analytics
       };
 
     if (!this.validated) {
@@ -327,7 +330,11 @@ class SchemaPack {
         // Update options on the basis of analysis.
         options = schemaUtils.determineOptions(analysis, options);
       }
-
+      Object.assign(this.analytics, analysis);
+      Object.assign(this.analytics, {
+        assignedStack: options.stackLimit,
+        complexityScore: options.complexityScore
+      });
 
       // ---- Collection Items ----
       // Adding the collection items from openapi spec based on folderStrategy option
@@ -340,8 +347,7 @@ class SchemaPack {
             generatedStore,
             specComponentsAndUtils,
             options,
-            schemaCache,
-            concreteUtils
+            schemaCache
           );
         }
         else {
@@ -350,8 +356,7 @@ class SchemaPack {
             generatedStore,
             specComponentsAndUtils,
             options,
-            schemaCache,
-            concreteUtils
+            schemaCache
           );
         }
 
@@ -361,8 +366,7 @@ class SchemaPack {
             generatedStore,
             specComponentsAndUtils,
             options,
-            schemaCache,
-            concreteUtils
+            schemaCache
           );
         }
       }
@@ -382,7 +386,8 @@ class SchemaPack {
         output: [{
           type: 'collection',
           data: collectionJSON
-        }]
+        }],
+        analytics: this.analytics
       });
     });
   }
@@ -401,7 +406,6 @@ class SchemaPack {
       analysis,
       options = this.computedOptions,
       schemaCache = {
-        schemaResolutionCache: this.schemaResolutionCache,
         schemaFakerCache: this.schemaFakerCache
       },
       matchedEndpoints = [],

--- a/test/unit/deref.test.js
+++ b/test/unit/deref.test.js
@@ -116,18 +116,19 @@ describe('DEREF FUNCTION TESTS ', function() {
         },
         parameterSource = 'REQUEST',
         // deref.resolveRefs modifies the input schema and components so cloning to keep tests independent of each other
-        output = deref.resolveRefs(schema, parameterSource, _.cloneDeep(componentsAndPaths)),
+        output = deref.resolveRefs(schema, parameterSource, _.cloneDeep(componentsAndPaths), {}),
         output_validation = deref.resolveRefs(schema, parameterSource, _.cloneDeep(componentsAndPaths),
-          {}, 'VALIDATION'),
-        output_withdot = deref.resolveRefs(schemaWithDotInKey, parameterSource, _.cloneDeep(componentsAndPaths)),
+          { 'resolveFor': 'VALIDATION' }),
+        output_withdot = deref.resolveRefs(schemaWithDotInKey, parameterSource, _.cloneDeep(componentsAndPaths), {}),
         output_customFormat = deref.resolveRefs(schemaWithCustomFormat, parameterSource,
-          _.cloneDeep(componentsAndPaths)),
-        output_withAllOf = deref.resolveRefs(schemaWithAllOf, parameterSource, _.cloneDeep(componentsAndPaths)),
+          _.cloneDeep(componentsAndPaths), {}),
+        output_withAllOf = deref.resolveRefs(schemaWithAllOf, parameterSource, _.cloneDeep(componentsAndPaths), {}),
         output_validationTypeArray = deref.resolveRefs(schemaWithTypeArray, parameterSource,
-          _.cloneDeep(componentsAndPaths), {}, 'VALIDATION'),
-        output_emptyObject = deref.resolveRefs(schemaWithEmptyObject, parameterSource, _.cloneDeep(componentsAndPaths)),
+          _.cloneDeep(componentsAndPaths), { 'resolveFor': 'VALIDATION' }),
+        output_emptyObject = deref.resolveRefs(schemaWithEmptyObject, parameterSource, _.cloneDeep(componentsAndPaths),
+          {}),
         output_additionalProps = deref.resolveRefs(schemaWithAdditionPropRef, parameterSource,
-          _.cloneDeep(componentsAndPaths), {}, 'VALIDATION'),
+          _.cloneDeep(componentsAndPaths), { 'resolveFor': 'VALIDATION' }),
         output_additionalPropsOverride;
 
       expect(output).to.deep.include({ type: 'object',
@@ -183,7 +184,7 @@ describe('DEREF FUNCTION TESTS ', function() {
       output_additionalProps.additionalProperties.properties.hello.default = '<string>';
 
       output_additionalPropsOverride = deref.resolveRefs(schemaWithAdditionPropRef, parameterSource,
-        _.cloneDeep(componentsAndPaths), {}, 'VALIDATION');
+        _.cloneDeep(componentsAndPaths), { resolveFor: 'VALIDATION' });
 
       // override should not affect newly resolved schema
       expect(output_additionalPropsOverride).to.deep.include(
@@ -216,7 +217,7 @@ describe('DEREF FUNCTION TESTS ', function() {
             components:
               { schemas: { schemaWithFormat: { type: 'string', format: supportedFormat } } },
             concreteUtils: schemaUtils30X
-          });
+          }, {});
 
         expect(output.type).to.equal('string');
         expect(output.format).to.equal(supportedFormat);
@@ -228,7 +229,7 @@ describe('DEREF FUNCTION TESTS ', function() {
           {
             components: { schemas: { schemaWithFormat: nonSupportedFormat } },
             concreteUtils: schemaUtils30X
-          });
+          }, {});
 
         expect(output.type).to.equal(nonSupportedFormat.type);
         expect(output.format).to.be.undefined;
@@ -246,7 +247,7 @@ describe('DEREF FUNCTION TESTS ', function() {
         parameterSource = 'REQUEST',
         output;
 
-      output = deref.resolveRefs(schema, parameterSource, { concreteUtils: schemaUtils30X });
+      output = deref.resolveRefs(schema, parameterSource, { concreteUtils: schemaUtils30X }, {});
       expect(output.type).to.equal('string');
       expect(output.format).to.be.undefined;
       expect(output.pattern).to.eql(schema.pattern);
@@ -276,7 +277,7 @@ describe('DEREF FUNCTION TESTS ', function() {
         parameterSource = 'REQUEST',
         output;
 
-      output = deref.resolveRefs(schema, parameterSource, { concreteUtils: schemaUtils30X });
+      output = deref.resolveRefs(schema, parameterSource, { concreteUtils: schemaUtils30X }, {});
       expect(output.type).to.equal('object');
       expect(output.properties).to.not.haveOwnProperty('id');
       expect(output.required).to.not.include('id');
@@ -306,7 +307,7 @@ describe('DEREF FUNCTION TESTS ', function() {
         parameterSource = 'RESPONSE',
         output;
 
-      output = deref.resolveRefs(schema, parameterSource, { concreteUtils: schemaUtils30X });
+      output = deref.resolveRefs(schema, parameterSource, { concreteUtils: schemaUtils30X }, {});
       expect(output.type).to.equal('object');
       expect(output.properties).to.not.haveOwnProperty('tag');
       expect(output.required).to.not.include('tag');
@@ -346,9 +347,7 @@ describe('DEREF FUNCTION TESTS ', function() {
         allOfschema,
         'REQUEST',
         { concreteUtils: schemaUtils30X },
-        {},
-        null,
-        'example'
+        { resolveTo: 'example' }
       )).to.deep.include({
         type: 'object',
         properties: {

--- a/test/unit/sanity.test.js
+++ b/test/unit/sanity.test.js
@@ -19,7 +19,7 @@ describe('Runing validation tests for all files in `valid_openapi`', function ()
       // Increase timeout for larger schema
       this.timeout(30000);
 
-      Converter.convert({ data: fileData, type: 'string' }, {}, (err, conversionResult) => {
+      Converter.convert({ data: fileData, type: 'string' }, { optimizeConversion: false }, (err, conversionResult) => {
         expect(err).to.be.null;
         expect(conversionResult.result).to.equal(true);
         var validator,

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -201,13 +201,10 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         resolvedSchema = deref.resolveRefs(schema,
           parameterSource,
           { components, concreteUtils },
-          {},
-          resolveFor,
-          resolveTo
+          { resolveFor, resolveTo }
         ),
         schemaCache = {
-          schemaFakerCache: {},
-          schemaResolutionCache: {}
+          schemaFakerCache: {}
         },
         key = hash('resolveToSchema ' + JSON.stringify(resolvedSchema)),
         options = {
@@ -247,15 +244,12 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         resolveTo = 'example',
         resolveFor = 'CONVERSION',
         schemaCache = {
-          schemaFakerCache: {},
-          schemaResolutionCache: {}
+          schemaFakerCache: {}
         },
         resolvedSchema = deref.resolveRefs(schema,
           parameterSource,
           { components, concreteUtils },
-          schemaCache.schemaResolutionCache,
-          resolveFor,
-          resolveTo
+          { resolveFor, resolveTo }
         ),
         key = hash('resolveToExample ' + JSON.stringify(resolvedSchema)),
         options = {
@@ -2805,7 +2799,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         explode: true
       };
 
-      SchemaUtils.getParamSerialisationInfo(param, 'REQUEST', {}, {});
+      SchemaUtils.getParamSerialisationInfo(param, 'REQUEST', {});
       expect(param.schema).to.have.property('type', 'array');
       expect(param.schema.items).to.have.property('type', 'string');
       expect(param.schema).to.not.have.property('default');


### PR DESCRIPTION
This PR:

1. Refactors the resolveRefs (and resolveAllOf) function to accept an options object. This was done because of the following reasons:
* To keep the number of args for the function limited. As the complexity of the module is increasing we are adding more and more arguments to the function which is not ideally a best practices
* To make it easy for more options to be added without increasing the number of arguments of that function
* The options object can simply be an empty object and still the conversion will work just fine with the defaults.
2. Adds another property in the return of the convert function which will be used for analytics logging. Currently we are logging all the required details that we calculate while analyzeSpec is run and also the actual and assigned values of the stack limit. To give us an idea of what kind of schemas are we receiving.
3. Removes unnecessary usage of schemaResolutionCache which was removed in a previous PR but wasn't cleaned up from the function call etc.