### PR TITLE
Fixed issue where for certain path segments, collection generation failed.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -651,7 +651,11 @@ module.exports = {
         // adding children for the nodes in the trie
         // start at the top-level and do a DFS
         for (i = 0; i < pathLength; i++) {
-          if (!currentNode.children[currentPath[i]]) {
+          /**
+           * Use hasOwnProperty to determine if property exists as certain JS fuction are present
+           * as part of each object. e.g. `constructor`.
+           */
+          if (!(typeof currentNode.children === 'object' && currentNode.children.hasOwnProperty(currentPath[i]))) {
             // if the currentPath doesn't already exist at this node,
             // add it as a folder
             currentNode.addChildren(currentPath[i], new Node({

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -686,6 +686,45 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
 
       done();
     });
+
+    it('should generate trie for definition with certain path segment same as JS object function names correctly',
+      function (done) {
+        var openapi = {
+            'openapi': '3.0.0',
+            'info': {
+              'version': '1.0.0',
+              'title': 'Swagger Petstore',
+              'license': {
+                'name': 'MIT'
+              }
+            },
+            'servers': [
+              {
+                'url': 'http://petstore.swagger.io/{v1}'
+              }
+            ],
+            'paths': {
+              '/constructor/v3/update-constructor': {
+                'get': {
+                  'summary': 'List all pets',
+                  'operationId': 'listPets',
+                  'responses': {
+                    '200': {
+                      'description': 'An paged array of pets'
+                    }
+                  }
+                }
+              }
+            }
+          },
+          output = SchemaUtils.generateTrieFromPaths(openapi),
+          root = output.tree.root;
+
+        expect(root.children).to.be.an('object').that.has.all.keys('constructor');
+        expect(root.children.constructor.requestCount).to.equal(1);
+
+        done();
+      });
   });
 
   describe('convertPathVariables', function() {


### PR DESCRIPTION
## RCA

When the definition had certain path that contained same name as standard JS prototype properties, collection generation was failing with TypeError.

For example, path like `/constructor/v3/update-constructor`.

We have following logic to determine if children already is present. Ideally, this should resolve to false while execution but because all JS object has a property called `constructor`. This was passing and further logic was not maintained correctly.

## Fix

Rather than directly accessing the properties, we'll now rely on `Object.hasOwnProperty()` function that makes sure it's true only when object has such own property.
