### PR TITLE
Fix for Issue#660

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -196,6 +196,13 @@ function safeSchemaFaker (oldSchema, resolveTo, resolveFor, parameterSourceOptio
     });
   }
 
+  if (schemaFormat === 'xml') {
+    key += ' schemaFormatXML';
+  }
+  else {
+    key += ' schemaFormatDEFAULT';
+  }
+
   key = hash(key);
   if (schemaFakerCache[key]) {
     return schemaFakerCache[key];
@@ -2090,7 +2097,7 @@ module.exports = {
             const regExp = new RegExp('([<\\?xml]+[\\s{1,}]+[version="\\d.\\d"]+[\\sencoding="]+.{1,15}"\\?>)');
             let xmlBody = bodyContent;
 
-            if (!String(bodyContent).match(regExp)) {
+            if (!bodyContent.match(regExp)) {
               const versionContent = '<?xml version="1.0" encoding="UTF-8"?>\n';
               xmlBody = versionContent + xmlBody;
             }

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2090,7 +2090,7 @@ module.exports = {
             const regExp = new RegExp('([<\\?xml]+[\\s{1,}]+[version="\\d.\\d"]+[\\sencoding="]+.{1,15}"\\?>)');
             let xmlBody = bodyContent;
 
-            if (!bodyContent.match(regExp)) {
+            if (!String(bodyContent).match(regExp)) {
               const versionContent = '<?xml version="1.0" encoding="UTF-8"?>\n';
               xmlBody = versionContent + xmlBody;
             }

--- a/lib/xmlSchemaFaker.js
+++ b/lib/xmlSchemaFaker.js
@@ -47,7 +47,7 @@ function convertSchemaToXML(name, schema, attribute, indentChar, indent) {
         attributes.push(`${key}="${propVal}"`);
       }
       else {
-        childNodes += propVal === undefined ? '' : propVal;
+        childNodes += _.isString(propVal) ? propVal : '';
       }
     });
     if (attributes.length > 0) {

--- a/lib/xmlSchemaFaker.js
+++ b/lib/xmlSchemaFaker.js
@@ -47,7 +47,7 @@ function convertSchemaToXML(name, schema, attribute, indentChar, indent) {
         attributes.push(`${key}="${propVal}"`);
       }
       else {
-        childNodes += propVal;
+        childNodes += propVal === undefined ? '' : propVal;
       }
     });
     if (attributes.length > 0) {
@@ -66,7 +66,7 @@ function convertSchemaToXML(name, schema, attribute, indentChar, indent) {
       contents;
 
     schemaItemsWithXmlProps.xml = schema.xml;
-    contents = convertSchemaToXML(arrayElemName, schemaItemsWithXmlProps, false, indentChar, indent + extraIndent) + 
+    contents = convertSchemaToXML(arrayElemName, schemaItemsWithXmlProps, false, indentChar, indent + extraIndent) +
       convertSchemaToXML(arrayElemName, schemaItemsWithXmlProps, false, indentChar, indent + extraIndent);
     if (isWrapped) {
       return `\n${cIndent}<${tagPrefix}${name}>${contents}\n${cIndent}</${tagPrefix}${name}>`;

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -206,7 +206,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         schemaCache = {
           schemaFakerCache: {}
         },
-        key = hash('resolveToSchema ' + JSON.stringify(resolvedSchema)),
+        key = hash('resolveToSchema ' + JSON.stringify(resolvedSchema) + ' schemaFormatDEFAULT'),
         options = {
           indentCharacter: '  ',
           stackLimit: 10,
@@ -251,7 +251,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           { components, concreteUtils },
           { resolveFor, resolveTo }
         ),
-        key = hash('resolveToExample ' + JSON.stringify(resolvedSchema)),
+        key = hash('resolveToExample ' + JSON.stringify(resolvedSchema) + ' schemaFormatDEFAULT'),
         options = {
           indentCharacter: '  ',
           stackLimit: 10,
@@ -268,6 +268,60 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
       done();
 
     });
+
+    it('should populate schemaFakerCache with distinct value when only the schemaFormat is different', function (done) {
+      var schema = {
+          $ref: '#/components/schema/request'
+        },
+        components = {
+          schema: {
+            request: {
+              properties: {
+                name: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        },
+        parameterSource = 'REQUEST',
+        resolveTo = 'schema',
+        resolveFor = 'CONVERSION',
+        resolvedSchema = deref.resolveRefs(schema,
+          parameterSource,
+          { components, concreteUtils },
+          { resolveFor, resolveTo }
+        ),
+        schemaCache = {
+          schemaFakerCache: {}
+        },
+        xml_key = hash('resolveToSchema ' + JSON.stringify(resolvedSchema) + ' schemaFormatXML'),
+        default_key = hash('resolveToSchema ' + JSON.stringify(resolvedSchema) + ' schemaFormatDEFAULT'),
+        options = {
+          indentCharacter: '  ',
+          stackLimit: 10,
+          includeDeprecated: true
+        },
+        fakedSchema_default = SchemaUtils.safeSchemaFaker(schema, resolveTo, resolveFor, parameterSource,
+          { components, concreteUtils }, 'default', schemaCache, options),
+        fakedSchema_xml = SchemaUtils.safeSchemaFaker(schema, resolveTo, resolveFor, parameterSource,
+          { components, concreteUtils }, 'xml', schemaCache, options);
+
+      expect(schemaCache.schemaFakerCache).to.have.property(default_key);
+      expect(schemaCache.schemaFakerCache[default_key]).to.equal(fakedSchema_default);
+      expect(fakedSchema_default).to.eql({
+        name: '<string>'
+      });
+
+      expect(schemaCache.schemaFakerCache).to.have.property(xml_key);
+      expect(schemaCache.schemaFakerCache[xml_key]).to.equal(fakedSchema_xml);
+      expect(fakedSchema_xml).to.eql(
+        '<element>\n  <name>(string)</name>\n</element>'
+      );
+
+      done();
+    });
+
   });
 
   describe('convertToPmCollectionVariables function', function() {


### PR DESCRIPTION
- Fixed [Issue#660](https://github.com/postmanlabs/openapi-to-postman/issues/660) by adding the `schemaFormat` parameter while generating `key` for `schemaFakerCache` (Refer to [this](https://postmanlabs.atlassian.net/wiki/spaces/IMP/pages/4362797233/Issue+660+TypeError+bodyContent.match+is+not+a+function#Resolution%3A))

- Fixed an issue where `undefined` was in the XML output. <img width="707" alt="Screenshot 2023-02-02 at 3 19 20 PM" src="https://user-images.githubusercontent.com/121886615/216449254-b24b83d8-9dfe-436a-8754-d9d48e8979b4.png">
