### PR TITLE
Added support for generating body examples as XML if mentioned.

### DIFF
--- a/lib/common/js2xml.js
+++ b/lib/common/js2xml.js
@@ -1,0 +1,472 @@
+/* eslint-disable */
+
+/**
+ * This code is stripped down version of https://github.com/ibm-maximo-dev/xml-js
+ * Only essential part to convert JSON to XML is used here.
+ *
+ * Ideally there should be no updates needed to this code as it already handles all types of data for JSON object.
+ * But in case this need updates, take a look at below file specifically from which this logic was inspired from.
+ *
+ * https://github.com/ibm-maximo-dev/xml-js/blob/master/lib/js2xml.js
+ */
+
+var currentElement, currentElementName;
+
+const DEFAULT_OPTIONS = {
+  spaces: '  ',
+  compact: true
+}
+
+function isArray (value) {
+  if (Array.isArray) {
+    return Array.isArray(value);
+  }
+  // fallback for older browsers like  IE 8
+  return Object.prototype.toString.call( value ) === '[object Array]';
+}
+
+// Options helper
+const helper = {
+  copyOptions: function (options) {
+    var key, copy = {};
+    for (key in options) {
+      if (options.hasOwnProperty(key)) {
+        copy[key] = options[key];
+      }
+    }
+    return copy;
+  },
+
+  ensureFlagExists: function (item, options) {
+    if (!(item in options) || typeof options[item] !== 'boolean') {
+      options[item] = false;
+    }
+  },
+
+  ensureSpacesExists: function (options) {
+    if (!('spaces' in options) || (typeof options.spaces !== 'number' && typeof options.spaces !== 'string')) {
+      options.spaces = 0;
+    }
+  },
+
+  ensureAlwaysArrayExists: function (options) {
+    if (!('alwaysArray' in options) || (typeof options.alwaysArray !== 'boolean' && !isArray(options.alwaysArray))) {
+      options.alwaysArray = false;
+    }
+  },
+
+  ensureKeyExists: function (key, options) {
+    if (!(key + 'Key' in options) || typeof options[key + 'Key'] !== 'string') {
+      options[key + 'Key'] = options.compact ? '_' + key : key;
+    }
+  },
+
+  checkFnExists: function (key, options) {
+    return key + 'Fn' in options;
+  }
+};
+
+function validateOptions(userOptions) {
+  var options = helper.copyOptions(userOptions);
+  helper.ensureFlagExists('ignoreDeclaration', options);
+  helper.ensureFlagExists('ignoreInstruction', options);
+  helper.ensureFlagExists('ignoreAttributes', options);
+  helper.ensureFlagExists('ignoreText', options);
+  helper.ensureFlagExists('ignoreComment', options);
+  helper.ensureFlagExists('ignoreCdata', options);
+  helper.ensureFlagExists('ignoreDoctype', options);
+  helper.ensureFlagExists('compact', options);
+  helper.ensureFlagExists('indentText', options);
+  helper.ensureFlagExists('indentCdata', options);
+  helper.ensureFlagExists('indentAttributes', options);
+  helper.ensureFlagExists('indentInstruction', options);
+  helper.ensureFlagExists('fullTagEmptyElement', options);
+  helper.ensureFlagExists('noQuotesForNativeAttributes', options);
+  helper.ensureSpacesExists(options);
+  if (typeof options.spaces === 'number') {
+    options.spaces = Array(options.spaces + 1).join(' ');
+  }
+  helper.ensureKeyExists('declaration', options);
+  helper.ensureKeyExists('instruction', options);
+  helper.ensureKeyExists('attributes', options);
+  helper.ensureKeyExists('text', options);
+  helper.ensureKeyExists('comment', options);
+  helper.ensureKeyExists('cdata', options);
+  helper.ensureKeyExists('doctype', options);
+  helper.ensureKeyExists('type', options);
+  helper.ensureKeyExists('name', options);
+  helper.ensureKeyExists('elements', options);
+  helper.checkFnExists('doctype', options);
+  helper.checkFnExists('instruction', options);
+  helper.checkFnExists('cdata', options);
+  helper.checkFnExists('comment', options);
+  helper.checkFnExists('text', options);
+  helper.checkFnExists('instructionName', options);
+  helper.checkFnExists('elementName', options);
+  helper.checkFnExists('attributeName', options);
+  helper.checkFnExists('attributeValue', options);
+  helper.checkFnExists('attributes', options);
+  helper.checkFnExists('fullTagEmptyElement', options);
+  return options;
+}
+
+function writeIndentation(options, depth, firstLine) {
+  return (!firstLine && options.spaces ? '\n' : '') + Array(depth + 1).join(options.spaces);
+}
+
+function writeAttributes(attributes, options, depth) {
+  if (options.ignoreAttributes) {
+    return '';
+  }
+  if ('attributesFn' in options) {
+    attributes = options.attributesFn(attributes, currentElementName, currentElement);
+  }
+  var key,
+    attr,
+    attrName,
+    attrPlusValue,
+    quote,
+    result = [];
+  // NOTE: we don't the length of the element name, so this is the best we can do
+  var attrLineWidth = (depth + 1) * options.spaces;
+  var wrapped = false;
+  for (key in attributes) {
+    if (
+      attributes.hasOwnProperty(key) &&
+      attributes[key] !== null &&
+      attributes[key] !== undefined
+    ) {
+      quote =
+        options.noQuotesForNativeAttributes &&
+          typeof attributes[key] !== "string"
+          ? ""
+          : '"';
+      attr = "" + attributes[key]; // ensure number and boolean are converted to String
+      attr = attr.replace(/"/g, "&quot;");
+      attr = attr.replace(/</g, "&lt;");
+      // edge case, graphite uses lots of && because of conditionals
+      attr = attr.replace(/&&/g, "&amp;&amp;");
+      attrName =
+        "attributeNameFn" in options
+          ? options.attributeNameFn(
+            key,
+            attr,
+            currentElementName,
+            currentElement
+          )
+          : key;
+      attrPlusValue =
+        attrName +
+        "=" +
+        quote +
+        ("attributeValueFn" in options
+          ? options.attributeValueFn(
+            attr,
+            key,
+            currentElementName,
+            currentElement
+          )
+          : attr) +
+        quote;
+      attrLineWidth += attrPlusValue.length + 1;
+      if (options.indentAttributesWidth) {
+        if (
+          options.spaces &&
+          options.indentAttributes &&
+          options.indentAttributesWidth &&
+          attrLineWidth > options.indentAttributesWidth
+        ) {
+          result.push(writeIndentation(options, depth + 1, false));
+          attrLineWidth =
+            (depth + 1) * options.spaces + attrPlusValue.length + 1;
+          wrapped = true;
+        } else {
+          result.push(" ");
+        }
+      } else {
+        result.push(
+          options.spaces && options.indentAttributes
+            ? writeIndentation(options, depth + 1, false)
+            : " "
+        );
+      }
+      result.push(attrPlusValue);
+    }
+  }
+  if (
+    attributes &&
+    Object.keys(attributes).length &&
+    options.spaces &&
+    options.indentAttributes
+  ) {
+    if (
+      options.indentAttributesWidth &&
+      !wrapped
+    ) {
+      result.push(" ");
+    } else {
+      result.push(writeIndentation(options, depth, false));
+    }
+  }
+  return result.join('');
+}
+
+function writeDeclaration(declaration, options, depth) {
+  currentElement = declaration;
+  currentElementName = 'xml';
+  return options.ignoreDeclaration ? '' : '<?' + 'xml' + writeAttributes(declaration[options.attributesKey], options, depth) + '?>';
+}
+
+function writeInstruction(instruction, options, depth) {
+  if (options.ignoreInstruction) {
+    return '';
+  }
+  var key;
+  for (key in instruction) {
+    if (instruction.hasOwnProperty(key)) {
+      break;
+    }
+  }
+  var instructionName = 'instructionNameFn' in options ? options.instructionNameFn(key, instruction[key], currentElementName, currentElement) : key;
+  if (typeof instruction[key] === 'object') {
+    currentElement = instruction;
+    currentElementName = instructionName;
+    return '<?' + instructionName + writeAttributes(instruction[key][options.attributesKey], options, depth) + '?>';
+  } else {
+    var instructionValue = instruction[key] ? instruction[key] : '';
+    if ('instructionFn' in options) instructionValue = options.instructionFn(instructionValue, key, currentElementName, currentElement);
+    return '<?' + instructionName + (instructionValue ? ' ' + instructionValue : '') + '?>';
+  }
+}
+
+function writeComment(comment, options) {
+  return options.ignoreComment ? '' : '<!--' + ('commentFn' in options ? options.commentFn(comment, currentElementName, currentElement) : comment) + '-->';
+}
+
+function writeCdata(cdata, options) {
+  return options.ignoreCdata ? '' : '<![CDATA[' + ('cdataFn' in options ? options.cdataFn(cdata, currentElementName, currentElement) : cdata.replace(']]>', ']]]]><![CDATA[>')) + ']]>';
+}
+
+function writeDoctype(doctype, options) {
+  return options.ignoreDoctype ? '' : '<!DOCTYPE ' + ('doctypeFn' in options ? options.doctypeFn(doctype, currentElementName, currentElement) : doctype) + '>';
+}
+
+function writeText(text, options) {
+  if (options.ignoreText) return '';
+  text = '' + text; // ensure Number and Boolean are converted to String
+  text = text.replace(/&amp;/g, '&'); // desanitize to avoid double sanitization
+  text = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return 'textFn' in options ? options.textFn(text, currentElementName, currentElement) : text;
+}
+
+function hasContent(element, options) {
+  var i;
+  if (element.elements && element.elements.length) {
+    for (i = 0; i < element.elements.length; ++i) {
+      switch (element.elements[i][options.typeKey]) {
+        case 'text':
+          if (options.indentText) {
+            return true;
+          }
+          break; // skip to next key
+        case 'cdata':
+          if (options.indentCdata) {
+            return true;
+          }
+          break; // skip to next key
+        case 'instruction':
+          if (options.indentInstruction) {
+            return true;
+          }
+          break; // skip to next key
+        case 'doctype':
+        case 'comment':
+        case 'element':
+          return true;
+        default:
+          return true;
+      }
+    }
+  }
+  return false;
+}
+
+function writeElement(element, options, depth) {
+  currentElement = element;
+  currentElementName = element.name;
+  var xml = [], elementName = 'elementNameFn' in options ? options.elementNameFn(element.name, element) : element.name;
+  xml.push('<' + elementName);
+  if (element[options.attributesKey]) {
+    xml.push(writeAttributes(element[options.attributesKey], options, depth));
+  }
+  var withClosingTag = element[options.elementsKey] && element[options.elementsKey].length || element[options.attributesKey] && element[options.attributesKey]['xml:space'] === 'preserve';
+  if (!withClosingTag) {
+    if ('fullTagEmptyElementFn' in options) {
+      withClosingTag = options.fullTagEmptyElementFn(element.name, element);
+    } else {
+      withClosingTag = options.fullTagEmptyElement;
+    }
+  }
+  if (withClosingTag) {
+    xml.push('>');
+    if (element[options.elementsKey] && element[options.elementsKey].length) {
+      xml.push(writeElements(element[options.elementsKey], options, depth + 1));
+      currentElement = element;
+      currentElementName = element.name;
+    }
+    xml.push(options.spaces && hasContent(element, options) ? '\n' + Array(depth + 1).join(options.spaces) : '');
+    xml.push('</' + elementName + '>');
+  } else {
+    xml.push('/>');
+  }
+  return xml.join('');
+}
+
+function writeElements(elements, options, depth, firstLine) {
+  return elements.reduce(function (xml, element) {
+    var indent = writeIndentation(options, depth, firstLine && !xml);
+    switch (element.type) {
+      case 'element': return xml + indent + writeElement(element, options, depth);
+      case 'comment': return xml + indent + writeComment(element[options.commentKey], options);
+      case 'doctype': return xml + indent + writeDoctype(element[options.doctypeKey], options);
+      case 'cdata': return xml + (options.indentCdata ? indent : '') + writeCdata(element[options.cdataKey], options);
+      case 'text': return xml + (options.indentText ? indent : '') + writeText(element[options.textKey], options);
+      case 'instruction':
+        var instruction = {};
+        instruction[element[options.nameKey]] = element[options.attributesKey] ? element : element[options.instructionKey];
+        return xml + (options.indentInstruction ? indent : '') + writeInstruction(instruction, options, depth);
+    }
+  }, '');
+}
+
+function hasContentCompact(element, options, anyContent) {
+  var key;
+  for (key in element) {
+    if (element.hasOwnProperty(key)) {
+      switch (key) {
+        case options.parentKey:
+        case options.attributesKey:
+          break; // skip to next key
+        case options.textKey:
+          if (options.indentText || anyContent) {
+            return true;
+          }
+          break; // skip to next key
+        case options.cdataKey:
+          if (options.indentCdata || anyContent) {
+            return true;
+          }
+          break; // skip to next key
+        case options.instructionKey:
+          if (options.indentInstruction || anyContent) {
+            return true;
+          }
+          break; // skip to next key
+        case options.doctypeKey:
+        case options.commentKey:
+          return true;
+        default:
+          return true;
+      }
+    }
+  }
+  return false;
+}
+
+function writeElementCompact(element, name, options, depth, indent) {
+  currentElement = element;
+  currentElementName = name;
+  var elementName = 'elementNameFn' in options ? options.elementNameFn(name, element) : name;
+  if (typeof element === 'undefined' || element === null || element === '') {
+    return 'fullTagEmptyElementFn' in options && options.fullTagEmptyElementFn(name, element) || options.fullTagEmptyElement ? '<' + elementName + '></' + elementName + '>' : '<' + elementName + '/>';
+  }
+  var xml = [];
+  if (name) {
+    xml.push('<' + elementName);
+    if (typeof element !== 'object') {
+      xml.push('>' + writeText(element, options) + '</' + elementName + '>');
+      return xml.join('');
+    }
+    if (element[options.attributesKey]) {
+      xml.push(writeAttributes(element[options.attributesKey], options, depth));
+    }
+    var withClosingTag = hasContentCompact(element, options, true) || element[options.attributesKey] && element[options.attributesKey]['xml:space'] === 'preserve';
+    if (!withClosingTag) {
+      if ('fullTagEmptyElementFn' in options) {
+        withClosingTag = options.fullTagEmptyElementFn(name, element);
+      } else {
+        withClosingTag = options.fullTagEmptyElement;
+      }
+    }
+    if (withClosingTag) {
+      xml.push('>');
+    } else {
+      xml.push('/>');
+      return xml.join('');
+    }
+  }
+  xml.push(writeElementsCompact(element, options, depth + 1, false));
+  currentElement = element;
+  currentElementName = name;
+  if (name) {
+    xml.push((indent ? writeIndentation(options, depth, false) : '') + '</' + elementName + '>');
+  }
+  return xml.join('');
+}
+
+function writeElementsCompact(element, options, depth, firstLine) {
+  var i, key, nodes, xml = [];
+  for (key in element) {
+    if (element.hasOwnProperty(key)) {
+      nodes = isArray(element[key]) ? element[key] : [element[key]];
+      for (i = 0; i < nodes.length; ++i) {
+        switch (key) {
+          case options.declarationKey: xml.push(writeDeclaration(nodes[i], options, depth)); break;
+          case options.instructionKey: xml.push((options.indentInstruction ? writeIndentation(options, depth, firstLine) : '') + writeInstruction(nodes[i], options, depth)); break;
+          case options.attributesKey: case options.parentKey: break; // skip
+          case options.textKey: xml.push((options.indentText ? writeIndentation(options, depth, firstLine) : '') + writeText(nodes[i], options)); break;
+          case options.cdataKey: xml.push((options.indentCdata ? writeIndentation(options, depth, firstLine) : '') + writeCdata(nodes[i], options)); break;
+          case options.doctypeKey: xml.push(writeIndentation(options, depth, firstLine) + writeDoctype(nodes[i], options)); break;
+          case options.commentKey: xml.push(writeIndentation(options, depth, firstLine) + writeComment(nodes[i], options)); break;
+          default: xml.push(writeIndentation(options, depth, firstLine) + writeElementCompact(nodes[i], key, options, depth, hasContentCompact(nodes[i], options)));
+        }
+        firstLine = firstLine && !xml.length;
+      }
+    }
+  }
+  return xml.join('');
+}
+
+module.exports = function (js, indentChar) {
+  // If provided data is not JSON, return it as is. XML string could be already present as example.
+  if (typeof js !== 'object') {
+    return js;
+  }
+
+  try {
+    let options = DEFAULT_OPTIONS;
+
+    // Override indent character if defined.
+    indentChar && (options.spaces = indentChar);
+    options = validateOptions(options);
+    var xml = [];
+    currentElement = js;
+    currentElementName = '_root_';
+    if (options.compact) {
+      xml.push(writeElementsCompact(js, options, 0, true));
+    } else {
+      if (js[options.declarationKey]) {
+        xml.push(writeDeclaration(js[options.declarationKey], options, 0));
+      }
+      if (js[options.elementsKey] && js[options.elementsKey].length) {
+        xml.push(writeElements(js[options.elementsKey], options, 0, !xml.length));
+      }
+    }
+    return xml.join('');
+  } catch (err) {
+    console.error(err);
+
+    // Handle failures gracefully via returning the message inside body rather than failing entire collection
+    return '<js2xmlError>Failed to generate XML data from provided Example.</js2xmlError>'
+  }
+};

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -13,6 +13,7 @@ const { formatDataPath, checkIsCorrectType, isKnownType } = require('./common/sc
   deref = require('./deref.js'),
   _ = require('lodash'),
   xmlFaker = require('./xmlSchemaFaker.js'),
+  js2xml = require('./common/js2xml.js'),
   openApiErr = require('./error.js'),
   ajvValidationError = require('./ajValidation/ajvValidationError'),
   utils = require('./utils.js'),
@@ -139,6 +140,24 @@ function verifyDeprecatedProperties(resolvedSchema, includeDeprecated) {
       }
     }
   });
+}
+
+/**
+ * Adds XML version content for XML specific bodies.
+ *
+ * @param {*} bodyContent - XML Body content
+ * @returns {*} - Body with correct XML version content
+ */
+function getXmlVersionContent (bodyContent) {
+  bodyContent = (typeof bodyContent === 'string') ? bodyContent : '';
+  const regExp = new RegExp('([<\\?xml]+[\\s{1,}]+[version="\\d.\\d"]+[\\sencoding="]+.{1,15}"\\?>)');
+  let xmlBody = bodyContent;
+
+  if (!bodyContent.match(regExp)) {
+    const versionContent = '<?xml version="1.0" encoding="UTF-8"?>\n';
+    xmlBody = versionContent + xmlBody;
+  }
+  return xmlBody;
 }
 
 /**
@@ -1396,7 +1415,7 @@ module.exports = {
    * @return {object} responseBody, contentType header needed
    */
   convertToPmResponseBody: function(contentObj, components, options, schemaCache) {
-    var responseBody, cTypeHeader, hasComputedType, cTypes,
+    var responseBody, cTypeHeader, hasComputedType, cTypes, headerFamily,
       isJsonLike = false;
     if (!contentObj) {
       return {
@@ -1432,10 +1451,16 @@ module.exports = {
         };
       }
     }
+
+    headerFamily = this.getHeaderFamily(cTypeHeader);
     responseBody = this.convertToPmBodyData(contentObj[cTypeHeader], REQUEST_TYPE.EXAMPLE, cTypeHeader,
       PARAMETER_SOURCE.RESPONSE, options.indentCharacter, components, options, schemaCache);
-    if (this.getHeaderFamily(cTypeHeader) === HEADER_TYPE.JSON) {
+
+    if (headerFamily === HEADER_TYPE.JSON) {
       responseBody = JSON.stringify(responseBody, null, options.indentCharacter);
+    }
+    else if (cTypeHeader === TEXT_XML || cTypeHeader === APP_XML || headerFamily === HEADER_TYPE.XML) {
+      responseBody = getXmlVersionContent(responseBody);
     }
     else if (typeof responseBody !== 'string') {
       if (cTypeHeader === MEDIA_TYPE_ALL_RANGES) {
@@ -1556,8 +1581,9 @@ module.exports = {
       resolveTo = this.resolveToExampleOrSchema(requestType, options.requestParametersResolution,
         options.exampleParametersResolution);
     let concreteUtils = components && components.hasOwnProperty('concreteUtils') ?
-      components.concreteUtils :
-      DEFAULT_SCHEMA_UTILS;
+        components.concreteUtils :
+        DEFAULT_SCHEMA_UTILS,
+      headerFamily = this.getHeaderFamily(contentType);
 
     if (_.isEmpty(bodyObj)) {
       return bodyData;
@@ -1566,7 +1592,7 @@ module.exports = {
     if (bodyObj.example && (resolveTo === 'example' || !bodyObj.schema)) {
       if (bodyObj.example.hasOwnProperty('$ref')) {
         bodyObj.example = this.getRefObject(bodyObj.example.$ref, components, options);
-        if (this.getHeaderFamily(contentType) === HEADER_TYPE.JSON) {
+        if (headerFamily === HEADER_TYPE.JSON) {
           // try to parse the example as JSON. OK if this fails
 
           // eslint-disable-next-line max-depth
@@ -1578,10 +1604,19 @@ module.exports = {
         }
       }
       bodyData = bodyObj.example;
+
+      // Convert example into XML if present as JSON data
+      if (contentType === TEXT_XML || contentType === APP_XML || headerFamily === HEADER_TYPE.XML) {
+        bodyData = js2xml(bodyData, indentCharacter);
+      }
     }
     else if (!_.isEmpty(bodyObj.examples) && (resolveTo === 'example' || !bodyObj.schema)) {
       // take one of the examples as the body and not all
       bodyData = this.getExampleData(bodyObj.examples, components, options);
+
+      if (contentType === TEXT_XML || contentType === APP_XML || headerFamily === HEADER_TYPE.XML) {
+        bodyData = js2xml(bodyData, indentCharacter);
+      }
     }
     else if (bodyObj.schema) {
       if (bodyObj.schema.hasOwnProperty('$ref')) {
@@ -1592,6 +1627,9 @@ module.exports = {
         if (outerProps) {
           resolvedSchema = this.getRefObject(bodyObj.schema.$ref, components, options);
           bodyObj.schema = concreteUtils.addOuterPropsToRefSchemaIfIsSupported(resolvedSchema, outerProps);
+        }
+        else {
+          bodyObj.schema = this.getRefObject(bodyObj.schema.$ref, components, options);
         }
       }
       if (options.schemaFaker) {
@@ -1613,9 +1651,18 @@ module.exports = {
           }
           return '<Error: Spec size too large, skipping faking of schemas>';
         }
-        // Do not fake the bodyData if the complexity is 10.
-        bodyData = safeSchemaFaker(bodyObj.schema || {}, resolveTo, PROCESSING_TYPE.CONVERSION, parameterSourceOption,
-          components, schemaFormat, schemaCache, options);
+
+        if (
+          resolveTo === 'example' &&
+          _.get(bodyObj.schema, 'example') !== undefined &&
+          (contentType === TEXT_XML || contentType === APP_XML || headerFamily === HEADER_TYPE.XML)
+        ) {
+          bodyData = js2xml(bodyObj.schema.example, indentCharacter);
+        }
+        else {
+          bodyData = safeSchemaFaker(bodyObj.schema || {}, resolveTo, PROCESSING_TYPE.CONVERSION, parameterSourceOption,
+            components, schemaFormat, schemaCache, options);
+        }
       }
       else {
         // do not fake if the option is false
@@ -2100,18 +2147,7 @@ module.exports = {
         };
       }
       else {
-        let getXmlVersionContent = (bodyContent) => {
-            bodyContent = (typeof bodyContent === 'string') ? bodyContent : '';
-            const regExp = new RegExp('([<\\?xml]+[\\s{1,}]+[version="\\d.\\d"]+[\\sencoding="]+.{1,15}"\\?>)');
-            let xmlBody = bodyContent;
-
-            if (!bodyContent.match(regExp)) {
-              const versionContent = '<?xml version="1.0" encoding="UTF-8"?>\n';
-              xmlBody = versionContent + xmlBody;
-            }
-            return xmlBody;
-          },
-          headerFamily;
+        let headerFamily;
 
         bodyData = this.convertToPmBodyData(contentObj[bodyType], requestType, bodyType,
           PARAMETER_SOURCE.REQUEST, options.indentCharacter, components, options, schemaCache);

--- a/test/data/valid_swagger/yaml/xml_example.yaml
+++ b/test/data/valid_swagger/yaml/xml_example.yaml
@@ -1,0 +1,233 @@
+swagger: '2.0'
+info:
+  title: YAML data
+  version: '1.0'
+schemes:
+  - https
+securityDefinitions:
+  Bearer:
+    description: Authorization 'Bearer' token
+    in: header
+    name: Authorization
+    type: apiKey
+tags:
+  - name: client
+    description: Client resources
+paths:
+  /client:
+    get:
+      deprecated: false
+      summary: Query Client
+      produces:
+        - application/xml
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Data'
+    post:
+      deprecated: false
+      summary: Query Client
+      produces:
+        - application/xml
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: object
+            properties:
+              CstmrPmtStsRpt:
+                type: object
+                properties:
+                  GrpHdr:
+                    type: object
+                    properties:
+                      MsgId:
+                        type: string
+                      CreDtTm:
+                        type: string
+                      InitgPty:
+                        type: object
+                        properties:
+                          Id:
+                            type: object
+                            properties:
+                              OrgId:
+                                type: object
+                                properties:
+                                  BICOrBEI:
+                                    type: string
+                                required:
+                                - BICOrBEI
+                            required:
+                            - OrgId
+                        required:
+                        - Id
+                    required:
+                    - MsgId
+                    - CreDtTm
+                    - InitgPty
+                  OrgnlGrpInfAndSts:
+                    type: object
+                    properties:
+                      OrgnlMsgId:
+                        type: string
+                      Orgn1MsgNmId:
+                        type: string
+                      OrgnlCreDtTm:
+                        type: string
+                      Orgn1NbOfTxs:
+                        type: string
+                    required:
+                    - OrgnlMsgId
+                    - Orgn1MsgNmId
+                    - OrgnlCreDtTm
+                    - Orgn1NbOfTxs
+                  OrgnlPmtInfAndSts:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        OrgnlPmtInfId:
+                          type: string
+                        TxInfAndSts:
+                          type: object
+                          properties:
+                            OrgnlEndToEndId:
+                              type: string
+                            TxSts:
+                              type: string
+                          required:
+                          - OrgnlEndToEndId
+                          - TxSts
+                      required:
+                      - OrgnlPmtInfId
+                      - TxInfAndSts
+                required:
+                - GrpHdr
+                - OrgnlGrpInfAndSts
+                - OrgnlPmtInfAndSts
+            required:
+            - CstmrPmtStsRpt
+          examples:
+            application/xml:
+              CstmrPmtStsRpt:
+                GrpHdr:
+                  MsgId: 20201213-PSR/1798570726
+                  InitgPty:
+                    Id:
+                      OrgId:
+                        BICOrBEI: US33
+                OrgnlGrpInfAndSts:
+                  OrgnlMsgId: '100060058'
+                  Orgn1MsgNmId: pain.001.02
+                  OrgnlCreDtTm: '2023-05-16T14:35:23-05:00'
+                  Orgn1NbOfTxs: '1'
+                OrgnlPmtInfAndSts:
+                - OrgnlPmtInfId: ASIA
+                  TxInfAndSts:
+                    OrgnlEndToEndId: ASIADD
+                    TxSts: ACTC
+                - OrgnlPmtInfId: EU
+                  TxInfAndSts:
+                    OrgnlEndToEndId: EUDD
+                    TxSts: EUTC
+definitions:
+  Data:
+    type: object
+    properties:
+      CstmrPmtStsRpt:
+        type: object
+        properties:
+          GrpHdr:
+            type: object
+            properties:
+              MsgId:
+                type: string
+              CreDtTm:
+                type: string
+              InitgPty:
+                type: object
+                properties:
+                  Id:
+                    type: object
+                    properties:
+                      OrgId:
+                        type: object
+                        properties:
+                          BICOrBEI:
+                            type: string
+                        required:
+                        - BICOrBEI
+                    required:
+                    - OrgId
+                required:
+                - Id
+            required:
+            - MsgId
+            - CreDtTm
+            - InitgPty
+          OrgnlGrpInfAndSts:
+            type: object
+            properties:
+              OrgnlMsgId:
+                type: string
+              Orgn1MsgNmId:
+                type: string
+              OrgnlCreDtTm:
+                type: string
+              Orgn1NbOfTxs:
+                type: string
+            required:
+            - OrgnlMsgId
+            - Orgn1MsgNmId
+            - OrgnlCreDtTm
+            - Orgn1NbOfTxs
+          OrgnlPmtInfAndSts:
+            type: array
+            items:
+              type: object
+              properties:
+                OrgnlPmtInfId:
+                  type: string
+                TxInfAndSts:
+                  type: object
+                  properties:
+                    OrgnlEndToEndId:
+                      type: string
+                    TxSts:
+                      type: string
+                  required:
+                  - OrgnlEndToEndId
+                  - TxSts
+              required:
+              - OrgnlPmtInfId
+              - TxInfAndSts
+        required:
+        - GrpHdr
+        - OrgnlGrpInfAndSts
+        - OrgnlPmtInfAndSts
+    required:
+    - CstmrPmtStsRpt
+    example:
+      CstmrPmtStsRpt:
+        GrpHdr:
+          MsgId: 20231213-PSR/1798570726
+          InitgPty:
+            Id:
+              OrgId:
+                BICOrBEI: US33
+        OrgnlGrpInfAndSts:
+          OrgnlMsgId: '100060058'
+          Orgn1MsgNmId: pain.001.02
+          OrgnlCreDtTm: '2023-05-16T14:35:23-05:00'
+          Orgn1NbOfTxs: '1'
+        OrgnlPmtInfAndSts:
+        - OrgnlPmtInfId: ASIA
+          TxInfAndSts:
+            OrgnlEndToEndId: ASIADD
+            TxSts: ACTC
+        - OrgnlPmtInfId: EU
+          TxInfAndSts:
+            OrgnlEndToEndId: EUDD
+            TxSts: EUTC

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -1593,7 +1593,8 @@ describe('CONVERT FUNCTION TESTS ', function() {
               '  <requestBoolean>(boolean)</requestBoolean>\n' +
               '  <requestNumber>(number)</requestNumber>\n' +
               '</ex:ExampleXMLRequest>',
-            expectedResponseBody = '<ex:ExampleXMLResponse xmlns:ex=\"urn:ExampleXML\">\n' +
+            expectedResponseBody = '<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n' +
+              '<ex:ExampleXMLResponse xmlns:ex=\"urn:ExampleXML\">\n' +
               '  <responseInteger>(integer)</responseInteger>\n' +
               '  <responseString>(string)</responseString>\n' +
               '  <responseBoolean>(boolean)</responseBoolean>\n' +
@@ -1623,7 +1624,8 @@ describe('CONVERT FUNCTION TESTS ', function() {
               '  <requestString>(string)</requestString>\n' +
               '  <requestBoolean>(boolean)</requestBoolean>\n' +
               '</ExampleXMLRequest>',
-            expectedResponseBody = '<ExampleXMLResponse xmlns=\"urn:ExampleXML\">\n' +
+            expectedResponseBody = '<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n' +
+              '<ExampleXMLResponse xmlns=\"urn:ExampleXML\">\n' +
               '  <responseInteger>(integer)</responseInteger>\n' +
               '  <responseString>(string)</responseString>\n' +
               '  <responseBoolean>(boolean)</responseBoolean>\n' +
@@ -1657,7 +1659,8 @@ describe('CONVERT FUNCTION TESTS ', function() {
               '  <requestString>(string)</requestString>\n' +
               '  <requestBoolean>(boolean)</requestBoolean>\n' +
               '</ex:ExampleXMLRequest>',
-            expectedResponseBody = '<ex:ExampleXMLResponse xmlns:ex=\"urn:ExampleXML\">\n' +
+            expectedResponseBody = '<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n' +
+              '<ex:ExampleXMLResponse xmlns:ex=\"urn:ExampleXML\">\n' +
               '  <requestInteger>(integer)</requestInteger>\n' +
               '  <requestString>(string)</requestString>\n' +
               '  <requestBoolean>(boolean)</requestBoolean>\n' +
@@ -1696,7 +1699,8 @@ describe('CONVERT FUNCTION TESTS ', function() {
               '  <requestString>(string)</requestString>\n' +
               '  <requestBoolean>(boolean)</requestBoolean>\n' +
               '</ExampleXMLRequest>',
-            expectedResponseBody = '<ExampleXMLResponse xmlns=\"urn:ExampleXML\">\n' +
+            expectedResponseBody = '<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n' +
+              '<ExampleXMLResponse xmlns=\"urn:ExampleXML\">\n' +
               '  <requestInteger>(integer)</requestInteger>\n' +
               '  <requestString>(string)</requestString>\n' +
               '  <requestBoolean>(boolean)</requestBoolean>\n' +
@@ -1737,7 +1741,8 @@ describe('CONVERT FUNCTION TESTS ', function() {
               '    <requestBoolean>(boolean)</requestBoolean>\n' +
               '  </ex:ExampleXMLRequest>\n' +
               '</ex:ExampleXMLRequest>',
-            expectedResponseBody = '<ex:ExampleXMLResponse>\n' +
+            expectedResponseBody = '<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n' +
+            '<ex:ExampleXMLResponse>\n' +
             '  <ex:ExampleXMLResponse xmlns:ex=\"urn:ExampleXML\">\n' +
             '    <requestInteger>(integer)</requestInteger>\n' +
             '    <requestString>(string)</requestString>\n' +
@@ -1961,8 +1966,8 @@ describe('CONVERT FUNCTION TESTS ', function() {
         expect(result.output[0].type).to.have.equal('collection');
         expect(result.output[0].data).to.have.property('info');
         expect(result.output[0].data).to.have.property('item');
+        done();
       });
-      done();
     });
 
     it('must read values consumes', function (done) {
@@ -2057,6 +2062,89 @@ describe('CONVERT FUNCTION TESTS ', function() {
         expect(expectedResponseBody1.payload).to.be.a('boolean');
         expect(expectedResponseBody2.payload).to.be.an('object')
           .and.to.have.all.keys('content', 'paging');
+      });
+    });
+
+    it('Should convert a swagger document with XML example correctly', function(done) {
+      const fileData = fs.readFileSync(path.join(__dirname, SWAGGER_20_FOLDER_YAML, 'xml_example.yaml'), 'utf8'),
+        input = {
+          type: 'string',
+          data: fileData
+        };
+      Converter.convert(input, { }, (error, result) => {
+        expect(error).to.be.null;
+        expect(result.result).to.equal(true);
+        expect(result.output.length).to.equal(1);
+        expect(result.output[0].type).to.have.equal('collection');
+        expect(result.output[0].data).to.have.property('info');
+        expect(result.output[0].data).to.have.property('item');
+        expect(result.output[0].data.item[0].item[0].response[0].body).to.eql(`<?xml version="1.0" encoding="UTF-8"?>
+<CstmrPmtStsRpt>
+  <GrpHdr>
+    <MsgId>20231213-PSR/1798570726</MsgId>
+    <InitgPty>
+      <Id>
+        <OrgId>
+          <BICOrBEI>US33</BICOrBEI>
+        </OrgId>
+      </Id>
+    </InitgPty>
+  </GrpHdr>
+  <OrgnlGrpInfAndSts>
+    <OrgnlMsgId>100060058</OrgnlMsgId>
+    <Orgn1MsgNmId>pain.001.02</Orgn1MsgNmId>
+    <OrgnlCreDtTm>2023-05-16T14:35:23-05:00</OrgnlCreDtTm>
+    <Orgn1NbOfTxs>1</Orgn1NbOfTxs>
+  </OrgnlGrpInfAndSts>
+  <OrgnlPmtInfAndSts>
+    <OrgnlPmtInfId>ASIA</OrgnlPmtInfId>
+    <TxInfAndSts>
+      <OrgnlEndToEndId>ASIADD</OrgnlEndToEndId>
+      <TxSts>ACTC</TxSts>
+    </TxInfAndSts>
+  </OrgnlPmtInfAndSts>
+  <OrgnlPmtInfAndSts>
+    <OrgnlPmtInfId>EU</OrgnlPmtInfId>
+    <TxInfAndSts>
+      <OrgnlEndToEndId>EUDD</OrgnlEndToEndId>
+      <TxSts>EUTC</TxSts>
+    </TxInfAndSts>
+  </OrgnlPmtInfAndSts>
+</CstmrPmtStsRpt>`);
+        expect(result.output[0].data.item[0].item[1].response[0].body).to.eql(`<?xml version="1.0" encoding="UTF-8"?>
+<CstmrPmtStsRpt>
+  <GrpHdr>
+    <MsgId>20201213-PSR/1798570726</MsgId>
+    <InitgPty>
+      <Id>
+        <OrgId>
+          <BICOrBEI>US33</BICOrBEI>
+        </OrgId>
+      </Id>
+    </InitgPty>
+  </GrpHdr>
+  <OrgnlGrpInfAndSts>
+    <OrgnlMsgId>100060058</OrgnlMsgId>
+    <Orgn1MsgNmId>pain.001.02</Orgn1MsgNmId>
+    <OrgnlCreDtTm>2023-05-16T14:35:23-05:00</OrgnlCreDtTm>
+    <Orgn1NbOfTxs>1</Orgn1NbOfTxs>
+  </OrgnlGrpInfAndSts>
+  <OrgnlPmtInfAndSts>
+    <OrgnlPmtInfId>ASIA</OrgnlPmtInfId>
+    <TxInfAndSts>
+      <OrgnlEndToEndId>ASIADD</OrgnlEndToEndId>
+      <TxSts>ACTC</TxSts>
+    </TxInfAndSts>
+  </OrgnlPmtInfAndSts>
+  <OrgnlPmtInfAndSts>
+    <OrgnlPmtInfId>EU</OrgnlPmtInfId>
+    <TxInfAndSts>
+      <OrgnlEndToEndId>EUDD</OrgnlEndToEndId>
+      <TxSts>EUTC</TxSts>
+    </TxInfAndSts>
+  </OrgnlPmtInfAndSts>
+</CstmrPmtStsRpt>`);
+        done();
       });
     });
   });

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -1872,8 +1872,8 @@ describe('The convert v2 Function', function() {
         expect(result.output[0].type).to.have.equal('collection');
         expect(result.output[0].data).to.have.property('info');
         expect(result.output[0].data).to.have.property('item');
+        done();
       });
-      done();
     });
 
     it('must read values consumes', function (done) {
@@ -1971,6 +1971,89 @@ describe('The convert v2 Function', function() {
         expect(expectedResponseBody2.payload).to.be.eql('<boolean>');
         expect(expectedResponseBody1.payload).to.be.an('object')
           .and.to.have.all.keys('content', 'paging');
+      });
+    });
+
+    it('Should convert a swagger document with XML example correctly', function(done) {
+      const fileData = fs.readFileSync(path.join(__dirname, SWAGGER_20_FOLDER_YAML, 'xml_example.yaml'), 'utf8'),
+        input = {
+          type: 'string',
+          data: fileData
+        };
+      Converter.convertV2(input, { parametersResolution: 'Example' }, (error, result) => {
+        expect(error).to.be.null;
+        expect(result.result).to.equal(true);
+        expect(result.output.length).to.equal(1);
+        expect(result.output[0].type).to.have.equal('collection');
+        expect(result.output[0].data).to.have.property('info');
+        expect(result.output[0].data).to.have.property('item');
+        expect(result.output[0].data.item[0].item[0].response[0].body).to.eql(`<?xml version="1.0" encoding="UTF-8"?>
+<CstmrPmtStsRpt>
+  <GrpHdr>
+    <MsgId>20231213-PSR/1798570726</MsgId>
+    <InitgPty>
+      <Id>
+        <OrgId>
+          <BICOrBEI>US33</BICOrBEI>
+        </OrgId>
+      </Id>
+    </InitgPty>
+  </GrpHdr>
+  <OrgnlGrpInfAndSts>
+    <OrgnlMsgId>100060058</OrgnlMsgId>
+    <Orgn1MsgNmId>pain.001.02</Orgn1MsgNmId>
+    <OrgnlCreDtTm>2023-05-16T14:35:23-05:00</OrgnlCreDtTm>
+    <Orgn1NbOfTxs>1</Orgn1NbOfTxs>
+  </OrgnlGrpInfAndSts>
+  <OrgnlPmtInfAndSts>
+    <OrgnlPmtInfId>ASIA</OrgnlPmtInfId>
+    <TxInfAndSts>
+      <OrgnlEndToEndId>ASIADD</OrgnlEndToEndId>
+      <TxSts>ACTC</TxSts>
+    </TxInfAndSts>
+  </OrgnlPmtInfAndSts>
+  <OrgnlPmtInfAndSts>
+    <OrgnlPmtInfId>EU</OrgnlPmtInfId>
+    <TxInfAndSts>
+      <OrgnlEndToEndId>EUDD</OrgnlEndToEndId>
+      <TxSts>EUTC</TxSts>
+    </TxInfAndSts>
+  </OrgnlPmtInfAndSts>
+</CstmrPmtStsRpt>`);
+        expect(result.output[0].data.item[0].item[1].response[0].body).to.eql(`<?xml version="1.0" encoding="UTF-8"?>
+<CstmrPmtStsRpt>
+  <GrpHdr>
+    <MsgId>20201213-PSR/1798570726</MsgId>
+    <InitgPty>
+      <Id>
+        <OrgId>
+          <BICOrBEI>US33</BICOrBEI>
+        </OrgId>
+      </Id>
+    </InitgPty>
+  </GrpHdr>
+  <OrgnlGrpInfAndSts>
+    <OrgnlMsgId>100060058</OrgnlMsgId>
+    <Orgn1MsgNmId>pain.001.02</Orgn1MsgNmId>
+    <OrgnlCreDtTm>2023-05-16T14:35:23-05:00</OrgnlCreDtTm>
+    <Orgn1NbOfTxs>1</Orgn1NbOfTxs>
+  </OrgnlGrpInfAndSts>
+  <OrgnlPmtInfAndSts>
+    <OrgnlPmtInfId>ASIA</OrgnlPmtInfId>
+    <TxInfAndSts>
+      <OrgnlEndToEndId>ASIADD</OrgnlEndToEndId>
+      <TxSts>ACTC</TxSts>
+    </TxInfAndSts>
+  </OrgnlPmtInfAndSts>
+  <OrgnlPmtInfAndSts>
+    <OrgnlPmtInfId>EU</OrgnlPmtInfId>
+    <TxInfAndSts>
+      <OrgnlEndToEndId>EUDD</OrgnlEndToEndId>
+      <TxSts>EUTC</TxSts>
+    </TxInfAndSts>
+  </OrgnlPmtInfAndSts>
+</CstmrPmtStsRpt>`);
+        done();
       });
     });
   });

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -2332,6 +2332,7 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
         }).responseBody;
         expect(pmResponseBody).to.equal(
           [
+            '<?xml version="1.0" encoding="UTF-8"?>',
             '<Person id="(integer)">',
             ' <sample:name xmlns:sample="http://example.com/schema/sample">(string)</sample:name>',
             ' <hobbies>',
@@ -2454,7 +2455,8 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
 
       pmResponse = SchemaUtils.convertToPmResponse(response, code, {}, {},
         { schemaFaker: true, indentCharacter: '  ' }).toJSON();
-      expect(pmResponse.body).to.equal('<element>\n  <id>(integer)</id>\n  <name>(string)</name>\n</element>');
+      expect(pmResponse.body).to.equal('<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<element>\n  <id>(integer)</id>\n  <name>(string)</name>\n</element>');
       expect(pmResponse.name).to.equal(response.description);
       expect(pmResponse.code).to.equal(200);
       expect(pmResponse._postman_previewlanguage).to.equal('xml');


### PR DESCRIPTION
## Overview

This PR adds support for generating request and response body correctly for XML type of data from example if available. This change is done on both v1 and v2 interface with corresponding tests.

To support the JSON data to XML body conversion, we've used a stripped-down version of [xml-js-graphite](https://github.com/ibm-maximo-dev/xml-js/blob/master/lib/js2xml.js) library to avoid extra dependencies. As this logic shouldn't need any updates in foreseeable future and logic being quite simple, having logic as separate file makes more sense.
