### PR TITLE
Fixed issue where definition with non-string URLs caused TypeError.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -371,7 +371,7 @@ module.exports = {
       }
       return '{' + p1 + '}';
     };
-    return url.replace(/(\{[^\/\{\}]+\})/g, replacer);
+    return _.isString(url) ? url.replace(/(\{[^\/\{\}]+\})/g, replacer) : '';
   },
 
   /**

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -2577,6 +2577,13 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
   });
 
   describe('fixPathVariablesInUrl function', function() {
+    it('should be able to handle incorrect urls', function(done) {
+      expect(SchemaUtils.fixPathVariablesInUrl({})).to.equal('');
+      expect(SchemaUtils.fixPathVariablesInUrl(null)).to.equal('');
+      expect(SchemaUtils.fixPathVariablesInUrl(undefined)).to.equal('');
+      done();
+    });
+
     it('should convert a url with scheme and path variables', function(done) {
       var convertedUrl = SchemaUtils.fixPathVariablesInUrl('{scheme}://developer.uspto.gov/{path0}/segment/{path1}');
       expect(convertedUrl).to.equal('{{scheme}}://developer.uspto.gov/{{path0}}/segment/{{path1}}');


### PR DESCRIPTION
### Problem / RCA

Currently one of function named  `fixPathVariablesInUrl()` is expecting operation URL to always be a string. Meanwhile, for certain definition where operation URLs are defined as non-string values, This results in type error.

### Fix

We'll be always checking if URL is string before doing manipulation on it. Also returning the empty string as URL if it's not a string.