### PR TITLE
Fix default value of auth as null in the collection request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+-   Fixed the default value of auth in the generated request when it is not resolved.
+
 ## [v4.13.0] - 2023-05-24
 
 ### Added

--- a/libV2/utils.js
+++ b/libV2/utils.js
@@ -52,7 +52,7 @@ const sdk = require('postman-collection'),
       pathParams = _.get(requestObject, 'request.params.pathParams', []),
       headers = _.get(requestObject, 'request.headers', []),
       responses = _.get(requestObject, 'request.responses', []),
-      auth = _.get(requestObject, 'request.auth', []);
+      auth = _.get(requestObject, 'request.auth', null);
 
     _.forEach(queryParams, (param) => {
       requestItem.request.url.addQueryParams(param);

--- a/test/data/valid_openapi/securityAuthUnresolvedInPathItem.yaml
+++ b/test/data/valid_openapi/securityAuthUnresolvedInPathItem.yaml
@@ -1,0 +1,60 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      security:
+        - auth: [pets.write]
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+
+  securitySchemes:
+      bearerAuth:
+          type: http
+          scheme: bearer
+

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -89,7 +89,9 @@ const expect = require('chai').expect,
   acceptHeaderExample =
     path.join(__dirname, VALID_OPENAPI_PATH, '/acceptHeaderExample.json'),
   recursiveRefComponents =
-    path.join(__dirname, VALID_OPENAPI_PATH, '/recursiveRefComponents.yaml');
+    path.join(__dirname, VALID_OPENAPI_PATH, '/recursiveRefComponents.yaml'),
+  securityAuthUnresolvedInPathItem =
+    path.join(__dirname, VALID_OPENAPI_PATH, '/securityAuthUnresolvedInPathItem.yaml');
 
 
 describe('The convert v2 Function', function() {
@@ -2287,6 +2289,24 @@ describe('The convert v2 Function', function() {
         expect(item.response[0].body).to.be.undefined;
         expect(item.response[1].header).to.be.empty;
         expect(item.response[1].body).to.be.undefined;
+        done();
+      });
+  });
+
+  it('Should generate auth as null when it cannot be resolved from provided security definitions', function(done) {
+    const openapi = fs.readFileSync(securityAuthUnresolvedInPathItem, 'utf8');
+    Converter.convertV2({ type: 'string', data: openapi }, {},
+      (err, conversionResult) => {
+        expect(err).to.be.null;
+        expect(conversionResult.result).to.equal(true);
+        expect(conversionResult.output.length).to.equal(1);
+        expect(conversionResult.output[0].type).to.equal('collection');
+        expect(conversionResult.output[0].data).to.have.property('info');
+        expect(conversionResult.output[0].data).to.have.property('item');
+        expect(conversionResult.output[0].data.item.length).to.equal(1);
+
+        const item = conversionResult.output[0].data.item[0].item[0];
+        expect(item.request.auth).to.be.null;
         done();
       });
   });


### PR DESCRIPTION
## Overview
When the path item referenced security definitions that did not exist in the specification, the generated collection was not in a valid format, resulting in failure in importing.

## RCA
The module `libV2/helpers/collection/generateAuthForCollectionFromOpenAPI.js` returned `undefined` when the path item was referencing an auth, but it did not exist in the security definitions. I've added a sample schema and a unit test case for reference.

When we returned `undefined` from this module, the method `generateRequestItemObject` in `libV2/utils.js` was using the default value of `auth` as `[]`, which is not a valid value as per the collection spec.

This issue is only present in the v2 conversion interface.

## Fix
I changed the default value of `auth` from `[]` to `null`, so in all cases when auth is `undefined`, it uses the `null` value.