### PR TITLE
Removed unnecessary options merging with each util function.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2283,7 +2283,7 @@ module.exports = {
     }
 
     if (seenRef[$ref]) {
-      return { value: `<Error: "${$ref}" contains circular references in it.` };
+      return { value: `Error: "${$ref}" contains circular references in it.` };
     }
 
     savedSchema = $ref.split('/').slice(1).map((elem) => {

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -16,7 +16,6 @@ const { formatDataPath, checkIsCorrectType, isKnownType } = require('./common/sc
   openApiErr = require('./error.js'),
   ajvValidationError = require('./ajValidation/ajvValidationError'),
   utils = require('./utils.js'),
-  defaultOptions = require('../lib/options.js').getOptions('use'),
   { Node, Trie } = require('./trie.js'),
   { validateSchema } = require('./ajValidation/ajvValidation'),
   inputValidation = require('./30XUtils/inputValidation'),
@@ -523,7 +522,6 @@ module.exports = {
    * @returns {*} combined requestParams from operation and path params.
    */
   getRequestParams: function(operationParam, pathParam, components, options) {
-    options = _.merge({}, defaultOptions, options);
     if (!Array.isArray(operationParam)) {
       operationParam = [];
     }
@@ -579,7 +577,6 @@ module.exports = {
    * @returns {Object} - The final object consists of the tree structure
    */
   generateTrieFromPaths: function (spec, options, fromWebhooks = false) {
-    options = _.merge({}, defaultOptions, options);
     let concreteUtils = getConcreteSchemaUtils({ type: 'json', data: spec }),
       specComponentsAndUtils = {
         concreteUtils
@@ -981,8 +978,6 @@ module.exports = {
    * @returns {Array<object>} returns an array of sdk.Variable
    */
   convertPathVariables: function(type, providedPathVars, commonPathVars, components, options, schemaCache) {
-    options = _.merge({}, defaultOptions, options);
-
     var variables = [];
     // converting the base uri path variables, if any
     // commonPathVars is an object for type = root/method
@@ -1036,7 +1031,6 @@ module.exports = {
    */
   convertChildToItemGroup: function (openapi, child, components, options,
     schemaCache, variableStore, fromWebhooks = false) {
-    options = _.merge({}, defaultOptions, options);
 
     var resource = child,
       itemGroup,
@@ -1398,8 +1392,6 @@ module.exports = {
    * @return {object} responseBody, contentType header needed
    */
   convertToPmResponseBody: function(contentObj, components, options, schemaCache) {
-    options = _.merge({}, defaultOptions, options);
-
     var responseBody, cTypeHeader, hasComputedType, cTypes,
       isJsonLike = false;
     if (!contentObj) {
@@ -1512,8 +1504,6 @@ module.exports = {
    * @returns {*} first example in the input map type
    */
   getExampleData: function(exampleObj, components, options) {
-    options = _.merge({}, defaultOptions, options);
-
     var example,
       exampleKey;
 
@@ -1556,7 +1546,6 @@ module.exports = {
   convertToPmBodyData: function(bodyObj, requestType, contentType, parameterSourceOption,
     indentCharacter, components, options, schemaCache) {
 
-    options = _.merge({}, defaultOptions, options);
     var bodyData = '',
       schemaFormat = SCHEMA_FORMATS.DEFAULT,
       schemaType,
@@ -1672,7 +1661,6 @@ module.exports = {
    * @returns {array} converted queryparam
    */
   convertToPmQueryParameters: function(param, requestType, components, options, schemaCache) {
-    options = _.merge({}, defaultOptions, options);
     var pmParams = [],
       paramValue,
       resolveTo = this.resolveToExampleOrSchema(requestType, options.requestParametersResolution,
@@ -1848,8 +1836,6 @@ module.exports = {
    * @returns {Object} instance of a Postman SDK Header
    */
   convertToPmHeader: function(header, requestType, parameterSource, components, options, schemaCache) {
-    options = _.merge({}, defaultOptions, options);
-
     var fakeData,
       convertedHeader,
       reqHeader,
@@ -1891,7 +1877,6 @@ module.exports = {
    * @returns {Object} - Postman requestBody and Content-Type Header
    */
   convertToPmBody: function(requestBody, requestType, components, options, schemaCache) {
-    options = _.merge({}, defaultOptions, options);
     var contentObj, // content is required
       bodyData,
       param,
@@ -2175,7 +2160,6 @@ module.exports = {
    * @returns {Object} postman response
    */
   convertToPmResponse: function(response, code, originalRequest, components, options, schemaCache) {
-    options = _.merge({}, defaultOptions, options);
     var responseHeaders = [],
       previewLanguage = 'text',
       responseBodyWrapper,
@@ -2291,7 +2275,6 @@ module.exports = {
    * @no-unit-tests
    */
   getRefObject: function($ref, components, options) {
-    options = _.merge({}, defaultOptions, options);
     var refObj, savedSchema;
 
     if (typeof $ref !== 'string') {
@@ -2461,7 +2444,6 @@ module.exports = {
   */
   convertRequestToItem: function(openapi, operationItem, components,
     options, schemaCache, variableStore, fromWebhooks = false) {
-    options = _.merge({}, defaultOptions, options);
     var reqName,
       pathVariables = openapi.baseUrlVariables,
       operation = operationItem.properties,
@@ -2825,7 +2807,6 @@ module.exports = {
   * @returns {*} array of all query params
   */
   convertToPmQueryArray: function(reqParams, requestType, components, options, schemaCache) {
-    options = _.merge({}, defaultOptions, options);
     let requestQueryParams = [];
     _.forEach(reqParams.query, (queryParam) => {
       this.convertToPmQueryParameters(queryParam, requestType, components, options, schemaCache).forEach((pmParam) => {

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2271,14 +2271,19 @@ module.exports = {
    * @param {object} components - components defined in the OAS spec. These are used to
    * resolve references while generating params.
    * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
+   * @param {*} seenRef - References that are repeated. Used to identify circular references.
    * @returns {Object} reference object from the saved components
    * @no-unit-tests
    */
-  getRefObject: function($ref, components, options) {
+  getRefObject: function($ref, components, options, seenRef = {}) {
     var refObj, savedSchema;
 
     if (typeof $ref !== 'string') {
       return { value: `Invalid $ref: ${$ref} was found` };
+    }
+
+    if (seenRef[$ref]) {
+      return { value: `<Error: "${$ref}" contains circular references in it.` };
     }
 
     savedSchema = $ref.split('/').slice(1).map((elem) => {
@@ -2311,9 +2316,15 @@ module.exports = {
       return { value: `reference ${$ref} not found in the given specification` };
     }
 
+    // Mark current $ref as seen while processing it further
+    seenRef[$ref] = true;
+
     if (refObj.$ref) {
-      return this.getRefObject(refObj.$ref, components, options);
+      return this.getRefObject(refObj.$ref, components, options, seenRef);
     }
+
+    // Unmark current $ref once resolved
+    seenRef[$ref] = false;
 
     return refObj;
   },

--- a/test/data/valid_openapi/recursiveRefComponents.yaml
+++ b/test/data/valid_openapi/recursiveRefComponents.yaml
@@ -1,0 +1,35 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - $ref: "#/components/parameters/rec-param"
+      responses:
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        default:
+          $ref: "#/components/responses/paramA"
+components:
+  parameters:
+    rec-param:
+      $ref: "#/components/parameters/rec-param"
+  responses:
+    Unauthorized:
+      $ref: "#/components/responses/Unauthorized"
+    paramA:
+      $ref: "#/components/responses/paramB"
+    paramB:
+      $ref: "#/components/responses/paramC"
+    paramC:
+      $ref: "#/components/responses/paramA"

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -92,7 +92,9 @@ describe('CONVERT FUNCTION TESTS ', function() {
       specWithNullParams =
         path.join(__dirname, VALID_OPENAPI_PATH, '/specWithNullParams.yaml'),
       acceptHeaderExample =
-        path.join(__dirname, VALID_OPENAPI_PATH, '/acceptHeaderExample.json');
+        path.join(__dirname, VALID_OPENAPI_PATH, '/acceptHeaderExample.json'),
+      recursiveRefComponents =
+        path.join(__dirname, VALID_OPENAPI_PATH, '/recursiveRefComponents.yaml');
 
 
     it('Should add collection level auth with type as `bearer`' +
@@ -1885,6 +1887,35 @@ describe('CONVERT FUNCTION TESTS ', function() {
           expect(item2.response[1].originalRequest.header.length).to.eql(2);
           expect(item2.response[1].originalRequest.header[0].key).to.eql('x-hello');
           expect(item2.response[1].originalRequest.header[1]).to.eql(acceptHeader);
+          done();
+        });
+    });
+
+    it('Should handle recursive references for non-schema $refs correctly', function(done) {
+      var openapi = fs.readFileSync(recursiveRefComponents, 'utf8');
+      Converter.convert({ type: 'string', data: openapi }, {},
+        (err, conversionResult) => {
+          expect(err).to.be.null;
+          expect(conversionResult.result).to.equal(true);
+          expect(conversionResult.output.length).to.equal(1);
+          expect(conversionResult.output[0].type).to.equal('collection');
+          expect(conversionResult.output[0].data).to.have.property('info');
+          expect(conversionResult.output[0].data).to.have.property('item');
+          expect(conversionResult.output[0].data.item.length).to.equal(1);
+
+          const item = conversionResult.output[0].data.item[0];
+
+          expect(item.request.header).to.be.undefined;
+          expect(item.request.url.query).to.be.empty;
+          expect(item.response.length).to.eql(2);
+          expect(item.response[0].header.length).to.eql(1);
+          expect(item.response[0].header[0].key).to.eql('Content-Type');
+          expect(item.response[0].header[0].value).to.eql('text/plain');
+          expect(item.response[0].body).to.be.empty;
+          expect(item.response[1].header.length).to.eql(1);
+          expect(item.response[1].header[0].key).to.eql('Content-Type');
+          expect(item.response[1].header[0].value).to.eql('text/plain');
+          expect(item.response[1].body).to.be.empty;
           done();
         });
     });

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -740,7 +740,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
               format: 'int32'
             }
           }
-        ]
+        ],
+        {}, {}, {}
       );
       expect(retVal).to.be.an('array');
       expect(retVal[0].key).to.equal('varName');
@@ -752,7 +753,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
   describe('convertToPmBodyData', function() {
     it('should not fail when bodyObj is not defined', function() {
       var bodyWithSchema,
-        retValSchema = SchemaUtils.convertToPmBodyData(bodyWithSchema, 'ROOT', 'application/json');
+        retValSchema = SchemaUtils.convertToPmBodyData(bodyWithSchema, 'ROOT', 'application/json',
+          'REQUEST', 'tab', {}, {}, {});
 
       expect(retValSchema).to.be.equal('');
     });
@@ -764,7 +766,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             format: 'int32'
           }
         },
-        retValSchema = SchemaUtils.convertToPmBodyData(bodyWithSchema, 'ROOT', 'application/json');
+        retValSchema = SchemaUtils.convertToPmBodyData(bodyWithSchema, 'ROOT', 'application/json',
+          'REQUEST', 'tab', {}, { schemaFaker: true }, {});
 
       expect(retValSchema).to.be.equal('<integer>');
     });
@@ -773,7 +776,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
       var bodyWithExample = {
           example: 'This is a sample value'
         },
-        retValExample = SchemaUtils.convertToPmBodyData(bodyWithExample, 'application/json');
+        retValExample = SchemaUtils.convertToPmBodyData(bodyWithExample, 'ROOT', 'application/json',
+          'REQUEST', 'tab', {}, {}, {});
 
       expect(retValExample).to.equal('This is a sample value');
     });
@@ -784,7 +788,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             value: 'This is a sample value'
           }
         },
-        retValExample = SchemaUtils.convertToPmBodyData(bodyWithExample, 'application/json');
+        retValExample = SchemaUtils.convertToPmBodyData(bodyWithExample, 'ROOT', 'application/json',
+          'REQUEST', 'tab', {}, {}, {});
 
       expect(retValExample.value).to.equal('This is a sample value');
     });
@@ -861,7 +866,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           format: 'int64'
         }
       };
-      let pmHeader = SchemaUtils.convertToPmHeader(header);
+      let pmHeader = SchemaUtils.convertToPmHeader(header, 'ROOT', 'REQUEST', {}, {}, {});
       expect(pmHeader.key).to.equal(header.name);
       expect(pmHeader.description).to.equal(header.description);
       expect(typeof pmHeader.value).to.equal('string');// because schema v2.1.0 supports only string value.
@@ -873,7 +878,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         in: 'header',
         description: 'Header1'
       };
-      let pmHeader = SchemaUtils.convertToPmHeader(header);
+      let pmHeader = SchemaUtils.convertToPmHeader(header, 'ROOT', 'REQUEST', {}, {}, {});
       expect(pmHeader.key).to.equal(header.name);
       expect(pmHeader.description).to.equal(header.description);
       expect(pmHeader.value).to.equal('');
@@ -890,7 +895,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           default: 'Bearer'
         }
       };
-      let pmHeader = SchemaUtils.convertToPmHeader(header);
+      let pmHeader = SchemaUtils.convertToPmHeader(header, 'ROOT', 'REQUEST', {}, { schemaFaker: true }, {});
       expect(pmHeader.key).to.equal('Authorization');
       expect(pmHeader.value).to.equal('Bearer'); // not \"Bearer\"
       done();
@@ -1121,7 +1126,9 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
   describe('convertToPmQueryParameters ', function() {
     it('Should convert undefined queryParam to pm param', function (done) {
       var param;
-      let pmParam = SchemaUtils.convertToPmQueryParameters(param);
+      let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
+        schemaFaker: true
+      });
       expect(pmParam.length).to.equal(0);
       done();
     });
@@ -1131,7 +1138,9 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         in: 'query',
         description: 'query param'
       };
-      let pmParam = SchemaUtils.convertToPmQueryParameters(param);
+      let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
+        schemaFaker: true
+      });
       expect(pmParam[0].key).to.equal(param.name);
       expect(pmParam[0].description).to.equal(param.description);
       expect(pmParam[0].value).to.equal('');
@@ -1147,7 +1156,9 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           default: 10
         }
       };
-      let pmParam = SchemaUtils.convertToPmQueryParameters(param);
+      let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
+        schemaFaker: true
+      });
       expect(pmParam[0].value).to.equal('10'); // '10', not 10
       done();
     });
@@ -1161,7 +1172,9 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           default: true
         }
       };
-      let pmParam = SchemaUtils.convertToPmQueryParameters(param);
+      let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
+        schemaFaker: true
+      });
       expect(pmParam[0].value).to.equal('true'); // 'true', not true
       done();
     });
@@ -1183,14 +1196,16 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           };
           it('schemaFaker = true', function (done) {
-            let pmParam = SchemaUtils.convertToPmQueryParameters(param);
+            let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
+              schemaFaker: true
+            });
             expect(pmParam[0].key).to.equal(param.name);
             expect(pmParam[0].description).to.equal(param.description);
             expect(pmParam[0].value).to.equal('<long>');
             done();
           });
           it('schemaFaker = false', function (done) {
-            let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'root', null, { schemaFaker: false });
+            let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', null, { schemaFaker: false });
             expect(pmParam[0].key).to.equal(param.name);
             expect(pmParam[0].description).to.equal(param.description);
             expect(pmParam[0].value).to.equal('');
@@ -1213,14 +1228,16 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           };
           it('schemaFaker = true', function (done) {
-            let pmParam = SchemaUtils.convertToPmQueryParameters(param);
+            let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
+              schemaFaker: true
+            });
             expect(pmParam[0].key).to.equal(param.name);
             expect(pmParam[0].description).to.equal(param.description);
             expect(pmParam[0].value).to.have.string(',');
             done();
           });
           it('schemaFaker = false', function (done) {
-            let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'root', null, { schemaFaker: false });
+            let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', null, { schemaFaker: false });
             expect(pmParam[0].key).to.equal(param.name);
             expect(pmParam[0].description).to.equal(param.description);
             expect(pmParam[0].value).to.have.string('');
@@ -1242,14 +1259,16 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           }
         };
         it('schemaFaker = true', function (done) {
-          let pmParam = SchemaUtils.convertToPmQueryParameters(param);
+          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
+            schemaFaker: true
+          });
           expect(pmParam[0].key).to.equal(param.name);
           expect(pmParam[0].description).to.equal(param.description);
           expect(pmParam[0].value).to.have.string('%20');
           done();
         });
         it('schemaFaker = false', function (done) {
-          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'request', null, {
+          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', null, {
             schemaFaker: false
           });
           expect(pmParam[0].key).to.equal(param.name);
@@ -1272,14 +1291,16 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           }
         };
         it('schemaFaker = true', function (done) {
-          let pmParam = SchemaUtils.convertToPmQueryParameters(param);
+          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
+            schemaFaker: true
+          });
           expect(pmParam[0].key).to.equal(param.name);
           expect(pmParam[0].description).to.equal(param.description);
           expect(pmParam[0].value).to.have.string('|');
           done();
         });
         it('schemaFaker = false', function (done) {
-          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'request', {}, {
+          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
             schemaFaker: false
           });
           expect(pmParam[0].key).to.equal(param.name);
@@ -1304,7 +1325,9 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           }
         };
         it('schemaFaker = true', function (done) {
-          let pmParam = SchemaUtils.convertToPmQueryParameters(param);
+          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
+            schemaFaker: true
+          });
           expect(pmParam[0].key).to.equal(param.name + '[R]');
           expect(pmParam[1].key).to.equal(param.name + '[G]');
           expect(pmParam[2].key).to.equal(param.name + '[B]');
@@ -1312,7 +1335,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           done();
         });
         it('schemaFaker = false', function (done) {
-          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'request', {}, {
+          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
             schemaFaker: false
           });
           expect(pmParam).to.eql([]);
@@ -1333,14 +1356,16 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           }
         };
         it('schemaFaker = true', function (done) {
-          let pmParam = SchemaUtils.convertToPmQueryParameters(param);
+          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
+            schemaFaker: true
+          });
           expect(pmParam[0].key).to.equal(param.name);
           expect(pmParam[0].description).to.equal(param.description);
           expect(pmParam[0].value).to.have.string(',');
           done();
         });
         it('schemaFaker = false', function (done) {
-          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'request', {}, {
+          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
             schemaFaker: false
           });
           expect(pmParam[0].key).to.equal(param.name);
@@ -1377,7 +1402,9 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           };
           it('schemaFaker = true', function (done) {
-            let pmParam = SchemaUtils.convertToPmQueryParameters(param);
+            let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
+              schemaFaker: true
+            });
             expect(pmParam[0].key).to.equal('id');
             expect(pmParam[1].key).to.equal('name');
             expect(pmParam[0].description).to.equal(param.description);
@@ -1387,7 +1414,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             done();
           });
           it('schemaFaker = false', function (done) {
-            let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'request', {}, {
+            let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
               schemaFaker: false
             });
             expect(pmParam[0].key).to.equal(param.name);
@@ -1421,7 +1448,9 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           };
           it('schemaFaker = true', function (done) {
-            let pmParam = SchemaUtils.convertToPmQueryParameters(param);
+            let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
+              schemaFaker: true
+            });
             expect(pmParam[0].key).to.equal(param.name);
             expect(pmParam[0].description).to.equal(param.description);
             expect(pmParam[0].value).to.have.string('id');
@@ -1429,7 +1458,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             done();
           });
           it('schemaFaker = false', function (done) {
-            let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'request', {}, {
+            let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
               schemaFaker: false
             });
             expect(pmParam[0].key).to.equal(param.name);
@@ -1464,14 +1493,16 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           }
         };
         it('schemaFaker = true', function (done) {
-          let pmParam = SchemaUtils.convertToPmQueryParameters(param);
+          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
+            schemaFaker: true
+          });
           expect(pmParam[0].key).to.equal(param.name);
           expect(pmParam[0].description).to.equal(param.description);
           expect(pmParam[0].value).to.have.string('%20');
           done();
         });
         it('schemaFaker = false', function (done) {
-          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'request', {}, {
+          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
             schemaFaker: false
           });
           expect(pmParam[0].key).to.equal(param.name);
@@ -1505,14 +1536,16 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           }
         };
         it('schemaFaker = true', function (done) {
-          let pmParam = SchemaUtils.convertToPmQueryParameters(param);
+          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
+            schemaFaker: true
+          });
           expect(pmParam[0].key).to.equal(param.name);
           expect(pmParam[0].description).to.equal(param.description);
           expect(pmParam[0].value).to.have.string('|');
           done();
         });
         it('schemaFaker = false', function (done) {
-          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'request', {}, {
+          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
             schemaFaker: false
           });
           expect(pmParam[0].key).to.equal(param.name);
@@ -1553,7 +1586,9 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           }
         };
         it('schemaFaker = true', function (done) {
-          let pmParam = SchemaUtils.convertToPmQueryParameters(param);
+          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
+            schemaFaker: true
+          });
           expect(pmParam).to.have.lengthOf(5);
           expect(pmParam[0].key).to.equal(param.name + '[id]');
           expect(pmParam[1].key).to.equal(param.name + '[name]');
@@ -1571,7 +1606,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           done();
         });
         it('schemaFaker = false', function (done) {
-          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'request', {}, {
+          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
             schemaFaker: false
           });
           expect(pmParam).to.eql([]);
@@ -1602,14 +1637,16 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           }
         };
         it('schemaFaker = true', function (done) {
-          let pmParam = SchemaUtils.convertToPmQueryParameters(param);
+          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
+            schemaFaker: true
+          });
           expect(pmParam[0].key).to.equal(param.name);
           expect(pmParam[0].description).to.equal(param.description);
           expect(typeof pmParam[0].value).to.equal('string');
           done();
         });
         it('schemaFaker = false', function (done) {
-          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'request', {}, {
+          let pmParam = SchemaUtils.convertToPmQueryParameters(param, 'ROOT', {}, {
             schemaFaker: false
           });
           expect(pmParam[0].key).to.equal(param.name);
@@ -1629,13 +1666,15 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
       };
 
       it('style:deepObject } to pm param', function (done) {
-        let pmParam = SchemaUtils.convertToPmQueryParameters(_.assign(emptyObjParam, { style: 'deepObject' }));
+        let pmParam = SchemaUtils.convertToPmQueryParameters(_.assign(emptyObjParam, { style: 'deepObject' }), 'ROOT',
+          {}, { schemaFaker: true });
         expect(pmParam).to.eql([]);
         done();
       });
 
       it('style:form } to pm param', function (done) {
-        let pmParam = SchemaUtils.convertToPmQueryParameters(_.assign(emptyObjParam, { style: 'form' }));
+        let pmParam = SchemaUtils.convertToPmQueryParameters(_.assign(emptyObjParam, { style: 'form' }), 'ROOT',
+          {}, { schemaFaker: true });
         expect(pmParam).to.eql([]);
         done();
       });
@@ -1675,7 +1714,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             },
             result, resultBody;
           result = SchemaUtils.convertToPmBody(requestBody, 'EXAMPLE', {}, {
-            exampleParametersResolution: 'example'
+            exampleParametersResolution: 'example',
+            schemaFaker: true
           });
           resultBody = JSON.parse(result.body.raw);
           expect(resultBody.id).to.be.a('number');
@@ -1727,7 +1767,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             },
             result, resultBody;
           result = SchemaUtils.convertToPmBody(requestBody, 'EXAMPLE', {}, {
-            exampleParametersResolution: 'example'
+            exampleParametersResolution: 'example',
+            schemaFaker: true
           });
           resultBody = (result.body.formdata.toJSON());
           expect(resultBody[0].key).to.equal('file');
@@ -1854,7 +1895,10 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           result, resultBody;
-        result = SchemaUtils.convertToPmBody(requestBody);
+        result = SchemaUtils.convertToPmBody(requestBody, 'EXAMPLE', {}, {
+          exampleParametersResolution: 'schema',
+          schemaFaker: true
+        });
         resultBody = JSON.parse(result.body.raw);
         expect(resultBody.id).to.equal('<long>');
         expect(resultBody.name).to.equal('<string>');
@@ -1872,7 +1916,9 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           result, resultBody;
-        result = SchemaUtils.convertToPmBody(requestBody);
+        result = SchemaUtils.convertToPmBody(requestBody, 'EXAMPLE', {}, {
+          exampleParametersResolution: 'example'
+        });
         resultBody = (result.body.urlencoded.toJSON());
         expect(resultBody).to.eql([]);
         expect(result.contentHeader).to.deep.include(
@@ -1909,7 +1955,10 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           result, resultBody;
-        result = SchemaUtils.convertToPmBody(requestBody);
+        result = SchemaUtils.convertToPmBody(requestBody, 'EXAMPLE', {}, {
+          exampleParametersResolution: 'example',
+          schemaFaker: true
+        });
         resultBody = (result.body.formdata.toJSON());
         expect(resultBody[0].key).to.equal('array');
         expect(resultBody[1].key).to.equal('file');
@@ -1934,7 +1983,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           result, resultBody;
-        result = SchemaUtils.convertToPmBody(requestBody, 'ROOT', {}, {
+        result = SchemaUtils.convertToPmBody(requestBody, 'EXAMPLE', {}, {
           requestParametersResolution: 'example'
         });
         resultBody = (result.body.raw);
@@ -1956,7 +2005,9 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           result, resultBody;
-        result = SchemaUtils.convertToPmBody(requestBody);
+        result = SchemaUtils.convertToPmBody(requestBody, 'EXAMPLE', {}, {
+          exampleParametersResolution: 'example'
+        });
         resultBody = result.body.raw;
         expect(resultBody).to.equal('text/plain description');
         expect(result.contentHeader).to.deep.include(
@@ -1973,7 +2024,9 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           result, resultBody;
-        result = SchemaUtils.convertToPmBody(requestBody);
+        result = SchemaUtils.convertToPmBody(requestBody, 'EXAMPLE', {}, {
+          exampleParametersResolution: 'example'
+        });
         resultBody = (result.body.raw);
         expect(resultBody).to.equal('<html><body><ul><li>item 1</li><li>item 2</li></ul></body></html>');
         expect(result.contentHeader).to.deep.include(
@@ -1989,7 +2042,9 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           result, resultBody;
-        result = SchemaUtils.convertToPmBody(requestBody);
+        result = SchemaUtils.convertToPmBody(requestBody, 'EXAMPLE', {}, {
+          exampleParametersResolution: 'example'
+        });
         resultBody = (result.body.raw);
         expect(typeof resultBody).to.equal('string');
         expect(result.contentHeader).to.deep.include(
@@ -2010,7 +2065,9 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           },
           result;
 
-        result = SchemaUtils.convertToPmBody(requestBody);
+        result = SchemaUtils.convertToPmBody(requestBody, 'EXAMPLE', {}, {
+          exampleParametersResolution: 'example'
+        });
         expect(result.body.mode).to.equal('file');
         done();
       });
@@ -2043,7 +2100,10 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           result, resultBody;
-        result = SchemaUtils.convertToPmBody(requestBody);
+        result = SchemaUtils.convertToPmBody(requestBody, 'EXAMPLE', {}, {
+          exampleParametersResolution: 'schema',
+          schemaFaker: true
+        });
         resultBody = JSON.parse(result.body.raw);
         expect(resultBody.id).to.equal('<long>');
         expect(resultBody.name).to.equal('<string>');
@@ -2066,7 +2126,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           result, resultBody;
-        result = SchemaUtils.convertToPmBody(requestBody, 'ROOT', {}, {
+        result = SchemaUtils.convertToPmBody(requestBody, 'EXAMPLE', {}, {
           requestParametersResolution: 'example'
         });
         resultBody = (result.body.raw);
@@ -2112,7 +2172,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           pmResponseBody;
-        pmResponseBody = JSON.parse(SchemaUtils.convertToPmResponseBody(contentObj).responseBody);
+        pmResponseBody = JSON.parse(SchemaUtils.convertToPmResponseBody(contentObj, {},
+          { schemaFaker: true }).responseBody);
         expect(pmResponseBody.id).to.equal('<long>');
         expect(pmResponseBody.name).to.equal('<string>');
       });
@@ -2138,7 +2199,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           pmResponseBody;
-        pmResponseBody = JSON.parse(SchemaUtils.convertToPmResponseBody(contentObj).responseBody);
+        pmResponseBody = JSON.parse(SchemaUtils.convertToPmResponseBody(contentObj, {},
+          { schemaFaker: true }).responseBody);
         expect(pmResponseBody.id).to.equal('<long>');
         expect(pmResponseBody.name).to.equal('<string>');
       });
@@ -2164,7 +2226,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           pmResponseBody;
-        pmResponseBody = JSON.parse(SchemaUtils.convertToPmResponseBody(contentObj).responseBody);
+        pmResponseBody = JSON.parse(SchemaUtils.convertToPmResponseBody(contentObj, {},
+          { schemaFaker: true }).responseBody);
         expect(pmResponseBody.id).to.equal('<long>');
         expect(pmResponseBody.name).to.equal('<string>');
       });
@@ -2183,7 +2246,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           },
           pmResponseBody;
         pmResponseBody = SchemaUtils.convertToPmResponseBody(contentObj, {}, {
-          indentCharacter: '\t'
+          indentCharacter: '\t',
+          schemaFaker: true
         }).responseBody;
         expect(pmResponseBody).to.equal('{\n\t"id": "<integer>"\n}');
       });
@@ -2196,7 +2260,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           pmResponseBody;
-        pmResponseBody = SchemaUtils.convertToPmResponseBody(contentObj).responseBody;
+        pmResponseBody = SchemaUtils.convertToPmResponseBody(contentObj, {},
+          { schemaFaker: true }).responseBody;
         expect(typeof pmResponseBody).to.equal('string');
       });
       it('with Content-Type application/xml', function() {
@@ -2223,7 +2288,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
           },
           pmResponseBody;
         pmResponseBody = SchemaUtils.convertToPmResponseBody(contentObj, {}, {
-          indentCharacter: ' '
+          indentCharacter: ' ',
+          schemaFaker: true
         }).responseBody;
         expect(pmResponseBody).to.equal(
           [
@@ -2244,7 +2310,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           pmResponseBody;
-        pmResponseBody = SchemaUtils.convertToPmResponseBody(contentObj).responseBody;
+        pmResponseBody = SchemaUtils.convertToPmResponseBody(contentObj, {},
+          { schemaFaker: true }).responseBody;
         expect(typeof pmResponseBody).to.equal('string');
       });
       it('with Content-Type unsupported', function() {
@@ -2269,7 +2336,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           },
           pmResponseBody;
-        pmResponseBody = SchemaUtils.convertToPmResponseBody(contentObj).responseBody;
+        pmResponseBody = SchemaUtils.convertToPmResponseBody(contentObj, {},
+          { schemaFaker: true }).responseBody;
         expect(pmResponseBody).to.equal('');
       });
       // things remaining application/xml, application/javascript
@@ -2304,7 +2372,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         code = '20X',
         pmResponse, responseBody;
 
-      pmResponse = SchemaUtils.convertToPmResponse(response, code).toJSON();
+      pmResponse = SchemaUtils.convertToPmResponse(response, code, {}, {},
+        { schemaFaker: true }).toJSON();
       responseBody = JSON.parse(pmResponse.body);
       expect(pmResponse.name).to.equal(response.description);
       expect(pmResponse.code).to.equal(200);
@@ -2344,7 +2413,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         code = '20X',
         pmResponse;
 
-      pmResponse = SchemaUtils.convertToPmResponse(response, code).toJSON();
+      pmResponse = SchemaUtils.convertToPmResponse(response, code, {}, {},
+        { schemaFaker: true, indentCharacter: '  ' }).toJSON();
       expect(pmResponse.body).to.equal('<element>\n  <id>(integer)</id>\n  <name>(string)</name>\n</element>');
       expect(pmResponse.name).to.equal(response.description);
       expect(pmResponse.code).to.equal(200);
@@ -2362,7 +2432,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         code = '201',
         pmResponse;
 
-      pmResponse = SchemaUtils.convertToPmResponse(response, code).toJSON();
+      pmResponse = SchemaUtils.convertToPmResponse(response, code, {}, {},
+        { schemaFaker: true }).toJSON();
       expect(pmResponse.name).to.equal(response.description);
       expect(pmResponse.code).to.equal(201);
       expect(pmResponse.body).to.equal('');
@@ -2411,7 +2482,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
               }
             }
           }
-        });
+        }, { schemaFaker: true });
 
       expect(pmResponse.headers.members[0].key).to.equal('Retry-After');
       expect(pmResponse.headers.members[0].description).to.equal('Some description');
@@ -2597,7 +2668,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
             }
           }
         },
-        pmResponse = SchemaUtils.convertToPmResponse(response, '200', originalRequest, components).toJSON(),
+        pmResponse = SchemaUtils.convertToPmResponse(response, '200', originalRequest, components,
+          { schemaFaker: true }).toJSON(),
         pathVariables = _.get(pmResponse, 'originalRequest.url.variable');
 
       expect(pathVariables.length).to.eql(3);


### PR DESCRIPTION
## Overview

This PR fixes issue where we were merging options when not needed due to all APIs now using SchemaPack which by default in it's constructor determines options to be used.

Ref: https://github.com/postmanlabs/openapi-to-postman/blob/b4ef1dc0caf1f899dd0b2272d8932c75ddda552b/lib/schemapack.js#L61

One of such instance was in `getRefObject()` which recursively resolves reference. This caused the merge operation to be done every single time a reference is resolved which is not required at all.

Apart from this, in cases when there were circular reference in non-schema `$ref`, we were resolving them without recursion break points. We'll be now making sure that we resolve circular $ref correctly.

We've removed all instance of merging of these options with default ones in `SchemaUtils.js` file and also fixed tests accordingly which were relying on this logic to be there.
