### PR TITLE
Fixed issue where a test in-consistently kept failing due to uncertainity of jsf library.

### DIFF
--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -1816,7 +1816,9 @@ describe('CONVERT FUNCTION TESTS ', function() {
           const responseBodyWithAdditionalProperties =
             JSON.parse(conversionResult.output[0].data.item[0].response[1].body);
           expect(responseBodyWithAdditionalProperties).to.include.keys('test1');
-          expect(Object.keys(responseBodyWithAdditionalProperties).length).to.be.greaterThan(1);
+
+          // json-schema-faker doesn't guarantee that there will always be additional properties generated
+          expect(Object.keys(responseBodyWithAdditionalProperties).length).to.be.greaterThanOrEqual(1);
           done();
         });
     });


### PR DESCRIPTION
For the corresponding test case, `json-schema-faker` doesn't guarantee that there will always be additional properties generated. This meant that there's a randomness to this behaviour as there can be case when no additional properties are generated. This PR makes change so that we are not always expecting such properties to be present.