### PR TITLE
Added support for enableOptionalParameters option in v2 interface.

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -18,6 +18,6 @@ validateMetadata|boolean|-|false|Whether to show mismatches for incorrect name a
 ignoreUnresolvedVariables|boolean|-|false|Whether to ignore mismatches resulting from unresolved variables in the Postman request|VALIDATION|v2, v1
 strictRequestMatching|boolean|-|false|Whether requests should be strictly matched with schema operations. Setting to true will not include any matches where the URL path segments don't match exactly.|VALIDATION|v2, v1
 allowUrlPathVarMatching|boolean|-|false|Whether to allow matching path variables that are available as part of URL itself in the collection request|VALIDATION|v2, v1
-enableOptionalParameters|boolean|-|true|Optional parameters aren't selected in the collection. Once enabled they will be selected in the collection and request as well.|CONVERSION|v1
+enableOptionalParameters|boolean|-|true|Optional parameters aren't selected in the collection. Once enabled they will be selected in the collection and request as well.|CONVERSION|v2, v1
 keepImplicitHeaders|boolean|-|false|Whether to keep implicit headers from the OpenAPI specification, which are removed by default.|CONVERSION|v2, v1
 includeDeprecated|boolean|-|true|Select whether to include deprecated operations, parameters, and properties in generated collection or not|CONVERSION, VALIDATION|v2, v1

--- a/lib/options.js
+++ b/lib/options.js
@@ -328,7 +328,7 @@ module.exports = {
         external: true,
         usage: ['CONVERSION'],
         supportedIn: [VERSION20, VERSION30, VERSION31],
-        supportedModuleVersion: [MODULE_VERSION.V1]
+        supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
         name: 'Keep implicit headers',

--- a/libV2/schemaUtils.js
+++ b/libV2/schemaUtils.js
@@ -926,11 +926,13 @@ let QUERYPARAM = 'query',
 
   serialiseParamsBasedOnStyle = (context, param, paramValue) => {
     const { style, explode, startValue, propSeparator, keyValueSeparator, isExplodable } =
-      getParamSerialisationInfo(context, param);
+      getParamSerialisationInfo(context, param),
+      { enableOptionalParameters } = context.computedOptions;
 
     let serialisedValue = '',
       description = getParameterDescription(param),
       paramName = _.get(param, 'name'),
+      disabled = !enableOptionalParameters && _.get(param, 'required') !== true,
       pmParams = [],
       isNotSerializable = false;
 
@@ -945,7 +947,8 @@ let QUERYPARAM = 'query',
             pmParams.push({
               key: isArrayValue ? paramName : key,
               value: (value === undefined ? '' : _.toString(value)),
-              description
+              description,
+              disabled
             });
           });
 
@@ -961,7 +964,8 @@ let QUERYPARAM = 'query',
             pmParams.push({
               key: extractedParam.key,
               value: _.toString(extractedParam.value) || '',
-              description
+              description,
+              disabled
             });
           });
 
@@ -971,7 +975,8 @@ let QUERYPARAM = 'query',
           isNotSerializable = true;
           pmParams.push({
             key: paramName,
-            value: '<Error: Not supported in OAS>'
+            value: '<Error: Not supported in OAS>',
+            disabled
           });
         }
 
@@ -1004,7 +1009,8 @@ let QUERYPARAM = 'query',
     pmParams.push({
       key: paramName,
       value: _.toString(serialisedValue),
-      description
+      description,
+      disabled
     });
 
     return pmParams;

--- a/libV2/validationUtils.js
+++ b/libV2/validationUtils.js
@@ -1735,7 +1735,7 @@ function checkQueryParams (context, queryParams, transactionPathPrefix, schemaPa
     requestQueryParams = [],
     resolvedSchemaParams = [],
     mismatchProperty = 'QUERYPARAM',
-    { includeDeprecated } = context.computedOptions;
+    { includeDeprecated, enableOptionalParameters } = context.computedOptions;
 
   if (options.validationPropertiesToIgnore.includes(mismatchProperty)) {
     return callback(null, []);
@@ -1837,6 +1837,11 @@ function checkQueryParams (context, queryParams, transactionPathPrefix, schemaPa
         return;
       }
 
+      // If optional parameters are disabled, do not report them as missing
+      if (!enableOptionalParameters && qp.required !== true) {
+        return;
+      }
+
       if (!_.find(requestQueryParams, (param) => {
         return param.key === qp.name;
       })) {
@@ -1888,7 +1893,7 @@ function checkRequestHeaders (context, headers, transactionPathPrefix, schemaPat
       return !_.includes(IMPLICIT_HEADERS, _.toLower(_.get(header, 'key')));
     }),
     mismatchProperty = 'HEADER',
-    { includeDeprecated } = context.computedOptions;
+    { includeDeprecated, enableOptionalParameters } = context.computedOptions;
 
   if (options.validationPropertiesToIgnore.includes(mismatchProperty)) {
     return callback(null, []);
@@ -1974,6 +1979,11 @@ function checkRequestHeaders (context, headers, transactionPathPrefix, schemaPat
           return;
         }
 
+        // If optional parameters are disabled, do not report them as missing
+        if (!enableOptionalParameters && header.required !== true) {
+          return;
+        }
+
         // assign parameter example(s) as schema examples;
         assignParameterExamples(header);
 
@@ -2019,7 +2029,7 @@ function checkResponseHeaders (context, schemaResponse, headers, transactionPath
       return !_.includes(IMPLICIT_HEADERS, _.toLower(_.get(header, 'key')));
     }),
     mismatchProperty = 'RESPONSE_HEADER',
-    { includeDeprecated } = context.computedOptions;
+    { includeDeprecated, enableOptionalParameters } = context.computedOptions;
 
   if (options.validationPropertiesToIgnore.includes(mismatchProperty)) {
     return callback(null, []);
@@ -2098,6 +2108,11 @@ function checkResponseHeaders (context, schemaResponse, headers, transactionPath
         return;
       }
 
+      // If optional parameters are disabled, do not report them as missing
+      if (!enableOptionalParameters && header.required !== true) {
+        return;
+      }
+
       if (!_.find(resHeaders, (param) => { return param.key === header.name; })) {
 
         // assign parameter example(s) as schema examples;
@@ -2139,7 +2154,7 @@ function checkRequestBody (context, requestBody, transactionPathPrefix, schemaPa
   let jsonSchemaBody,
     jsonContentType,
     mismatchProperty = 'BODY',
-    { includeDeprecated } = context.computedOptions;
+    { includeDeprecated, enableOptionalParameters } = context.computedOptions;
 
   if (options.validationPropertiesToIgnore.includes(mismatchProperty)) {
     return callback(null, []);
@@ -2275,6 +2290,11 @@ function checkRequestBody (context, requestBody, transactionPathPrefix, schemaPa
 
       _.each(filteredSchemaParams, (uParam) => {
         if (uParam.deprecated && !includeDeprecated) {
+          return;
+        }
+
+        // If optional parameters are disabled, do not report them as missing
+        if (!enableOptionalParameters && uParam.required !== true) {
           return;
         }
 

--- a/test/data/disabled_param_url_encoded_body/urlencodedBodyCollectionDisabled.json
+++ b/test/data/disabled_param_url_encoded_body/urlencodedBodyCollectionDisabled.json
@@ -1,0 +1,319 @@
+{
+  "item": [
+    {
+      "name": "pets",
+      "description": "",
+      "item": [
+        {
+          "name": "{petId}",
+          "description": "",
+          "item": [
+            {
+              "id": "a42ce42e-522b-4fc7-b1b9-adedb686ab5b",
+              "name": "Updates a pet in the store with form data",
+              "request": {
+                "name": "Updates a pet in the store with form data",
+                "description": {},
+                "url": {
+                  "path": [
+                    "pets",
+                    ":petId"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variable": [
+                    {
+                      "type": "any",
+                      "value": "<string>",
+                      "key": "petId",
+                      "disabled": false
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/x-www-form-urlencoded"
+                  }
+                ],
+                "method": "POST",
+                "body": {
+                  "mode": "urlencoded",
+                  "urlencoded": [
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "",
+                        "type": "text/plain"
+                      },
+                      "key": "prop1dwawdawd",
+                      "value": "1234"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "",
+                        "type": "text/plain"
+                      },
+                      "key": "prop2",
+                      "value": "<string>"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "",
+                        "type": "text/plain"
+                      },
+                      "key": "propObjectNonExplodable",
+                      "value": "prop3,<string>,prop4,<string>"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "",
+                        "type": "text/plain"
+                      },
+                      "key": "propArray",
+                      "value": "<string>"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "",
+                        "type": "text/plain"
+                      },
+                      "key": "propArray",
+                      "value": "<string>"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "",
+                        "type": "text/plain"
+                      },
+                      "key": "propSimple",
+                      "value": "<integer>"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "",
+                        "type": "text/plain"
+                      },
+                      "key": "propDeepObject[id]",
+                      "value": "false"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "",
+                        "type": "text/plain"
+                      },
+                      "key": "propDeepObject[name]",
+                      "value": "<string>"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "",
+                        "type": "text/plain"
+                      },
+                      "key": "propDeepObject[address][city]",
+                      "value": "<string>"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "",
+                        "type": "text/plain"
+                      },
+                      "key": "propDeepObject[address][country]",
+                      "value": "<string>"
+                    },
+                    {
+                      "disabled": true,
+                      "key": "propArrayComplex",
+                      "value": "<Error: Not supported in OAS>"
+                    },
+                    {
+                      "disabled": true,
+                      "description": {
+                        "content": "This property is not available in matched collection.",
+                        "type": "text/plain"
+                      },
+                      "key": "propMissingInReq",
+                      "value": "<integer>"
+                    }
+                  ]
+                },
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "97737738-c691-4ad2-8a13-5e9ca6540a01",
+                  "name": "Pet updated.",
+                  "originalRequest": {
+                    "url": {
+                      "path": [
+                        "pets",
+                        ":petId"
+                      ],
+                      "host": [
+                        "{{baseUrl}}"
+                      ],
+                      "query": [],
+                      "variable": []
+                    },
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/x-www-form-urlencoded"
+                      }
+                    ],
+                    "method": "POST",
+                    "body": {
+                      "mode": "urlencoded",
+                      "urlencoded": [
+                        {
+                          "disabled": true,
+                          "description": {
+                            "content": "",
+                            "type": "text/plain"
+                          },
+                          "key": "prop1",
+                          "value": "<string>"
+                        },
+                        {
+                          "disabled": true,
+                          "description": {
+                            "content": "",
+                            "type": "text/plain"
+                          },
+                          "key": "prop2",
+                          "value": "<string>"
+                        },
+                        {
+                          "disabled": true,
+                          "description": {
+                            "content": "",
+                            "type": "text/plain"
+                          },
+                          "key": "propObjectNonExplodable",
+                          "value": "prop3,<string>,prop4,<string>"
+                        },
+                        {
+                          "disabled": true,
+                          "description": {
+                            "content": "",
+                            "type": "text/plain"
+                          },
+                          "key": "propArray",
+                          "value": "<string>"
+                        },
+                        {
+                          "disabled": true,
+                          "description": {
+                            "content": "",
+                            "type": "text/plain"
+                          },
+                          "key": "propArray",
+                          "value": "<string>"
+                        },
+                        {
+                          "disabled": true,
+                          "description": {
+                            "content": "",
+                            "type": "text/plain"
+                          },
+                          "key": "propSimple",
+                          "value": "<integer>"
+                        },
+                        {
+                          "disabled": true,
+                          "description": {
+                            "content": "",
+                            "type": "text/plain"
+                          },
+                          "key": "propDeepObject[id]",
+                          "value": "<integer>"
+                        },
+                        {
+                          "disabled": true,
+                          "description": {
+                            "content": "",
+                            "type": "text/plain"
+                          },
+                          "key": "propDeepObject[name]",
+                          "value": "<string>"
+                        },
+                        {
+                          "disabled": true,
+                          "description": {
+                            "content": "",
+                            "type": "text/plain"
+                          },
+                          "key": "propDeepObject[address][city]",
+                          "value": "<string>"
+                        },
+                        {
+                          "disabled": true,
+                          "description": {
+                            "content": "",
+                            "type": "text/plain"
+                          },
+                          "key": "propDeepObject[address][country]",
+                          "value": "<string>"
+                        },
+                        {
+                          "disabled": true,
+                          "key": "propArrayComplex",
+                          "value": "<Error: Not supported in OAS>"
+                        },
+                        {
+                          "disabled": true,
+                          "description": {
+                            "content": "This property is not available in matched collection.",
+                            "type": "text/plain"
+                          },
+                          "key": "propMissingInReq",
+                          "value": "<integer>"
+                        }
+                      ]
+                    }
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [],
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": [],
+              "protocolProfileBehavior": {
+                "disableBodyPruning": true
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "info": {
+    "_postman_id": "82b88ce4-5b4c-43e8-8734-ef45b6e80957",
+    "name": "Swagger Petstore",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "",
+      "type": "text/plain"
+    }
+  }
+}

--- a/test/data/disabled_query_param_test_data/collection_disabled.json
+++ b/test/data/disabled_query_param_test_data/collection_disabled.json
@@ -1,0 +1,301 @@
+{
+	"item": [
+	  {
+		"name": "spacecrafts",
+		"description": "",
+		"item": [
+		  {
+			"name": "{spacecraftId}",
+			"description": "",
+			"item": [
+			  {
+				"id": "897e61f4-677f-424c-b59e-c158c6f1168a",
+				"name": "Read a ssspacecraft",
+				"request": {
+				  "name": "Read a ssspacecraft",
+				  "description": {},
+				  "url": {
+					"path": [
+					  "spacecrafts",
+					  ":spacecraftId"
+					],
+					"host": [
+					  "{{baseUrl}}"
+					],
+					"query": [
+					  {
+						"disabled": true,
+						"description": {
+						  "content": "The unique identifier of the spacecraft",
+						  "type": "text/plain"
+						},
+						"key": "changedddd",
+						"value": "<string>"
+					  }
+					],
+					"variable": [
+					  {
+						"type": "any",
+						"value": "<string>",
+						"key": "spacecraftId",
+						"disabled": false
+					  }
+					]
+				  },
+				  "header": [
+					{
+					  "disabled": true,
+					  "description": {
+						"content": "The unisssque identifier of the spacecraft",
+						"type": "text/plain"
+					  },
+					  "key": "h1",
+					  "value": "<string>"
+					},
+					{
+					  "key": "Accept",
+					  "value": "application/json"
+					}
+				  ],
+				  "method": "GET",
+				  "body": {},
+				  "auth": null
+				},
+				"response": [
+				  {
+					"id": "1f74e033-291b-4d36-9508-ea55e468ff84",
+					"name": "The spacecraft corresponding to the provided `spacecraftId`",
+					"originalRequest": {
+					  "url": {
+						"path": [
+						  "spacecrafts",
+						  ":spacecraftId"
+						],
+						"host": [
+						  "{{baseUrl}}"
+						],
+						"query": [
+						  {
+							"disabled": true,
+							"description": {
+							  "content": "The unique identifier of the spacecraft",
+							  "type": "text/plain"
+							},
+							"key": "changed",
+							"value": "<string>"
+						  }
+						],
+						"variable": []
+					  },
+					  "header": [
+						{
+						  "disabled": true,
+						  "description": {
+							"content": "The unisssque identifier of the spacecraft",
+							"type": "text/plain"
+						  },
+						  "key": "h1",
+						  "value": "<string>"
+						},
+						{
+						  "key": "Accept",
+						  "value": "application/json"
+						},
+						{
+						  "description": {
+							"content": "Added as a part of security scheme: apikey",
+							"type": "text/plain"
+						  },
+						  "key": "X-Api-Key",
+						  "value": "<API Key>"
+						}
+					  ],
+					  "method": "GET",
+					  "body": {}
+					},
+					"status": "OK",
+					"code": 200,
+					"header": [
+					  {
+						"key": "Content-Type",
+						"value": "application/json"
+					  }
+					],
+					"body": "{\n  \"id\": \"<string>\",\n  \"name\": \"<string>\",\n  \"type\": \"spaceplane\",\n  \"description\": \"<string>\"\n}",
+					"cookie": [],
+					"_postman_previewlanguage": "json"
+				  },
+				  {
+					"id": "e3041437-4a32-4837-9984-f1f38cfe064f",
+					"name": "No spacecraft found for the provided `spacecraftId`",
+					"originalRequest": {
+					  "url": {
+						"path": [
+						  "spacecrafts",
+						  ":spacecraftId"
+						],
+						"host": [
+						  "{{baseUrl}}"
+						],
+						"query": [
+						  {
+							"disabled": true,
+							"description": {
+							  "content": "The unique identifier of the spacecraft",
+							  "type": "text/plain"
+							},
+							"key": "changed",
+							"value": "<string>"
+						  }
+						],
+						"variable": []
+					  },
+					  "header": [
+						{
+						  "disabled": true,
+						  "description": {
+							"content": "The unisssque identifier of the spacecraft",
+							"type": "text/plain"
+						  },
+						  "key": "h1",
+						  "value": "<string>"
+						},
+						{
+						  "key": "Accept",
+						  "value": "application/json"
+						},
+						{
+						  "description": {
+							"content": "Added as a part of security scheme: apikey",
+							"type": "text/plain"
+						  },
+						  "key": "X-Api-Key",
+						  "value": "<API Key>"
+						}
+					  ],
+					  "method": "GET",
+					  "body": {}
+					},
+					"status": "Not Found",
+					"code": 404,
+					"header": [
+					  {
+						"key": "Content-Type",
+						"value": "application/json"
+					  }
+					],
+					"body": "{\n  \"message\": \"<string>\"\n}",
+					"cookie": [],
+					"_postman_previewlanguage": "json"
+				  },
+				  {
+					"id": "820635ba-f0dc-46b5-8d4b-8bdacd2815a9",
+					"name": "Unexpected error",
+					"originalRequest": {
+					  "url": {
+						"path": [
+						  "spacecrafts",
+						  ":spacecraftId"
+						],
+						"host": [
+						  "{{baseUrl}}"
+						],
+						"query": [
+						  {
+							"disabled": true,
+							"description": {
+							  "content": "The unique identifier of the spacecraft",
+							  "type": "text/plain"
+							},
+							"key": "changed",
+							"value": "<string>"
+						  }
+						],
+						"variable": []
+					  },
+					  "header": [
+						{
+						  "disabled": true,
+						  "description": {
+							"content": "The unisssque identifier of the spacecraft",
+							"type": "text/plain"
+						  },
+						  "key": "h1",
+						  "value": "<string>"
+						},
+						{
+						  "key": "Accept",
+						  "value": "application/json"
+						},
+						{
+						  "description": {
+							"content": "Added as a part of security scheme: apikey",
+							"type": "text/plain"
+						  },
+						  "key": "X-Api-Key",
+						  "value": "<API Key>"
+						}
+					  ],
+					  "method": "GET",
+					  "body": {}
+					},
+					"status": "Internal Server Error",
+					"code": 500,
+					"header": [
+					  {
+						"key": "Content-Type",
+						"value": "application/json"
+					  }
+					],
+					"body": "{\n  \"message\": \"<string>\"\n}",
+					"cookie": [],
+					"_postman_previewlanguage": "json"
+				  }
+				],
+				"event": [],
+				"protocolProfileBehavior": {
+				  "disableBodyPruning": true
+				}
+			  }
+			]
+		  }
+		]
+	  }
+	],
+	"auth": {
+	  "type": "apikey",
+	  "apikey": [
+		{
+		  "type": "any",
+		  "value": "X-Api-Key",
+		  "key": "key"
+		},
+		{
+		  "type": "any",
+		  "value": "{{apiKey}}",
+		  "key": "value"
+		},
+		{
+		  "type": "any",
+		  "value": "header",
+		  "key": "in"
+		}
+	  ]
+	},
+	"event": [],
+	"variable": [
+	  {
+		"key": "baseUrl",
+		"value": "/"
+	  }
+	],
+	"info": {
+	  "_postman_id": "b9a55300-d719-4d4c-8647-d48738dd544d",
+	  "name": "Sample API",
+	  "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+	  "description": {
+		"content": "Buy or rent spacecrafts",
+		"type": "text/plain"
+	  }
+	}
+  }

--- a/test/unit/ValidateV2.test.js
+++ b/test/unit/ValidateV2.test.js
@@ -1804,6 +1804,38 @@ describe('Bug fixes', function () {
     });
   });
 
+  it('should not validate non required paramters when option enableOptionalParameters=false', function (done) {
+    let collectionPath = path.join(__dirname, '../data/disabled_query_param_test_data/collection_disabled.json'),
+      specPath = path.join(__dirname, '../data/disabled_query_param_test_data/spec.json'),
+      collectionData = JSON.parse(fs.readFileSync(collectionPath, 'utf8')),
+      spec = fs.readFileSync(specPath, 'utf8'),
+      schemaPack = new Converter.SchemaPack({ type: 'string', data: spec }, {
+        strictRequestMatching: true,
+        detailedBlobValidation: true,
+        suggestAvailableFixes: true,
+        ignoreUnresolvedVariables: true,
+        showMissingInSchemaErrors: true,
+        validateMetadata: true,
+        parametersResolution: 'Example',
+        enableOptionalParameters: false
+      }),
+      requests = [];
+
+    getAllTransactionsInjectingId(collectionData, requests);
+
+    schemaPack.validateTransactionV2(requests, (err, result) => {
+      expect(err).to.be.null;
+      expect(result).to.be.an('object');
+
+      // check for result.requests structure
+      const requestId = Object.keys(result.requests)[0],
+        mismatches = _.get(result, ['requests', requestId, 'endpoints', '0', 'mismatches']);
+
+      expect(mismatches).to.have.lengthOf(0);
+      return done();
+    });
+  });
+
   it('should validate non required parameters in url encoded body', function (done) {
     let collectionPath = path.join(__dirname, '../data/disabled_param_url_encoded_body/urlencodedBodyCollection.json'),
       specPath = path.join(__dirname, '../data/disabled_param_url_encoded_body/urlencodedBodySpec.yaml'),
@@ -1841,4 +1873,38 @@ describe('Bug fixes', function () {
       return done();
     });
   });
+
+  it('should not validate non required parameters when option enableOptionalParameters=false in url encoded body',
+    function (done) {
+      let collectionPath = path.join(__dirname,
+          '../data/disabled_param_url_encoded_body/urlencodedBodyCollectionDisabled.json'),
+        specPath = path.join(__dirname, '../data/disabled_param_url_encoded_body/urlencodedBodySpec.yaml'),
+        collectionData = JSON.parse(fs.readFileSync(collectionPath, 'utf8')),
+        spec = fs.readFileSync(specPath, 'utf8'),
+        schemaPack = new Converter.SchemaPack({ type: 'string', data: spec }, {
+          strictRequestMatching: true,
+          detailedBlobValidation: true,
+          suggestAvailableFixes: true,
+          ignoreUnresolvedVariables: true,
+          showMissingInSchemaErrors: true,
+          validateMetadata: true,
+          parametersResolution: 'Example',
+          enableOptionalParameters: false
+        }),
+        requests = [];
+
+      getAllTransactions(collectionData, requests);
+
+      schemaPack.validateTransactionV2(requests, (err, result) => {
+        expect(err).to.be.null;
+        expect(result).to.be.an('object');
+
+        // check for result.requests structure
+        const requestId = Object.keys(result.requests)[0],
+          mismatches = _.get(result, ['requests', requestId, 'endpoints', '0', 'mismatches']);
+
+        expect(mismatches).to.have.lengthOf(0);
+        return done();
+      });
+    });
 });

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -841,6 +841,7 @@ describe('The convert v2 Function', function() {
             {
               key: 'access_token',
               value: 'X-access-token',
+              disabled: false,
               description: {
                 content: 'Access token',
                 type: 'text/plain'
@@ -947,18 +948,18 @@ describe('The convert v2 Function', function() {
   });
 
   // Handle optional parameters to be made disabled
-  it.skip('[Github #31] & [GitHub #337] - should set optional params as disabled', function(done) {
+  it('[Github #31] & [GitHub #337] - should set optional params as disabled', function(done) {
     let options = { schemaFaker: true, enableOptionalParameters: false };
     Converter.convertV2({ type: 'file', data: requiredInParams }, options, (err, conversionResult) => {
       expect(err).to.be.null;
-      let requests = conversionResult.output[0].data.item,
+      let requests = conversionResult.output[0].data.item[0].item,
         request,
         urlencodedBody;
 
       // GET /pets
       // query1 required, query2 optional
       // header1 required, header2 optional
-      request = requests[0].request;
+      request = requests[1].request;
       expect(request.url.query[0].disabled).to.be.false;
       expect(request.url.query[1].disabled).to.be.true;
       expect(request.header[0].disabled).to.be.false;
@@ -966,7 +967,7 @@ describe('The convert v2 Function', function() {
 
       // POST /pets
       // urlencoded body
-      urlencodedBody = requests[2].request.body.urlencoded;
+      urlencodedBody = requests[3].request.body.urlencoded;
       expect(urlencodedBody[0].key).to.eql('urlencodedParam1');
       expect(urlencodedBody[0].disabled).to.be.false;
       expect(urlencodedBody[1].key).to.eql('urlencodedParam2');

--- a/test/unit/validationJourney.test.js
+++ b/test/unit/validationJourney.test.js
@@ -101,7 +101,8 @@ describe('validateTransactionV2() should be able to validate collections generat
           ignoreUnresolvedVariables: true,
           validateMetadata: true,
           suggestAvailableFixes: true,
-          detailedBlobValidation: false
+          detailedBlobValidation: false,
+          enableOptionalParameters: false
         },
         // Different schemaPack instances are used as conversion resolves schema differently then validation
         schemaPackConversion = new Converter.SchemaPack({ type: 'string', data: fileData }, options, MODULE_VERSION.V2),


### PR DESCRIPTION
## Overview

This PR adds support for option `enableOptionalParameters` in `convertV2` and `validateTransactionV2` interfaces. As reported by users here https://github.com/postmanlabs/openapi-to-postman/issues/31#issuecomment-1481258315, we did not add this option with v2 interface.

## Solution

We'll now be marking all optional params as disabled if option `enableOptionalParameters` is provided as `false`. (Default value for it is `true`).

We'll also be making sure to not report such params as missing in validation flow given option is `false`.

## Track

https://go.postman-beta.co?_track=br-feature-IMPORT-227

Both conversion and validation can be checked on this branch.