### PR TITLE
Fixed issue where outer schema along with allOf schema were not resolved correctly.

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -91,7 +91,7 @@ module.exports = {
   /**
    * Creates a schema that's a union of all input schemas (only type: object is supported)
    *
-   * @param {array} schemaArr REQUIRED - array of schemas, all of which must be valid in the returned object
+   * @param {*} schema REQUIRED - OpenAPI defined schema object to be resolved
    * @param {string} parameterSourceOption REQUIRED tells that the schema object is of request or response
    * @param {*} components REQUIRED components in openapi spec.
    * @param {object} options - REQUIRED a list of options to indicate the type of resolution needed.
@@ -103,7 +103,7 @@ module.exports = {
    * @param {*} options.stackLimit Depth to which the schema should be resolved.
    * @returns {*} schema - schema that adheres to all individual schemas in schemaArr
    */
-  resolveAllOf: function (schemaArr, parameterSourceOption, components, {
+  resolveAllOf: function (schema, parameterSourceOption, components, {
     resolveFor = RESOLVE_REF_DEFAULTS.resolveFor,
     resolveTo = RESOLVE_REF_DEFAULTS.resolveTo,
     stack = RESOLVE_REF_DEFAULTS.stack,
@@ -112,23 +112,25 @@ module.exports = {
     analytics = {}
   }) {
 
-    if (!(schemaArr instanceof Array)) {
+    if (_.isEmpty(schema)) {
       return null;
     }
 
-    if (schemaArr.length === 1) {
-      // for just one entry in allOf, don't need to enforce type: object restriction
-      return this.resolveRefs(schemaArr[0], parameterSourceOption, components,
-        { stack, seenRef: _.cloneDeep(seenRef), resolveFor, resolveTo, stackLimit, analytics });
+    let resolvedNonAllOfSchema = {};
+
+    // Resolve schema excluding allOf keyword which will be further used to resolve entire schema along with allOf
+    if (_.keys(schema).length > 1) {
+      resolvedNonAllOfSchema = this.resolveRefs(_.omit(schema, 'allOf'), parameterSourceOption, components,
+        { stack, seenRef: _.cloneDeep(seenRef), resolveFor, resolveTo, stackLimit, isAllOf: true, analytics });
     }
 
     try {
-      return mergeAllOf({
-        allOf: schemaArr.map((schema) => {
+      return mergeAllOf(_.assign(resolvedNonAllOfSchema, {
+        allOf: _.map(schema.allOf, (schema) => {
           return this.resolveRefs(schema, parameterSourceOption, components,
             { stack, seenRef: _.cloneDeep(seenRef), resolveFor, resolveTo, stackLimit, isAllOf: true, analytics });
         })
-      }, {
+      }), {
         resolvers: {
           // for keywords in OpenAPI schema that are not standard defined JSON schema keywords, use default resolver
           defaultResolver: (compacted) => { return compacted[0]; }
@@ -246,7 +248,7 @@ module.exports = {
       }) };
     }
     if (schema.allOf) {
-      return this.resolveAllOf(schema.allOf, parameterSourceOption, components,
+      return this.resolveAllOf(schema, parameterSourceOption, components,
         {
           resolveFor,
           resolveTo,

--- a/test/unit/deref.test.js
+++ b/test/unit/deref.test.js
@@ -316,41 +316,127 @@ describe('DEREF FUNCTION TESTS ', function() {
   });
 
   describe('resolveAllOf Function', function () {
-    it('should resolve allOf schemas correctly', function (done) {
-      var allOfschema = [
-        {
-          'type': 'object',
-          'properties': {
-            'source': {
-              'type': 'string',
-              'format': 'uuid'
+    it('should resolve schemas containing allOf keyword correctly', function (done) {
+      var schema = {
+        'allOf': [
+          {
+            'type': 'object',
+            'properties': {
+              'source': {
+                'type': 'string',
+                'format': 'uuid'
+              },
+              'actionId': { 'type': 'integer', 'minimum': 5 },
+              'result': { 'type': 'object' }
             },
-            'actionId': { 'type': 'integer', 'minimum': 5 },
-            'result': { 'type': 'object' }
+            'required': ['source', 'actionId', 'result']
           },
-          'required': ['source', 'actionId', 'result']
-        },
-        {
-          'properties': {
-            'result': {
-              'type': 'object',
-              'properties': {
-                'err': { 'type': 'string' },
-                'data': { 'type': 'object' }
+          {
+            'properties': {
+              'result': {
+                'type': 'object',
+                'properties': {
+                  'err': { 'type': 'string' },
+                  'data': { 'type': 'object' }
+                }
               }
             }
           }
-        }
-      ];
+        ]
+      };
 
       expect(deref.resolveAllOf(
-        allOfschema,
+        schema,
         'REQUEST',
         { concreteUtils: schemaUtils30X },
         { resolveTo: 'example' }
       )).to.deep.include({
         type: 'object',
         properties: {
+          source: {
+            type: 'string',
+            format: 'uuid'
+          },
+          actionId: { 'type': 'integer', 'minimum': 5 },
+          result: {
+            type: 'object',
+            properties: {
+              err: { 'type': 'string' },
+              data: { 'type': 'object' }
+            }
+          }
+        }
+      });
+      done();
+    });
+
+    it('should resolve schemas containing allOf keyword along with outer properties correctly', function (done) {
+      var schema = {
+        'properties': {
+          'id': {
+            'type': 'integer'
+          },
+          'name': {
+            'type': 'string'
+          },
+          'type': {
+            'type': 'string',
+            'enum': ['capsule', 'probe', 'satellite', 'spaceplane', 'station']
+          },
+          'registerdDate': {
+            'type': 'string',
+            'format': 'date-time'
+          }
+        },
+        'allOf': [
+          {
+            'type': 'object',
+            'properties': {
+              'source': {
+                'type': 'string',
+                'format': 'uuid'
+              },
+              'actionId': { 'type': 'integer', 'minimum': 5 },
+              'result': { 'type': 'object' }
+            },
+            'required': ['source', 'actionId', 'result']
+          },
+          {
+            'properties': {
+              'result': {
+                'type': 'object',
+                'properties': {
+                  'err': { 'type': 'string' },
+                  'data': { 'type': 'object' }
+                }
+              }
+            }
+          }
+        ]
+      };
+
+      expect(deref.resolveAllOf(
+        schema,
+        'REQUEST',
+        { concreteUtils: schemaUtils30X },
+        { resolveTo: 'example' }
+      )).to.deep.include({
+        type: 'object',
+        properties: {
+          id: {
+            type: 'integer'
+          },
+          name: {
+            type: 'string'
+          },
+          type: {
+            type: 'string',
+            enum: ['capsule', 'probe', 'satellite', 'spaceplane', 'station']
+          },
+          registerdDate: {
+            type: 'string',
+            format: 'date-time'
+          },
           source: {
             type: 'string',
             format: 'uuid'


### PR DESCRIPTION
### Problem
Fixes issue: https://github.com/postmanlabs/postman-app-support/issues/11656

When the definition contains schema that has `allOf` keyword along with outer schema, generated collection did not contain any properties from outer schema and only part of `allOf` schema.

Below is example for which it was failing.

```
"schema": {
    "allOf": [
        {
            "$ref": "#/components/schemas/Request"
        }
    ],
    "properties": {
        "announcement": {
            "$ref": "#/components/schemas/Announcement"
        },
        "skipCondition": {
            "$ref": "#/components/schemas/SkipCondition"
        },
        "responseProfile": {
            "$ref": "#/components/schemas/BaseResponseProfile"
        }
    },
    "type": "object"
}
```

### Root cause
The issue was happening due to, `deref.resolveAllOf()` function only considering the schemas inside `allOf` whenever `allOf` was mentioned in schema. This results in outer schema being ignored completely.

### Fix
We will be also resolving the outer schema (non `allOf` schema) along with `allOf` keyword by first resolving outer schema first and then merging `allOf` schemas along with the resolved outer schema.