### PR TITLE
Fixed an issue where definition validation was not considering multiple white space characters.

### DIFF
--- a/lib/common/versionUtils.js
+++ b/lib/common/versionUtils.js
@@ -21,7 +21,7 @@ const _ = require('lodash'),
  * @returns {object} the resultant regular expresion using the provided data
  */
 function getVersionRegexp({ key, version }) {
-  return new RegExp(`${key}['|"]?:\\s?[\\\]?['|"]?${version}`);
+  return new RegExp(`${key}['|"]?\\s*:\\s*[\\\]?['|"]?${version}`);
 }
 
 /**

--- a/test/unit/versionUtils.test.js
+++ b/test/unit/versionUtils.test.js
@@ -25,6 +25,23 @@ describe('getSpecVersion', function() {
     expect(specVersion).to.be.equal('3.0');
   });
 
+  it('Should resolve as 3.0 even if the provided spec contain spaces before version from a YAML input', function() {
+    const inputData = 'openapi : 3.0.0' +
+      'info:' +
+      '  version: 1.0.0' +
+      '  title: Sample API' +
+      '  description: A sample API to illustrate OpenAPI concepts' +
+      'paths:' +
+      '  /list:' +
+      '    get:' +
+      '      description: Returns a list of stuff' +
+      '      responses:' +
+      '        \'200\':' +
+      '          description: Successful response',
+      specVersion = getSpecVersion({ type: stringType, data: inputData });
+    expect(specVersion).to.be.equal('3.0');
+  });
+
   it('Should resolve as 3.1 the provided spec version from a YAML input', function() {
     const inputData = 'openapi: 3.1.0' +
       'info:' +
@@ -48,8 +65,59 @@ describe('getSpecVersion', function() {
     expect(specVersion).to.be.equal('3.1');
   });
 
+  it('Should resolve as 3.1 even if the provided spec contain spaces before version from a YAML input', function() {
+    // Below data contains tabs and spaces before version field which is considered a valid YAML
+    const inputData = 'openapi :  \t"3.1.0"' +
+      'info:' +
+      '  title: Non-oAuth Scopes example' +
+      '  version: 1.0.0' +
+      'paths:' +
+      '  /users:' +
+      '    get:' +
+      '      security:' +
+      '        - bearerAuth:' +
+      '            - \'read:users\'' +
+      '            - \'public\'' +
+      'components:' +
+      '  securitySchemes:' +
+      '    bearerAuth:' +
+      '      type: http' +
+      '      scheme: bearer' +
+      '      bearerFormat: jwt' +
+      '      description: \'note: non-oauth scopes are not defined at the securityScheme level\'',
+      specVersion = getSpecVersion({ type: stringType, data: inputData });
+    expect(specVersion).to.be.equal('3.1');
+  });
+
   it('Should resolve as 2.0 the provided spec version from a YAML input', function() {
     const inputData = 'swagger: "2.0"' +
+      'info:' +
+      '  version: 1.0.0' +
+      '  title: Swagger Petstore' +
+      '  license:' +
+      '    name: MIT' +
+      'host: petstore.swagger.io' +
+      'basePath: /v1' +
+      'schemes:' +
+      '  - http' +
+      'consumes:' +
+      '  - application/json' +
+      'produces:' +
+      '  - application/json' +
+      'paths:' +
+      '  /pets:' +
+      '    get:' +
+      '      summary: List all pets' +
+      '      operationId: listPets' +
+      '      tags:' +
+      '        - pets',
+      specVersion = getSpecVersion({ type: stringType, data: inputData });
+    expect(specVersion).to.be.equal('2.0');
+  });
+
+  it('Should resolve as 2.0 even if the provided spec contain spaces before version from a YAML input', function() {
+    // Below data contains newline before version field which is considered a valid YAML
+    const inputData = 'swagger  :\n "2.0"\n' +
       'info:' +
       '  version: 1.0.0' +
       '  title: Swagger Petstore' +
@@ -101,6 +169,33 @@ describe('getSpecVersion', function() {
     expect(specVersion).to.be.equal('3.0');
   });
 
+  it('Should resolve as 3.0 even if the provided spec contain spaces before version from a JSON input', function() {
+    const inputData = `{
+        'openapi' :  '3.0.0',
+        'info': {
+          'version': '1.0.0',
+          'title': 'Sample API',
+          'description': 'A sample API to illustrate OpenAPI concepts'
+        },
+        'paths': {
+          '/users': {
+            'get': {
+              'security': [
+                {
+                  'bearerAuth': [
+                    'read:users',
+                    'public'
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }`,
+      specVersion = getSpecVersion({ type: stringType, data: inputData });
+    expect(specVersion).to.be.equal('3.0');
+  });
+
   it('Should resolve as 3.1 the provided spec version from a JSON input', function() {
     const inputData = {
         'openapi': '3.1.0',
@@ -134,6 +229,43 @@ describe('getSpecVersion', function() {
         }
       },
       specVersion = getSpecVersion({ type: jsonType, data: inputData });
+    expect(specVersion).to.be.equal('3.1');
+  });
+
+  it('Should resolve as 3.1 even if the provided spec contain spaces before version from a JSON input', function() {
+    // Below data contains both tab and spaces after openapi field
+    const inputData = `{
+        'openapi'	 : '3.1.0',
+        'info': {
+          'title': 'Non-oAuth Scopes example',
+          'version': '1.0.0'
+        },
+        'paths': {
+          '/users': {
+            'get': {
+              'security': [
+                {
+                  'bearerAuth': [
+                    'read:users',
+                    'public'
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        'components': {
+          'securitySchemes': {
+            'bearerAuth': {
+              'type': 'http',
+              'scheme': 'bearer',
+              'bearerFormat': 'jwt',
+              'description': 'note: non-oauth scopes are not defined at the securityScheme level'
+            }
+          }
+        }
+      }`,
+      specVersion = getSpecVersion({ type: stringType, data: inputData });
     expect(specVersion).to.be.equal('3.1');
   });
 
@@ -171,6 +303,45 @@ describe('getSpecVersion', function() {
         }
       },
       specVersion = getSpecVersion({ type: jsonType, data: inputData });
+    expect(specVersion).to.be.equal('2.0');
+  });
+
+  it('Should resolve as 2.0 even if the provided spec contain spaces before version from a JSON input', function() {
+    // Below data contains new line before version field which is a valid json
+    const inputData = `{
+        'swagger':
+        '2.0',
+        'info': {
+          'version': '1.0.0',
+          'title': 'Swagger Petstore',
+          'license': {
+            'name': 'MIT'
+          }
+        },
+        'host': 'petstore.swagger.io',
+        'basePath': '/v1',
+        'schemes': [
+          'http'
+        ],
+        'consumes': [
+          'application/json'
+        ],
+        'produces': [
+          'application/json'
+        ],
+        'paths': {
+          '/pets': {
+            'get': {
+              'summary': 'List all pets',
+              'operationId': 'listPets',
+              'tags': [
+                'pets'
+              ]
+            }
+          }
+        }
+      }`,
+      specVersion = getSpecVersion({ type: stringType, data: inputData });
     expect(specVersion).to.be.equal('2.0');
   });
 });

--- a/test/unit/versionUtils.test.js
+++ b/test/unit/versionUtils.test.js
@@ -485,23 +485,23 @@ describe('compareVersion method', function () {
 describe('getVersionRegexBySpecificationVersion method', function () {
   it('should return regex for 3.0', function () {
     const result = getVersionRegexBySpecificationVersion('3.0');
-    expect(result.toString()).to.equal('/openapi[\'|\"]?:\\s?[\\]?[\'|\"]?3.0/');
+    expect(result.toString()).to.equal('/openapi[\'|\"]?\\s*:\\s*[\\]?[\'|\"]?3.0/');
   });
   it('should return regex for 3.0.0', function () {
     const result = getVersionRegexBySpecificationVersion('3.0.0');
-    expect(result.toString()).to.equal('/openapi[\'|\"]?:\\s?[\\]?[\'|\"]?3.0/');
+    expect(result.toString()).to.equal('/openapi[\'|\"]?\\s*:\\s*[\\]?[\'|\"]?3.0/');
   });
   it('should return regex for 3.1', function () {
     const result = getVersionRegexBySpecificationVersion('3.1');
-    expect(result.toString()).to.equal('/openapi[\'|\"]?:\\s?[\\]?[\'|\"]?3.1/');
+    expect(result.toString()).to.equal('/openapi[\'|\"]?\\s*:\\s*[\\]?[\'|\"]?3.1/');
   });
   it('should return regex for 2.0', function () {
     const result = getVersionRegexBySpecificationVersion('2.0');
-    expect(result.toString()).to.equal('/swagger[\'|\"]?:\\s?[\\]?[\'|\"]?2.0/');
+    expect(result.toString()).to.equal('/swagger[\'|\"]?\\s*:\\s*[\\]?[\'|\"]?2.0/');
   });
   it('should return regex for 3.0 as default', function () {
     const result = getVersionRegexBySpecificationVersion('invalid');
-    expect(result.toString()).to.equal('/openapi[\'|\"]?:\\s?[\\]?[\'|\"]?3.0/');
+    expect(result.toString()).to.equal('/openapi[\'|\"]?\\s*:\\s*[\\]?[\'|\"]?3.0/');
   });
 });
 


### PR DESCRIPTION
## Overview

This PR fixes issue where having extra spaces between `openapi` or `swagger` and `version` field was considered an incorrect definition.

We'll now be accepting zero or more of a any white space before and after `:` to determine spec versions.

See all added test cases to see more different scenarios.