### PR TITLE
Fixed issue where TypeErrors were happening for null/undefined params.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -696,7 +696,7 @@ module.exports = {
           operationItem.parameters = this.getRequestParams(operationItem.parameters, commonParams,
             specComponentsAndUtils, options);
           summary = operationItem.summary || operationItem.description;
-          currentNode.addMethod({
+          _.isFunction(currentNode.addMethod) && currentNode.addMethod({
             name: summary,
             method: method,
             path: path,
@@ -1480,6 +1480,10 @@ module.exports = {
       includeDeprecated = options.includeDeprecated !== false;
 
     _.forEach(localParams, (param) => {
+      if (!_.isObject(param)) {
+        return;
+      }
+
       tempParam = param;
       let verifyAddDeprecated = (includeDeprecated ||
         includeDeprecated === false && tempParam.deprecated !== true);
@@ -2182,6 +2186,10 @@ module.exports = {
       return null;
     }
     _.forOwn(response.headers, (value, key) => {
+      if (!_.isObject(value)) {
+        return;
+      }
+
       if (_.toLower(key) !== 'content-type') {
         if (_.get(value, '$ref')) {
           // the convert to PmHeader function handles the

--- a/libV2/schemaUtils.js
+++ b/libV2/schemaUtils.js
@@ -227,7 +227,7 @@ let QUERYPARAM = 'query',
     _.forOwn(serverObj.variables, (value, key) => {
       serverVariables.push({
         key,
-        value: value.default || ''
+        value: _.get(value, 'default') || ''
       });
     });
 
@@ -1150,6 +1150,10 @@ let QUERYPARAM = 'query',
         // TODO: This could have properties inside properties which needs to be handled
         // That's why for some properties we are not deleting the format
         _.forOwn(requestBodySchema.properties, (schema, prop) => {
+          if (!_.isObject(requestBodySchema.properties[prop])) {
+            return;
+          }
+
           if (
             requestBodySchema.properties[prop].format === 'binary' ||
             requestBodySchema.properties[prop].format === 'byte' ||
@@ -1466,6 +1470,10 @@ let QUERYPARAM = 'query',
       { includeDeprecated } = context.computedOptions;
 
     _.forEach(params, (param) => {
+      if (!_.isObject(param)) {
+        return;
+      }
+
       if (_.has(param, '$ref')) {
         param = resolveSchema(context, param);
       }
@@ -1497,6 +1505,10 @@ let QUERYPARAM = 'query',
       pmParams = [];
 
     _.forEach(params, (param) => {
+      if (!_.isObject(param)) {
+        return;
+      }
+
       if (_.has(param, '$ref')) {
         param = resolveSchema(context, param);
       }
@@ -1557,6 +1569,10 @@ let QUERYPARAM = 'query',
       { keepImplicitHeaders, includeDeprecated } = context.computedOptions;
 
     _.forEach(params, (param) => {
+      if (!_.isObject(param)) {
+        return;
+      }
+
       if (_.has(param, '$ref')) {
         param = resolveSchema(context, param);
       }
@@ -1646,6 +1662,10 @@ let QUERYPARAM = 'query',
     }
 
     _.forOwn(responseHeaders, (value, headerName) => {
+      if (!_.isObject(value)) {
+        return;
+      }
+
       if (!includeDeprecated && value.deprecated) {
         return;
       }

--- a/test/data/valid_openapi/specWithNullParams.yaml
+++ b/test/data/valid_openapi/specWithNullParams.yaml
@@ -1,0 +1,72 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets/{petid}:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: petid
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+        -
+      responses:
+        '200':
+          description: An paged array of pets
+          headers:
+            x-next: null
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -88,7 +88,9 @@ describe('CONVERT FUNCTION TESTS ', function() {
       xmlRequestAndResponseBodyArrayTypeWrapped =
         path.join(__dirname, VALID_OPENAPI_PATH, '/xmlRequestAndResponseBodyArrayTypeWrapped.json'),
       schemaWithAdditionalProperties =
-        path.join(__dirname, VALID_OPENAPI_PATH, '/schemaWithAdditionalProperties.yaml');
+        path.join(__dirname, VALID_OPENAPI_PATH, '/schemaWithAdditionalProperties.yaml'),
+      specWithNullParams =
+        path.join(__dirname, VALID_OPENAPI_PATH, '/specWithNullParams.yaml');
 
 
     it('Should add collection level auth with type as `bearer`' +
@@ -1822,6 +1824,30 @@ describe('CONVERT FUNCTION TESTS ', function() {
           done();
         });
     });
+
+    it('The converter should not throw error for definition with undefined/null params and response headers',
+      function(done) {
+        var openapi = fs.readFileSync(specWithNullParams, 'utf8');
+        Converter.convert({ type: 'string', data: openapi }, {},
+          (err, conversionResult) => {
+            expect(err).to.be.null;
+            expect(conversionResult.result).to.equal(true);
+            expect(conversionResult.output.length).to.equal(1);
+            expect(conversionResult.output[0].type).to.equal('collection');
+            expect(conversionResult.output[0].data).to.have.property('info');
+            expect(conversionResult.output[0].data).to.have.property('item');
+            expect(conversionResult.output[0].data.item.length).to.equal(1);
+
+            const item = conversionResult.output[0].data.item[0];
+
+            expect(item.request.url.query.length).to.eql(1);
+            expect(item.request.url.variable.length).to.eql(1);
+            expect(item.request.header.length).to.eql(1);
+
+            expect(item.response[0].header.length).to.eql(1);
+            done();
+          });
+      });
   });
 
   describe('Converting swagger 2.0 files', function() {

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -83,7 +83,9 @@ const expect = require('chai').expect,
   schemaWithAdditionalProperties =
     path.join(__dirname, VALID_OPENAPI_PATH, '/schemaWithAdditionalProperties.yaml'),
   specWithResponseRef =
-    path.join(__dirname, VALID_OPENAPI_PATH, '/specWithResponseRef.yaml');
+    path.join(__dirname, VALID_OPENAPI_PATH, '/specWithResponseRef.yaml'),
+  specWithNullParams =
+    path.join(__dirname, VALID_OPENAPI_PATH, '/specWithNullParams.yaml');
 
 
 describe('The convert v2 Function', function() {
@@ -733,7 +735,7 @@ describe('The convert v2 Function', function() {
     });
   });
 
-  it('[Github #137]- Should add `requried` keyword in parameters where ' +
+  it('[Github #137]- Should add `required` keyword in parameters where ' +
     'required field is set to true', function(done) {
     Converter.convertV2({ type: 'file', data: requiredInParams }, { schemaFaker: true }, (err, conversionResult) => {
       expect(err).to.be.null;
@@ -2103,6 +2105,29 @@ describe('The convert v2 Function', function() {
 
         // Incorrectly defined properties will be skipped
         expect(JSON.parse(item.response[1].body)).to.not.have.property('nullProp');
+        done();
+      });
+  });
+
+  it('Should convert a collection with undefined/null params and response headers without error', function(done) {
+    var openapi = fs.readFileSync(specWithNullParams, 'utf8');
+    Converter.convertV2({ type: 'string', data: openapi }, {},
+      (err, conversionResult) => {
+        expect(err).to.be.null;
+        expect(conversionResult.result).to.equal(true);
+        expect(conversionResult.output.length).to.equal(1);
+        expect(conversionResult.output[0].type).to.equal('collection');
+        expect(conversionResult.output[0].data).to.have.property('info');
+        expect(conversionResult.output[0].data).to.have.property('item');
+        expect(conversionResult.output[0].data.item.length).to.equal(1);
+
+        const item = conversionResult.output[0].data.item[0].item[0].item[0];
+
+        expect(item.request.url.query.length).to.eql(1);
+        expect(item.request.url.variable.length).to.eql(1);
+        expect(item.request.header.length).to.eql(1);
+
+        expect(item.response[0].header.length).to.eql(1);
         done();
       });
   });


### PR DESCRIPTION
## Overview

This PR fixes a few known TyepErrors as mentioned below.

## RCA

While resolving query params, headers and path variables, we were expecting param to be always object as OpenAPI official documentation mentions that they have to be object. This was causing typeerrors in case when such params are null or undefined. 

On similar note, other issue was happening due to access of certain method for empty node.

## Fix

We'll be making sure to safely check first if the param is object or not before accessing data. Similarly, safely check if function is actually present before executing it.