### PR TITLE
Release v4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OpenAPI-Postman Changelog
 
+#### v4.7.0 (January 16, 2023)
+* Fixed an issue where same schema was being validated against examples multiple times during a conversion - using local cache here.
+* Added a way to return analytics along with the result for better observability into the kind of schemas we get for conversion.
+* Refactored the resolveRefs and resolveAll to take in an options object as an argument.
+
 #### v4.6.0 (December 30, 2022)
 * Fixed issue where bundling of multi-file definition was not working correctly for more than 10 params correctly.
 * Fixed issue where request name was not using operation description if available.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-to-postmanv2",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-to-postmanv2",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "description": "Convert a given OpenAPI specification to Postman Collection v2.0",
   "homepage": "https://github.com/postmanlabs/openapi-to-postman",
   "bugs": "https://github.com/postmanlabs/openapi-to-postman/issues",


### PR DESCRIPTION
* Fixed an issue where same schema was being validated against examples multiple times during a conversion - using local cache here.
* Added a way to return analytics along with the result for better observability into the kind of schemas we get for conversion.
* Refactored the resolveRefs and resolveAll to take in an options object as an argument.