### PR TITLE
Fixed certain TypeErrors causing process to fail unexpectedly.

### DIFF
--- a/lib/31XUtils/schemaUtils31X.js
+++ b/lib/31XUtils/schemaUtils31X.js
@@ -125,7 +125,7 @@ module.exports = {
       schema.items = this.fixExamplesByVersion(schema.items);
     }
     else if (hasProperties) {
-      const schemaProperties = Object.keys(schema.properties);
+      const schemaProperties = _.keys(schema.properties);
       schemaProperties.forEach((property) => {
         schema.properties[property] = this.fixExamplesByVersion(schema.properties[property]);
       });
@@ -141,7 +141,7 @@ module.exports = {
    * @returns {boolean} Returns true if content is a binary type
    */
   isBinaryContentType (bodyType, contentObj) {
-    return Object.keys(contentObj[bodyType]).length === 0 && fileUploadTypes.includes(bodyType);
+    return _.keys(contentObj[bodyType]).length === 0 && fileUploadTypes.includes(bodyType);
   },
 
   getOuterPropsIfIsSupported(schema) {
@@ -152,7 +152,7 @@ module.exports = {
 
   addOuterPropsToRefSchemaIfIsSupported(refSchema, outerProps) {
     const resolvedSchema = _.cloneDeep(refSchema),
-      outerKeys = Object.keys(outerProps);
+      outerKeys = _.keys(outerProps);
 
     if (_.isObject(resolvedSchema) && _.isObject(outerProps)) {
       outerKeys.forEach((key) => {

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2797,7 +2797,7 @@ module.exports = {
   // also, any endpoint-level params are merged into the returned pathItemObject
   findMatchingRequestFromSchema: function (method, url, schema, options) {
     // first step - get array of requests from schema
-    let parsedUrl = require('url').parse(url),
+    let parsedUrl = require('url').parse(_.isString(url) ? url : ''),
       retVal = [],
       pathToMatch,
       matchedPath,

--- a/test/unit/31Xsupport/schemaUtils31X.test.js
+++ b/test/unit/31Xsupport/schemaUtils31X.test.js
@@ -624,6 +624,26 @@ describe('fixExamplesByVersion method', function() {
     expect(JSON.stringify(fixedSchemaWithExample)).to.be.equal(JSON.stringify(expectedSchemaAfterFix));
   });
 
+  it('Should correctly handle schema with properties defined as null', function() {
+    const providedSchema = {
+        required: [
+          'id',
+          'name'
+        ],
+        type: 'object',
+        properties: null
+      },
+      expectedSchemaAfterFix = {
+        required: [
+          'id',
+          'name'
+        ],
+        type: 'object',
+        properties: null
+      },
+      fixedSchemaWithExample = concreteUtils.fixExamplesByVersion(providedSchema);
+    expect(JSON.stringify(fixedSchemaWithExample)).to.be.equal(JSON.stringify(expectedSchemaAfterFix));
+  });
 });
 
 describe('isBinaryContentType method', function() {
@@ -650,6 +670,15 @@ describe('isBinaryContentType method', function() {
       },
       isBinary = concreteUtils.isBinaryContentType(bodyType, contentObject);
     expect(isBinary).to.be.false;
+  });
+
+  it('Should correctly handle null value for corresponding body', function() {
+    const bodyType = 'application/octet-stream',
+      contentObject = {
+        'application/octet-stream': null
+      },
+      isBinary = concreteUtils.isBinaryContentType(bodyType, contentObject);
+    expect(isBinary).to.be.true;
   });
 });
 
@@ -702,6 +731,22 @@ describe('getOuterPropsIfIsSupported method', function() {
     expect(resolvedSchema).to.be.an('object')
       .nested.to.have.all.keys('name', 'age', 'job', 'required');
     expect(resolvedSchema.job).to.be.equal(outerProperties.job);
+    expect(JSON.stringify(resolvedSchema.required)).to.be.equal(JSON.stringify(expectedRequiredValue));
+  });
+
+  it('Should correctly handle if outer properties are defined as null', function() {
+    const referencedSchema = {
+        name: 'Test name',
+        age: '30',
+        required: [
+          'name'
+        ]
+      },
+      outerProperties = null,
+      expectedRequiredValue = ['name'],
+      resolvedSchema = concreteUtils.addOuterPropsToRefSchemaIfIsSupported(referencedSchema, outerProperties);
+    expect(resolvedSchema).to.be.an('object')
+      .nested.to.have.all.keys('name', 'age', 'required');
     expect(JSON.stringify(resolvedSchema.required)).to.be.equal(JSON.stringify(expectedRequiredValue));
   });
 });

--- a/test/unit/validator.test.js
+++ b/test/unit/validator.test.js
@@ -1404,6 +1404,23 @@ describe('VALIDATE FUNCTION TESTS ', function () {
       expect(result[1].name).to.eql('GET /lookups');
       done();
     });
+
+    it('should correctly handle non string URLs', function (done) {
+      let schema = {
+          paths: {
+            '/lookups': {
+              'get': { 'summary': 'Lookup Job Values' }
+            }
+          }
+        },
+        schemaPath = null,
+        result;
+
+      result = schemaUtils.findMatchingRequestFromSchema('GET', schemaPath, schema, { strictRequestMatching: true });
+
+      expect(result).to.have.lengthOf(0);
+      done();
+    });
   });
 });
 


### PR DESCRIPTION
### Issue 1:

```
TypeError: The "url" argument must be of type string. Received undefined
  File "internal/validators.js", line 124, col 11, in validateString
  File "url.js", line 160, col 3, in Url.parse
  File "url.js", line 155, col 13, in Object.urlParse [as parse]
  File "/var/www-api/node_modules/openapi-to-postmanv2/lib/schemaUtils.js", line 2707, col 36, in Object.findMatchingRequestFromSchema
    let parsedUrl = require('url').parse(url),
  File "/var/www-api/node_modules/openapi-to-postmanv2/lib/schemapack.js", line 480, col 36, in null.<anonymous>
    matchedPaths = schemaUtils.findMatchingRequestFromSchema(
```

### Issue 2:
```
TypeError: Cannot convert undefined or null to object
  ?, in Function.keys
  File "/var/www-api/node_modules/openapi-to-postmanv2/lib/31XUtils/schemaUtils31X.js", line 144, col 19, in Object.isBinaryContentType
    return Object.keys(contentObj[bodyType]).length === 0 && fileUploadTypes.includes(bodyType);
  File "/var/www-api/node_modules/openapi-to-postmanv2/lib/schemaUtils.js", line 1932, col 23, in Object.convertToPmBody
    concreteUtils.isBinaryContentType(bodyType, contentObj)
```

### Root Cause
Issue is happening due to corresponding code not handling other data types correctly. For Issue 1, `url` is supposed to be string and for other values used `url.parse()` API providing TypeError. As for Issue 2, `Object.keys()` API expecting object only.

### Solution
For both issues we'll be making sure to handle other data types correctly and underlying APIs not providing TypeErrors anymore.