### PR TITLE
#708 Fixes issue where if string is defined for required field, conversion was failing.

### DIFF
--- a/assets/json-schema-faker.js
+++ b/assets/json-schema-faker.js
@@ -24258,7 +24258,7 @@ function extend() {
 
     const properties = value.properties || {};
     const patternProperties = value.patternProperties || {};
-    const requiredProperties = typeof value.required === 'boolean' ? [] : (value.required || []).slice();
+    const requiredProperties = (!Array.isArray(value.required)) ? [] : (value.required || []).slice();
     const allowsAdditional = value.additionalProperties !== false;
 
     const propertyKeys = Object.keys(properties);
@@ -24351,6 +24351,10 @@ function extend() {
 
     const skipped = [];
     const missing = [];
+
+    if (typeof _props !== 'object') {
+      console.log('here');
+    }
 
     _props.forEach(key => {
       for (let i = 0; i < ignoreProperties.length; i += 1) {

--- a/assets/json-schema-faker.js
+++ b/assets/json-schema-faker.js
@@ -24352,10 +24352,6 @@ function extend() {
     const skipped = [];
     const missing = [];
 
-    if (typeof _props !== 'object') {
-      console.log('here');
-    }
-
     _props.forEach(key => {
       for (let i = 0; i < ignoreProperties.length; i += 1) {
         if ((ignoreProperties[i] instanceof RegExp && ignoreProperties[i].test(key))

--- a/test/unit/faker.test.js
+++ b/test/unit/faker.test.js
@@ -136,4 +136,22 @@ describe('JSON SCHEMA FAKER TESTS', function () {
     expect(fakedData.length >= 2).to.be.true;
     expect(fakedData.length <= 63).to.be.true;
   });
+
+  it('Should successsfully generate data iff required is defined as string', function () {
+    const schema = {
+      type: 'object',
+      required: 'timebase',
+      properties: {
+        timebase: { type: 'string' },
+        linkid: { type: 'string' },
+        chartRef: { type: 'string' }
+      }
+    };
+
+    var fakedData = schemaFaker(schema);
+    expect(fakedData).to.be.an('object');
+    expect(fakedData.timebase).to.be.a('string');
+    expect(fakedData.linkid).to.be.a('string');
+    expect(fakedData.chartRef).to.be.a('string');
+  });
 });


### PR DESCRIPTION
## Overview

Fixes issue: #708 

## RCA

According to JSON. schema standards, value of `required` should always be an `array` ([Ref](https://json-schema.org/understanding-json-schema/reference/object.html#id8)). But when it contains `string` type  of data, json-schema-faker was failing to convert the data due to invalid types passing down in further logic resulting in TypeError.

## Fix

We'll make sure that `requiredProperties` is always an array to avid TypeErrors.