### PR TITLE
Fixes options copy and swapped disable optional params with enable

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -1,7 +1,7 @@
 id|type|available options|default|description|usage
 |---|---|---|---|---|---|
 requestNameSource|enum|URL, Fallback|Fallback|Determines how the requests inside the generated collection will be named. If “Fallback” is selected, the request will be named after one of the following schema values: `summary`, `operationId`, `description`, `url`.|CONVERSION, VALIDATION
-indentCharacter|enum|Space, Tab|Space|Option for setting indentation character|CONVERSION
+indentCharacter|enum|Space, Tab|Space|Option for setting indentation character.|CONVERSION
 collapseFolders|boolean|-|true|Importing will collapse all folders that have only one child element and lack persistent folder-level data.|CONVERSION
 optimizeConversion|boolean|-|true|Optimizes conversion for large specification, disabling this option might affect the performance of conversion.|CONVERSION
 requestParametersResolution|enum|Example, Schema|Schema|Select whether to generate the request parameters based on the [schema](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schemaObject) or the [example](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#exampleObject) in the schema.|CONVERSION
@@ -9,7 +9,7 @@ exampleParametersResolution|enum|Example, Schema|Example|Select whether to gener
 folderStrategy|enum|Paths, Tags|Paths|Select whether to create folders according to the spec’s paths or tags.|CONVERSION
 schemaFaker|boolean|-|true|Whether or not schemas should be faked.|CONVERSION
 stackLimit|integer|-|10|Number of nesting limit till which schema resolution will happen. Increasing this limit may result in more time to convert collection depending on complexity of specification. (To make sure this option works correctly "optimizeConversion" option needs to be disabled)|CONVERSION
-includeAuthInfoInExample|boolean|-|true|Select whether to include authentication parameters in the example request|CONVERSION
+includeAuthInfoInExample|boolean|-|true|Select whether to include authentication parameters in the example request.|CONVERSION
 shortValidationErrors|boolean|-|false|Whether detailed error messages are required for request <> schema validation operations.|VALIDATION
 validationPropertiesToIgnore|array|-|[]|Specific properties (parts of a request/response pair) to ignore during validation. Must be sent as an array of strings. Valid inputs in the array: PATHVARIABLE, QUERYPARAM, HEADER, BODY, RESPONSE_HEADER, RESPONSE_BODY|VALIDATION
 showMissingInSchemaErrors|boolean|-|false|MISSING_IN_SCHEMA indicates that an extra parameter was included in the request. For most use cases, this need not be considered an error.|VALIDATION
@@ -19,7 +19,7 @@ validateMetadata|boolean|-|false|Whether to show mismatches for incorrect name a
 ignoreUnresolvedVariables|boolean|-|false|Whether to ignore mismatches resulting from unresolved variables in the Postman request|VALIDATION
 strictRequestMatching|boolean|-|false|Whether requests should be strictly matched with schema operations. Setting to true will not include any matches where the URL path segments don't match exactly.|VALIDATION
 allowUrlPathVarMatching|boolean|-|false|Whether to allow matching path variables that are available as part of URL itself in the collection request|VALIDATION
-disableOptionalParameters|boolean|-|false|Whether to set optional parameters as disabled|CONVERSION
+enableOptionalParameters|boolean|-|true|Optional parameters aren't selected in the collection. Once enabled they will be selected in the collection and request as well.|CONVERSION
 keepImplicitHeaders|boolean|-|false|Whether to keep implicit headers from the OpenAPI specification, which are removed by default.|CONVERSION
 includeWebhooks|boolean|-|false|Select whether to include Webhooks in the generated collection|CONVERSION
 includeReferenceMap|boolean|-|false|Whether or not to include reference map or not as part of output|BUNDLE

--- a/lib/options.js
+++ b/lib/options.js
@@ -75,7 +75,7 @@ module.exports = {
         type: 'enum',
         default: 'Space',
         availableOptions: ['Space', 'Tab'],
-        description: 'Option for setting indentation character',
+        description: 'Option for setting indentation character.',
         external: true,
         usage: ['CONVERSION'],
         supportedIn: [VERSION20, VERSION30, VERSION31]
@@ -168,7 +168,7 @@ module.exports = {
         id: 'includeAuthInfoInExample',
         type: 'boolean',
         default: true,
-        description: 'Select whether to include authentication parameters in the example request',
+        description: 'Select whether to include authentication parameters in the example request.',
         external: true,
         usage: ['CONVERSION'],
         supportedIn: [VERSION20, VERSION30, VERSION31]
@@ -270,11 +270,12 @@ module.exports = {
         usage: ['VALIDATION']
       },
       {
-        name: 'Disable optional parameters',
-        id: 'disableOptionalParameters',
+        name: 'Enable optional parameters',
+        id: 'enableOptionalParameters',
         type: 'boolean',
-        default: false,
-        description: 'Whether to set optional parameters as disabled',
+        default: true,
+        description: 'Optional parameters aren\'t selected in the collection. ' +
+          'Once enabled they will be selected in the collection and request as well.',
         external: true,
         usage: ['CONVERSION'],
         supportedIn: [VERSION20, VERSION30, VERSION31]

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1749,7 +1749,7 @@ module.exports = {
     let { style, explode, startValue, propSeparator, keyValueSeparator, isExplodable } =
       this.getParamSerialisationInfo(param, parameterSource, components);
 
-    if (options && options.disableOptionalParameters) {
+    if (options && !options.enableOptionalParameters) {
       disabled = !param.required;
     }
 

--- a/test/system/structure.test.js
+++ b/test/system/structure.test.js
@@ -22,7 +22,7 @@ const optionIds = [
     'ignoreUnresolvedVariables',
     'optimizeConversion',
     'strictRequestMatching',
-    'disableOptionalParameters',
+    'enableOptionalParameters',
     'keepImplicitHeaders',
     'includeWebhooks',
     'allowUrlPathVarMatching',
@@ -77,7 +77,7 @@ const optionIds = [
       type: 'enum',
       default: 'Space',
       availableOptions: ['Space', 'Tab'],
-      description: 'Option for setting indentation character'
+      description: 'Option for setting indentation character.'
     },
     requestNameSource: {
       name: 'Naming requests',
@@ -106,7 +106,7 @@ const optionIds = [
       name: 'Include auth info in example requests',
       type: 'boolean',
       default: true,
-      description: 'Select whether to include authentication parameters in the example request'
+      description: 'Select whether to include authentication parameters in the example request.'
     },
     shortValidationErrors: {
       name: 'Short error messages during request <> schema validation',
@@ -162,11 +162,12 @@ const optionIds = [
       description: 'Whether requests should be strictly matched with schema operations. Setting to true will not ' +
         'include any matches where the URL path segments don\'t match exactly.'
     },
-    disableOptionalParameters: {
-      name: 'Disable optional parameters',
+    enableOptionalParameters: {
+      name: 'Enable optional parameters',
       type: 'boolean',
-      default: false,
-      description: 'Whether to set optional parameters as disabled'
+      default: true,
+      description: 'Optional parameters aren\'t selected in the collection. ' +
+        'Once enabled they will be selected in the collection and request as well.'
     },
     keepImplicitHeaders: {
       name: 'Keep implicit headers',

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -1080,7 +1080,7 @@ describe('CONVERT FUNCTION TESTS ', function() {
     });
 
     it('[Github #31] & [GitHub #337] - should set optional params as disabled', function(done) {
-      let options = { schemaFaker: true, disableOptionalParameters: true };
+      let options = { schemaFaker: true, enableOptionalParameters: false };
       Converter.convert({ type: 'file', data: requiredInParams }, options, (err, conversionResult) => {
         expect(err).to.be.null;
         let requests = conversionResult.output[0].data.item[0].item,


### PR DESCRIPTION
This pull request is regarding the copy changes suggested by the UI/UX team.
It involves -
- Minor copy improvement
- Swapping of 'Disable optional parameters' which was set as `false` to 'Enable optional parameters' set to `true` by default to avoid confusion to the users.


More details here : https://postmanlabs.atlassian.net/l/cp/H2ckGesG