### PR TITLE
Fix Issue#627: Add defined example parameter when schema $ref is resolved

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -295,6 +295,9 @@ module.exports = {
         resolvedSchema = concreteUtils.addOuterPropsToRefSchemaIfIsSupported(resolvedSchema, outerProperties);
       }
       if (resolvedSchema) {
+        if (schema.example) {
+          resolvedSchema.example = schema.example;
+        }
         let refResolvedSchema = this.resolveRefs(resolvedSchema, parameterSourceOption,
           components, {
             resolveFor,

--- a/test/unit/deref.test.js
+++ b/test/unit/deref.test.js
@@ -316,7 +316,8 @@ describe('DEREF FUNCTION TESTS ', function() {
 
     it('should return schema with example parameter(if given) for $ref just like inline schema', function(done) {
       var schema = {
-          $ref: '#/components/schemas/schema1'
+          $ref: '#/components/schemas/schema1',
+          example: 'asc'
         },
         componentsAndPaths = {
           components: {

--- a/test/unit/deref.test.js
+++ b/test/unit/deref.test.js
@@ -313,6 +313,32 @@ describe('DEREF FUNCTION TESTS ', function() {
       expect(output.required).to.not.include('tag');
       done();
     });
+
+    it('should return schema with example parameter(if given) for $ref just like inline schema', function(done) {
+      var schema = {
+          $ref: '#/components/schemas/schema1'
+        },
+        componentsAndPaths = {
+          components: {
+            schemas: {
+              schema1: {
+                description: 'The unique identifier of a spacecraft',
+                enum: [
+                  'asc',
+                  'desc'
+                ],
+                type: 'string'
+              }
+            }
+          }
+        },
+        parameterSource = 'REQUEST',
+        // deref.resolveRefs modifies the input schema and components so cloning to keep tests independent of each other
+        output = deref.resolveRefs(schema, parameterSource, _.cloneDeep(componentsAndPaths), {});
+
+      expect(output.example).to.equal(schema.example);
+      done();
+    });
   });
 
   describe('resolveAllOf Function', function () {


### PR DESCRIPTION
* Fixes [Issue#627:](https://github.com/postmanlabs/openapi-to-postman/issues/627) when the schema $ref was being resolved it did not contain the example parameter.