### PR TITLE
Fixed issue where conversion was stuck for certain schemas with pattern.

### DIFF
--- a/assets/json-schema-faker.js
+++ b/assets/json-schema-faker.js
@@ -23846,8 +23846,10 @@ function extend() {
                   /**
                    * CHANGE: This Makes sure that we're not adding extra spaces in generated value,
                    * As such behaviour generates invalid data when pattern is mentioned.
+                   *
+                   * To avoid infinite loop, make sure we keep adding spaces in cases where value is empty string
                    */
-                  value += (schema.pattern ? '' : ' ') + value;
+                  value += ((schema.pattern && value.length !== 0) ? '' : ' ') + value;
               }
               if (value.length > max) {
                   value = value.substr(0, max);

--- a/test/unit/faker.test.js
+++ b/test/unit/faker.test.js
@@ -121,4 +121,19 @@ describe('JSON SCHEMA FAKER TESTS', function () {
       expect(value.name).to.be.a('string');
     });
   });
+
+  it('Should successsfully generate data for certain patterns that can generate empty string', function () {
+    const schema = {
+      'maxLength': 63,
+      'minLength': 2,
+      'pattern': '^[A-Za-z !#$%&0-9,\'*+\\-.()/:;=@\\\\_\\[\\]`{}]*$',
+      'type': 'string',
+      'description': 'The exact name on the credit card.'
+    };
+
+    var fakedData = schemaFaker(schema);
+    expect(fakedData).to.be.an('string');
+    expect(fakedData.length >= 2).to.be.true;
+    expect(fakedData.length <= 63).to.be.true;
+  });
 });


### PR DESCRIPTION
## Overview

For certain definitions, the conversion process was getting stuck. i.e. Even after large amount of type conversion was still going without any result. Below is sample definition for which this issue could happen sometimes.

<details>
<summary>Sample definition</summary>
<br>

```
openapi: "3.0.0"
info:
  version: 1.0.0
  title: Swagger Petstore
  license:
    name: MIT
servers:
  - url: http://petstore.swagger.io/v1
paths:
  /pets:
    get:
      summary: List all pets
      operationId: listPets
      tags:
        - pets
      parameters:
        - name: limit
          in: query
          description: How many items to return at one time (max 100)
          required: false
          schema:
            type: integer
            format: int32
      responses:
        '200':
          description: An paged array of pets
          headers:
            x-next:
              description: A link to the next page of responses
              schema:
                type: string
          content:
            application/json:    
              schema:
                $ref: "#/components/schemas/Pets"
        default:
          description: unexpected error
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/Error"
components:
  schemas:
    Pet:
      required:
        - id
        - name
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
        tag:
          type: string
        nameOnCard:
          maxLength: 63
          minLength: 2
          pattern: "^[A-Za-z !#$%&0-9,'*+\\-.()/:;=@\\\\_\\[\\]`{}]*$"
          type: string
          description: The exact name on the credit card.
    Pets:
      type: array
      items:
        $ref: "#/components/schemas/Pet"
    Error:
      required:
        - code
        - message
      properties:
        code:
          type: integer
          format: int32
        message:
          type: string
```

</br>
</details>

## RCA

Issue was happening due to an infinite loop due to randomness in generation of data from random express. We use `json-schema-faker` to generate data from schema. In this interface, we have a logic where we add same value into string in cases schema has `maxLength` defined and generated data from `pattern` does not satisfy `maxLength`. While doing so, we were contacting already generated `value` to itself.

In certain cases having `patterns` which can generate string with length of 0 as well, we ended up concating empty string on top of empty string infinitely as breaking condition requires certain string length.

## Fix

We'll make sure in case of empty string, we keep adding a space to this string in loop to avoid infinite loop.
