### PR TITLE
Fixed issue where Accept header was not present in Example request.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2180,9 +2180,10 @@ module.exports = {
       previewLanguage = 'text',
       responseBodyWrapper,
       header,
-      sdkResponse;
+      sdkResponse,
+      responseMediaTypes;
 
-    if (!response) {
+    if (!_.isObject(response)) {
       return null;
     }
     _.forOwn(response.headers, (value, key) => {
@@ -2214,6 +2215,19 @@ module.exports = {
     // replace 'X' char with '0'
     code = code.replace(/X|x/g, '0');
     code = code === 'default' ? 500 : _.toSafeInteger(code);
+
+    responseMediaTypes = _.keys(response.content);
+
+    if (responseMediaTypes.length > 0) {
+      let acceptHeader = new sdk.Header({
+        key: 'Accept',
+        value: responseMediaTypes[0]
+      });
+
+      if (_.isArray(_.get(originalRequest, 'header'))) {
+        originalRequest.header.push(acceptHeader);
+      }
+    }
 
     sdkResponse = new sdk.Response({
       name: response.description,

--- a/libV2/schemaUtils.js
+++ b/libV2/schemaUtils.js
@@ -1785,6 +1785,9 @@ let QUERYPARAM = 'query',
         reqHeaders = _.clone(request.headers) || [],
         reqQueryParams = _.clone(_.get(request, 'params.queryParams', []));
 
+      // add Accept header in example's original request headers
+      _.isArray(acceptHeader) && (reqHeaders.push(...acceptHeader));
+
       if (includeAuthInfoInExample) {
         if (!auth) {
           auth = generateAuthForCollectionFromOpenAPI(context.openapi, context.openapi.security);
@@ -1798,6 +1801,11 @@ let QUERYPARAM = 'query',
         originalRequest = _.assign({}, request, {
           headers: reqHeaders,
           params: _.assign({}, request.params, { queryParams: reqQueryParams })
+        });
+      }
+      else {
+        originalRequest = _.assign({}, request, {
+          headers: reqHeaders
         });
       }
 

--- a/test/data/valid_openapi/acceptHeaderExample.json
+++ b/test/data/valid_openapi/acceptHeaderExample.json
@@ -1,0 +1,159 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "svc-activity",
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "http:\/\/localhost\/svc\/activity"
+        }
+    ],
+    "paths": {
+        "\/api\/log": {
+            "post": {
+                "summary": "Store",
+                "description": "Create new log item",
+                "parameters": [
+                  {
+                    "name": "x-hello",
+                    "required": true,
+                    "schema": {
+                      "type": "string"
+                    },
+                    "in": "header"
+                  }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "201 Created",
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "422 Validation Errors",
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/response-validation-errors"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "\/api\/logs\/{log}": {
+            "get": {
+                "summary": "Show",
+                "description": "Show one log by id",
+                "parameters": [
+                    {
+                        "name": "log",
+                        "in": "path",
+                        "description": "Log ID",
+                        "required": true,
+                        "schema": {
+                            "format": "int64",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "example": 1
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "200 OK",
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "id",
+                                        "metadata",
+                                        "timestamp",
+                                        "actor",
+                                        "action",
+                                        "namespace"
+                                    ],
+                                    "properties": {
+                                        "id": {
+                                            "description": "UUID of the object",
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "example": 12
+                                        },
+                                        "namespace": {
+                                            "description": "Where this actions took, preferably service name. Must be exists before",
+                                            "type": "string",
+                                            "example": "some-project"
+                                        },
+                                        "action": {
+                                            "description": "What is the action",
+                                            "type": "string",
+                                            "example": "create_user"
+                                        },
+                                        "actor": {
+                                            "description": "Who took the action, Subject, string, can be id, email, username",
+                                            "type": "string",
+                                            "example": "email@email.com"
+                                        },
+                                        "timestamp": {
+                                            "format": "date-time",
+                                            "type": "string"
+                                        },
+                                        "metadata": {
+                                            "type": "object",
+                                            "nullable": true
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "404 Not Found"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "response-validation-errors": {
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "example": "The given data was invalid."
+                    },
+                    "errors": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "example": {
+                            "field": [
+                                "Something is wrong with this field!"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -90,7 +90,9 @@ describe('CONVERT FUNCTION TESTS ', function() {
       schemaWithAdditionalProperties =
         path.join(__dirname, VALID_OPENAPI_PATH, '/schemaWithAdditionalProperties.yaml'),
       specWithNullParams =
-        path.join(__dirname, VALID_OPENAPI_PATH, '/specWithNullParams.yaml');
+        path.join(__dirname, VALID_OPENAPI_PATH, '/specWithNullParams.yaml'),
+      acceptHeaderExample =
+        path.join(__dirname, VALID_OPENAPI_PATH, '/acceptHeaderExample.json');
 
 
     it('Should add collection level auth with type as `bearer`' +
@@ -1848,6 +1850,44 @@ describe('CONVERT FUNCTION TESTS ', function() {
             done();
           });
       });
+
+    it('Should add corresponding Accept header in collection example\'s request correctly', function(done) {
+      var openapi = fs.readFileSync(acceptHeaderExample, 'utf8');
+      Converter.convertV2({ type: 'string', data: openapi }, {},
+        (err, conversionResult) => {
+          expect(err).to.be.null;
+          expect(conversionResult.result).to.equal(true);
+          expect(conversionResult.output.length).to.equal(1);
+          expect(conversionResult.output[0].type).to.equal('collection');
+          expect(conversionResult.output[0].data).to.have.property('info');
+          expect(conversionResult.output[0].data).to.have.property('item');
+          expect(conversionResult.output[0].data.item.length).to.equal(1);
+
+          const item1 = conversionResult.output[0].data.item[0].item[0].item[0].item[0],
+            item2 = conversionResult.output[0].data.item[0].item[1].item[0],
+            acceptHeader = {
+              key: 'Accept',
+              value: 'application/json'
+            };
+
+          expect(item1.request.header.length).to.eql(1);
+          expect(item1.request.header[0]).to.eql(acceptHeader);
+          expect(item1.response[0].originalRequest.header.length).to.eql(1);
+          expect(item1.response[0].originalRequest.header[0]).to.eql(acceptHeader);
+          expect(item1.response[1].originalRequest.header).to.be.undefined;
+
+          expect(item2.request.header.length).to.eql(2);
+          expect(item2.request.header[0].key).to.eql('x-hello');
+          expect(item2.request.header[1]).to.eql(acceptHeader);
+          expect(item2.response[0].originalRequest.header.length).to.eql(2);
+          expect(item2.response[0].originalRequest.header[0].key).to.eql('x-hello');
+          expect(item2.response[0].originalRequest.header[1]).to.eql(acceptHeader);
+          expect(item2.response[1].originalRequest.header.length).to.eql(2);
+          expect(item2.response[1].originalRequest.header[0].key).to.eql('x-hello');
+          expect(item2.response[1].originalRequest.header[1]).to.eql(acceptHeader);
+          done();
+        });
+    });
   });
 
   describe('Converting swagger 2.0 files', function() {

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -85,7 +85,9 @@ const expect = require('chai').expect,
   specWithResponseRef =
     path.join(__dirname, VALID_OPENAPI_PATH, '/specWithResponseRef.yaml'),
   specWithNullParams =
-    path.join(__dirname, VALID_OPENAPI_PATH, '/specWithNullParams.yaml');
+    path.join(__dirname, VALID_OPENAPI_PATH, '/specWithNullParams.yaml'),
+  acceptHeaderExample =
+    path.join(__dirname, VALID_OPENAPI_PATH, '/acceptHeaderExample.json');
 
 
 describe('The convert v2 Function', function() {
@@ -2128,6 +2130,44 @@ describe('The convert v2 Function', function() {
         expect(item.request.header.length).to.eql(1);
 
         expect(item.response[0].header.length).to.eql(1);
+        done();
+      });
+  });
+
+  it('Should add corresponding Accept header in collection example\'s request correctly', function(done) {
+    var openapi = fs.readFileSync(acceptHeaderExample, 'utf8');
+    Converter.convertV2({ type: 'string', data: openapi }, {},
+      (err, conversionResult) => {
+        expect(err).to.be.null;
+        expect(conversionResult.result).to.equal(true);
+        expect(conversionResult.output.length).to.equal(1);
+        expect(conversionResult.output[0].type).to.equal('collection');
+        expect(conversionResult.output[0].data).to.have.property('info');
+        expect(conversionResult.output[0].data).to.have.property('item');
+        expect(conversionResult.output[0].data.item.length).to.equal(1);
+
+        const item1 = conversionResult.output[0].data.item[0].item[0].item[0].item[0],
+          item2 = conversionResult.output[0].data.item[0].item[1].item[0],
+          acceptHeader = {
+            key: 'Accept',
+            value: 'application/json'
+          };
+
+        expect(item1.request.header.length).to.eql(1);
+        expect(item1.request.header[0]).to.eql(acceptHeader);
+        expect(item1.response[0].originalRequest.header.length).to.eql(1);
+        expect(item1.response[0].originalRequest.header[0]).to.eql(acceptHeader);
+        expect(item1.response[1].originalRequest.header).to.be.undefined;
+
+        expect(item2.request.header.length).to.eql(2);
+        expect(item2.request.header[0].key).to.eql('x-hello');
+        expect(item2.request.header[1]).to.eql(acceptHeader);
+        expect(item2.response[0].originalRequest.header.length).to.eql(2);
+        expect(item2.response[0].originalRequest.header[0].key).to.eql('x-hello');
+        expect(item2.response[0].originalRequest.header[1]).to.eql(acceptHeader);
+        expect(item2.response[1].originalRequest.header.length).to.eql(2);
+        expect(item2.response[1].originalRequest.header[0].key).to.eql('x-hello');
+        expect(item2.response[1].originalRequest.header[1]).to.eql(acceptHeader);
         done();
       });
   });

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -2020,6 +2020,10 @@ describe('The convert v2 Function', function() {
         expect(item.request.header[0].key).to.eql('Accept');
         expect(item.request.header[0].value).to.eql('application/json');
         expect(item.response[0].originalRequest.header[0]).to.be.eql({
+          key: 'Accept',
+          value: 'application/json'
+        });
+        expect(item.response[0].originalRequest.header[1]).to.be.eql({
           description: {
             content: 'Added as a part of security scheme: apikey',
             type: 'text/plain'
@@ -2071,6 +2075,10 @@ describe('The convert v2 Function', function() {
         expect(item.request.header[0].key).to.eql('Accept');
         expect(item.request.header[0].value).to.eql('application/json');
         expect(item.response[0].originalRequest.header[0]).to.be.eql({
+          key: 'Accept',
+          value: 'application/json'
+        });
+        expect(item.response[0].originalRequest.header[1]).to.be.eql({
           description: {
             content: 'Added as a part of security scheme: oauth1',
             type: 'text/plain'


### PR DESCRIPTION
## Problem

This PR fixes issue https://github.com/postmanlabs/postman-app-support/issues/11835, where for generated collection from OpenAPI definition was not containing Accept header correctly in example request. This created certain issues in further flows like mocks.

## RCA

We are not adding Accept header in example request similar to as present in request ATM.

## Fix

We'll be now adding corresponding Accept header in the example request.

