### PR TITLE
Added support for usage of interface version in CLI conversions with v2 as default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,28 +56,31 @@ The converter can be used as a CLI tool as well. The following [command line opt
 
 ### Options
 
-- `-s <source>`, `--spec <source>`  
+- `-s <source>`, `--spec <source>`
   Used to specify the OpenAPI specification (file path) which is to be converted
 
-- `-o <destination>`, `--output <destination>`  
+- `-o <destination>`, `--output <destination>`
   Used to specify the destination file in which the collection is to be written
 
-- `-p`, `--pretty`  
+- `-p`, `--pretty`
   Used to pretty print the collection object while writing to a file
 
-- `-O`, `--options`  
+- `-i`, `--interface-version`
+  Specifies the interface version of the converter to be used. Value can be 'v2' or 'v1'. Default is 'v2'.
+
+- `-O`, `--options`
   Used to supply options to the converter, for complete options details see [here](/OPTIONS.md)
 
-- `-c`, `--options-config`  
+- `-c`, `--options-config`
   Used to supply options to the converter through config file, for complete options details see [here](/OPTIONS.md)
 
-- `-t`, `--test`  
+- `-t`, `--test`
   Used to test the collection with an in-built sample specification
 
-- `-v`, `--version`  
+- `-v`, `--version`
   Specifies the version of the converter
 
-- `-h`, `--help`  
+- `-h`, `--help`
   Specifies all the options along with a few usage examples on the terminal
 
 

--- a/libV2/schemaUtils.js
+++ b/libV2/schemaUtils.js
@@ -237,6 +237,19 @@ let QUERYPARAM = 'query',
   },
 
   /**
+   * Provides ref stack limit for current instance
+   * @param {*} stackLimit - Defined stackLimit in options
+   *
+   * @returns {Number} Returns the stackLimit to be used
+   */
+  getRefStackLimit = (stackLimit) => {
+    if (typeof stackLimit === 'number' && stackLimit > REF_STACK_LIMIT) {
+      return stackLimit;
+    }
+    return REF_STACK_LIMIT;
+  },
+
+  /**
    * Resolve a given ref from the schema
    * @param {Object} context - Global context object
    * @param {Object} $ref - Ref that is to be resolved
@@ -246,9 +259,10 @@ let QUERYPARAM = 'query',
    * @returns {Object} Returns the object that staisfies the schema
    */
   resolveRefFromSchema = (context, $ref, stackDepth = 0, seenRef = {}) => {
-    const { specComponents } = context;
+    const { specComponents } = context,
+      { stackLimit } = context.computedOptions;
 
-    if (stackDepth >= REF_STACK_LIMIT) {
+    if (stackDepth >= getRefStackLimit(stackLimit)) {
       return { value: ERR_TOO_MANY_LEVELS };
     }
 
@@ -315,9 +329,10 @@ let QUERYPARAM = 'query',
    * @returns {Object} Returns the object that staisfies the schema
    */
   resolveRefForExamples = (context, $ref, stackDepth = 0, seenRef = {}) => {
-    const { specComponents } = context;
+    const { specComponents } = context,
+      { stackLimit } = context.computedOptions;
 
-    if (stackDepth >= REF_STACK_LIMIT) {
+    if (stackDepth >= getRefStackLimit(stackLimit)) {
       return { value: ERR_TOO_MANY_LEVELS };
     }
 
@@ -467,12 +482,15 @@ let QUERYPARAM = 'query',
       return new Error('Schema is empty');
     }
 
-    if (stack >= REF_STACK_LIMIT) {
+    const { stackLimit } = context.computedOptions;
+
+    if (stack >= getRefStackLimit(stackLimit)) {
       return { value: ERR_TOO_MANY_LEVELS };
     }
 
     stack++;
 
+    // eslint-disable-next-line one-var
     const compositeKeyword = schema.anyOf ? 'anyOf' : 'oneOf',
       { concreteUtils } = context;
 


### PR DESCRIPTION
This PR adds support for usage of newer v2 interface for CLI conversion usage. It also adds support for usage of custom stack limit defined in CLI for v2 interface.

With this PR, by default v2 interface of convert will be used and one can specify the `v1` value for with option `-i` to override this behaviour.