### PR TITLE
Used safer lodash object functions to avoid type errors.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -288,9 +288,9 @@ module.exports = {
     // The complexity is 10.
     if (size < 8) {
       // Finds the number of requests that would be generated from this spec
-      if (spec.paths) {
+      if (_.isObject(spec.paths)) {
         Object.values(spec.paths).forEach((value) => {
-          Object.keys(value).forEach((key) => {
+          _.keys(value).forEach((key) => {
             if (METHODS.includes(key)) {
               numberOfRequests++;
             }
@@ -645,7 +645,7 @@ module.exports = {
         pathLength = currentPath.length;
 
         // get method names available for this path
-        pathMethods = getPathMethods(Object.keys(currentPathObject));
+        pathMethods = getPathMethods(_.keys(currentPathObject));
 
         // the number of requests under this node
         currentPathRequestCount = pathMethods.length;
@@ -724,7 +724,7 @@ module.exports = {
       variableStore = {},
       webhooksVariables = [];
 
-    if (Object.keys(webhooksTree.root.children).length === 0) {
+    if (_.keys(webhooksTree.root.children).length === 0) {
       return;
     }
 
@@ -1059,7 +1059,7 @@ module.exports = {
       // with parent folder.
       /* eslint-disable max-depth */
       if (resource.childCount === 1 && options.collapseFolders) {
-        let subChild = Object.keys(resource.children)[0],
+        let subChild = _.keys(resource.children)[0],
           resourceSubChild = resource.children[subChild];
 
         resourceSubChild.name = resource.name + '/' + resourceSubChild.name;
@@ -1140,7 +1140,7 @@ module.exports = {
         };
         return false;
       }
-      securityDef = _.get(openapi, ['securityDefs', Object.keys(security)[0]]);
+      securityDef = _.get(openapi, ['securityDefs', _.keys(security)[0]]);
       if (!_.isObject(securityDef)) {
         return;
       }
@@ -1189,7 +1189,7 @@ module.exports = {
           oauth2: []
         };
 
-        if (_.isObject(securityDef.flows) && FLOW_TYPE[Object.keys(securityDef.flows)[0]]) {
+        if (_.isObject(securityDef.flows) && FLOW_TYPE[_.keys(securityDef.flows)[0]]) {
           /*
 
           //===================[]========================\\
@@ -1209,8 +1209,8 @@ module.exports = {
           • "authorization_code_with_pkce"
 
           */
-          currentFlowType = FLOW_TYPE[Object.keys(securityDef.flows)[0]];
-          flowObj = _.get(securityDef, `flows.${Object.keys(securityDef.flows)[0]}`);
+          currentFlowType = FLOW_TYPE[_.keys(securityDef.flows)[0]];
+          flowObj = _.get(securityDef, `flows.${_.keys(securityDef.flows)[0]}`);
         }
 
         if (currentFlowType) { // Means the flow is of supported type
@@ -1219,7 +1219,7 @@ module.exports = {
           if (!_.isEmpty(flowObj.scopes)) {
             helper.oauth2.push({
               key: 'scope',
-              value: Object.keys(flowObj.scopes).join(' ')
+              value: _.keys(flowObj.scopes).join(' ')
             });
           }
 
@@ -1408,7 +1408,7 @@ module.exports = {
         responseBody: ''
       };
     }
-    let headers = Object.keys(contentObj);
+    let headers = _.keys(contentObj);
 
     for (let i = 0; i < headers.length; i++) {
       let headerFamily = this.getHeaderFamily(headers[i]);
@@ -1423,7 +1423,7 @@ module.exports = {
 
     // if no JSON or XML, take whatever we have
     if (!hasComputedType) {
-      cTypes = Object.keys(contentObj);
+      cTypes = _.keys(contentObj);
       if (cTypes.length > 0) {
         cTypeHeader = cTypes[0];
         hasComputedType = true;
@@ -1521,7 +1521,7 @@ module.exports = {
       return '';
     }
 
-    exampleKey = Object.keys(exampleObj)[0];
+    exampleKey = _.keys(exampleObj)[0];
     example = exampleObj[exampleKey];
     // return example value if present else example is returned
 
@@ -1722,7 +1722,7 @@ module.exports = {
   extractDeepObjectParams: function (deepObject, objectKey) {
     let extractedParams = [];
 
-    Object.keys(deepObject).forEach((key) => {
+    _.keys(deepObject).forEach((key) => {
       let value = deepObject[key];
       if (value && typeof value === 'object') {
         extractedParams = _.concat(extractedParams, this.extractDeepObjectParams(value, objectKey + '[' + key + ']'));
@@ -2250,12 +2250,12 @@ module.exports = {
         previewLanguage = PREVIEW_LANGUAGE.JSON;
       }
     }
-    else if (response.content && Object.keys(response.content).length > 0) {
-      responseHeaders.push({ key: 'Content-Type', value: Object.keys(response.content)[0] });
-      if (this.getHeaderFamily(Object.keys(response.content)[0]) === HEADER_TYPE.JSON) {
+    else if (response.content && _.keys(response.content).length > 0) {
+      responseHeaders.push({ key: 'Content-Type', value: _.keys(response.content)[0] });
+      if (this.getHeaderFamily(_.keys(response.content)[0]) === HEADER_TYPE.JSON) {
         previewLanguage = PREVIEW_LANGUAGE.JSON;
       }
-      else if (this.getHeaderFamily(Object.keys(response.content)[0]) === HEADER_TYPE.XML) {
+      else if (this.getHeaderFamily(_.keys(response.content)[0]) === HEADER_TYPE.XML) {
         previewLanguage = PREVIEW_LANGUAGE.XML;
       }
       else if (responseBodyWrapper.isJsonLike) {
@@ -5142,9 +5142,10 @@ module.exports = {
         bundleOutput;
 
       if (isSwagger(version)) {
-        Object.entries(contentAndComponents.components).forEach(([key, value]) => {
-          bundledFile[key] = value;
-        });
+        _.isObject(contentAndComponents.components) &&
+          Object.entries(contentAndComponents.components).forEach(([key, value]) => {
+            bundledFile[key] = value;
+          });
       }
       else if (!_.isEmpty(contentAndComponents.components)) {
         bundledFile.components = contentAndComponents.components;

--- a/libV2/schemaUtils.js
+++ b/libV2/schemaUtils.js
@@ -896,7 +896,7 @@ let QUERYPARAM = 'query',
   extractDeepObjectParams = (deepObject, objectKey) => {
     let extractedParams = [];
 
-    Object.keys(deepObject).forEach((key) => {
+    _.keys(deepObject).forEach((key) => {
       let value = deepObject[key];
       if (value && typeof value === 'object') {
         extractedParams = _.concat(extractedParams, extractDeepObjectParams(value, objectKey + '[' + key + ']'));


### PR DESCRIPTION
## Overview
This PR fixes a few known TyepErrors as mentioned below.

## RCA
Applying `Object.keys(data)` on data that is not object will return with a TypeError. We had multiple such occurrences in our codebase. As we want to gracefully convert even invalid definition, we need to fix such type errors.

## Fix
We'll be using safer lodash alternatives that can handle such scenarios gracefully.