### PR TITLE
Fixed various known type errors related issues.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -1513,7 +1513,7 @@ module.exports = {
     var example,
       exampleKey;
 
-    if (typeof exampleObj !== 'object') {
+    if (!exampleObj || typeof exampleObj !== 'object') {
       return '';
     }
 
@@ -1720,7 +1720,7 @@ module.exports = {
 
     Object.keys(deepObject).forEach((key) => {
       let value = deepObject[key];
-      if (typeof value === 'object') {
+      if (value && typeof value === 'object') {
         extractedParams = _.concat(extractedParams, this.extractDeepObjectParams(value, objectKey + '[' + key + ']'));
       }
       else {
@@ -2640,7 +2640,7 @@ module.exports = {
     // App / Collection transformer fail with the object syntax
     if (item.request.url.variables.members && item.request.url.variables.members.length > 0) {
       item.request.url.variables.members = _.map(item.request.url.variables.members, (m) => {
-        if (typeof m.description === 'object' && m.description.content) {
+        if (m.description && typeof m.description === 'object' && m.description.content) {
           m.description = m.description.content;
         }
         return m;

--- a/libV2/schemaUtils.js
+++ b/libV2/schemaUtils.js
@@ -401,7 +401,7 @@ let QUERYPARAM = 'query',
     let example = {},
       exampleKey;
 
-    if (typeof exampleObj !== 'object') {
+    if (!exampleObj || typeof exampleObj !== 'object') {
       return '';
     }
 
@@ -545,6 +545,11 @@ let QUERYPARAM = 'query',
         { includeDeprecated } = context.computedOptions;
 
       _.forOwn(schema.properties, (property, propertyName) => {
+        // Skip property resolution if it's not schema object
+        if (!_.isObject(property)) {
+          return;
+        }
+
         if (
           property.format === 'decimal' ||
           property.format === 'byte' ||
@@ -875,7 +880,7 @@ let QUERYPARAM = 'query',
 
     Object.keys(deepObject).forEach((key) => {
       let value = deepObject[key];
-      if (typeof value === 'object') {
+      if (value && typeof value === 'object') {
         extractedParams = _.concat(extractedParams, extractDeepObjectParams(value, objectKey + '[' + key + ']'));
       }
       else {
@@ -1720,8 +1725,9 @@ let QUERYPARAM = 'query',
     let responses = [],
       requestAcceptHeader;
 
-    _.forOwn(operationItem.responses, (responseSchema, code) => {
+    _.forOwn(operationItem.responses, (responseObj, code) => {
       let response,
+        responseSchema = _.has(responseObj, '$ref') ? resolveSchema(context, responseObj) : responseObj,
         { includeAuthInfoInExample } = context.computedOptions,
         responseAuthHelper,
         auth = request.auth,

--- a/libV2/validationUtils.js
+++ b/libV2/validationUtils.js
@@ -885,7 +885,7 @@ function extractDeepObjectParams (deepObject, objectKey) {
 
   Object.keys(deepObject).forEach((key) => {
     let value = deepObject[key];
-    if (typeof value === 'object') {
+    if (value && typeof value === 'object') {
       extractedParams = _.concat(extractedParams, extractDeepObjectParams(value, objectKey + '[' + key + ']'));
     }
     else {

--- a/test/data/valid_openapi/specWithResponseRef.yaml
+++ b/test/data/valid_openapi/specWithResponseRef.yaml
@@ -1,0 +1,72 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          $ref: "#/components/responses/defaultRes"
+components:
+  responses:
+    defaultRes:
+      description: unexpected error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+      headers:
+        x-trace-id:
+          schema:
+            type: string
+          example: 12345-6789
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+        nullProp: null

--- a/test/unit/schemaUtils.test.js
+++ b/test/unit/schemaUtils.test.js
@@ -1,4 +1,9 @@
-const { getParametersForPathItem, verifyDeprecatedProperties } = require('../../lib/schemaUtils'),
+const {
+    getParametersForPathItem,
+    verifyDeprecatedProperties,
+    getExampleData,
+    extractDeepObjectParams
+  } = require('../../lib/schemaUtils'),
   expect = require('chai').expect;
 
 
@@ -259,5 +264,24 @@ describe('verifyDeprecatedProperties function', function () {
     expect(schema.properties.b).to.not.be.undefined;
     expect(schema.properties.b.properties.c).to.be.undefined;
     expect(schema.properties.b.properties.d).to.not.be.undefined;
+  });
+});
+
+describe('getExampleData function', function () {
+  it('should correctly provide result with null example object', function () {
+    const result = getExampleData(null, {}, {});
+
+    expect(result).to.equal('');
+  });
+});
+
+describe('extractDeepObjectParams function', function () {
+  it('should correctly provide result with nested object containing null values', function () {
+    const result = extractDeepObjectParams({ id: null }, 'user');
+
+    expect(result).to.eql([{
+      key: 'user[id]',
+      value: null
+    }]);
   });
 });


### PR DESCRIPTION
## Overview

This PR fixed known type errors that could be caused due to invalid definitions. We'll be handling such cases gracefully to make sure collection gets generated without type error.

It also fixes one issue I noticed, which was causing incorrect name and headers for response if $ref was defined for them.

## RCA

`typeof null` in Javascript evaluates as `object` this caused further code i.e. `Object.keys()` to fail. Most of such type errors were happening due to expectation of valid definition but as there can be null or undefined values in such cases, we ended up with type error.

For the issue with response $ref, we were not resolving $ref if present in response before deciding name and headers. Although body was resolved correctly.

## Fix

We'll now be checking the value to be not null or undefined along with it's type to be `object` to make sure the value is actual object.

For the issue with response $ref, we'll now be resolving the response beforehand if we find $ref in response.