### PR TITLE
ISSUE #401 - Fix for schema having enum but no type

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -427,7 +427,7 @@ module.exports = {
     }
     else if (!schema.hasOwnProperty('default')) {
       if (schema.hasOwnProperty('type')) {
-        // Override default value to schema for CONVERSION only for parmeter resolution set to schema
+        // Override default value to schema for CONVERSION only for parameter resolution set to schema
         if (resolveFor === 'CONVERSION' && resolveTo === 'schema') {
           if (!schema.hasOwnProperty('format')) {
             schema.default = '<' + schema.type + '>';
@@ -447,10 +447,27 @@ module.exports = {
         }
       }
       else if (schema.enum && schema.enum.length > 0) {
-        return {
-          type: (typeof (schema.enum[0])),
-          value: schema.enum[0]
-        };
+        if (resolveFor === 'CONVERSION' && resolveTo === 'schema') {
+          schema.type = (typeof (schema.enum[0]));
+          if (!schema.hasOwnProperty('format')) {
+            schema.default = '<' + schema.type + '>';
+          }
+          else if (typesMap.hasOwnProperty(schema.type)) {
+            schema.default = typesMap[schema.type][schema.format];
+            if (!schema.default && schema.format) {
+              schema.default = '<' + schema.format + '>';
+            }
+          }
+          else {
+            schema.default = '<' + schema.type + (schema.format ? ('-' + schema.format) : '') + '>';
+          }
+        }
+        else {
+          return {
+            type: (typeof (schema.enum[0])),
+            value: schema.enum[0]
+          };
+        }
       }
       else if (isAllOf) {
         return schema;

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -1821,7 +1821,7 @@ describe('CONVERT FUNCTION TESTS ', function() {
   });
 
   describe('Converting swagger 2.0 files', function() {
-    it('should convert path paramters to postman-compatible paramters', function (done) {
+    it('should convert path parameters to postman-compatible parameters', function (done) {
       const fileData = path.join(__dirname, SWAGGER_20_FOLDER_JSON, 'swagger2-with-params.json'),
         input = {
           type: 'file',

--- a/test/unit/deref.test.js
+++ b/test/unit/deref.test.js
@@ -313,7 +313,7 @@ describe('DEREF FUNCTION TESTS ', function() {
       expect(output.required).to.not.include('tag');
       done();
     });
-    
+
     it('should handle schema with enum having no type defined for resolveTo set as schema', function(done) {
       var schema = {
           'enum': [
@@ -335,6 +335,8 @@ describe('DEREF FUNCTION TESTS ', function() {
       });
       expect(output.type).to.equal('string');
       expect(output.default).to.equal('<string>');
+      done();
+    });
 
     it('should return schema with example parameter(if given) for $ref just like inline schema', function(done) {
       var schema = {

--- a/test/unit/deref.test.js
+++ b/test/unit/deref.test.js
@@ -313,6 +313,30 @@ describe('DEREF FUNCTION TESTS ', function() {
       expect(output.required).to.not.include('tag');
       done();
     });
+
+    it('should handle schema with enum having no type defined for resolveTo set as schema', function(done) {
+      var schema = {
+          'enum': [
+            'capsule',
+            'probe',
+            'satellite',
+            'spaceplane',
+            'station'
+          ]
+        },
+        resolveFor = 'CONVERSION',
+        resolveTo = 'schema',
+        parameterSource = 'REQUEST',
+        output;
+
+      output = deref.resolveRefs(schema, parameterSource, { concreteUtils: schemaUtils30X }, {
+        resolveFor,
+        resolveTo
+      });
+      expect(output.type).to.equal('string');
+      expect(output.default).to.equal('<string>');
+      done();
+    });
   });
 
   describe('resolveAllOf Function', function () {


### PR DESCRIPTION
* Fix for Issue #401: When request/example ParametersResolution to schema and the schema has no type for enum then we were receiving ipsum text, this PR fixes that.