### PR TITLE
Fixed issue where defintions with empty title were converted with empty collection name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 -   Fixed the default value of auth in the generated request when it is not resolved.
+-   Fixed issue where collection name was empty in cases where definition title was defined as empty string.
 
 ## [v4.13.0] - 2023-05-24
 

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -1,8 +1,6 @@
 'use strict';
 
-// This is the default collection name if one can't be inferred from the OpenAPI spec
-const COLLECTION_NAME = 'Imported from OpenAPI',
-  { getConcreteSchemaUtils } = require('./common/versionUtils.js'),
+const { getConcreteSchemaUtils } = require('./common/versionUtils.js'),
   { convertToOAS30IfSwagger } = require('./swaggerUtils/swaggerToOpenapi.js'),
   BROWSER = 'browser',
   Ajv = require('ajv'),
@@ -194,11 +192,7 @@ class SchemaPack {
     }
     // if the schema is validated, return the meta data as required.
     else if (this.validated) {
-      let name = _.get(this.openapi, 'info.title');
-
-      if (_.isEmpty(name) || !_.isString(name)) {
-        name = COLLECTION_NAME;
-      }
+      let name = utils.getCollectionName(_.get(this.openapi, 'info.title'));
 
       return cb(null, {
         result: true,
@@ -219,11 +213,7 @@ class SchemaPack {
           return cb(null, validationResult);
         }
 
-        let name = _.get(this.openapi, 'info.title');
-
-        if (_.isEmpty(name) || !_.isString(name)) {
-          name = COLLECTION_NAME;
-        }
+        let name = utils.getCollectionName(_.get(this.openapi, 'info.title'));
 
         return cb(null, {
           result: true,
@@ -348,17 +338,11 @@ class SchemaPack {
         // Fix {scheme} and {path} vars in the URL to :scheme and :path
         openapi.baseUrl = schemaUtils.fixPathVariablesInUrl(openapi.baseUrl);
 
-        let name = _.get(this.openapi, 'info.title');
-
-        if (_.isEmpty(name) || !_.isString(name)) {
-          name = COLLECTION_NAME;
-        }
-
         // Creating a new instance of a Postman collection
         // All generated folders and requests will go inside this
         generatedStore.collection = new sdk.Collection({
           info: {
-            name: name
+            name: utils.getCollectionName(_.get(openapi, 'info.title'))
           }
         });
 

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // This is the default collection name if one can't be inferred from the OpenAPI spec
-const COLLECTION_NAME = 'Imported from OpenAPI 3.0',
+const COLLECTION_NAME = 'Imported from OpenAPI',
   { getConcreteSchemaUtils } = require('./common/versionUtils.js'),
   { convertToOAS30IfSwagger } = require('./swaggerUtils/swaggerToOpenapi.js'),
   BROWSER = 'browser',
@@ -194,12 +194,18 @@ class SchemaPack {
     }
     // if the schema is validated, return the meta data as required.
     else if (this.validated) {
+      let name = _.get(this.openapi, 'info.title');
+
+      if (_.isEmpty(name) || !_.isString(name)) {
+        name = COLLECTION_NAME;
+      }
+
       return cb(null, {
         result: true,
-        name: _.get(this.openapi, 'info.title', COLLECTION_NAME),
+        name: name,
         output: [{
           type: 'collection',
-          name: _.get(this.openapi, 'info.title', COLLECTION_NAME)
+          name: name
         }]
       });
     }
@@ -213,12 +219,18 @@ class SchemaPack {
           return cb(null, validationResult);
         }
 
+        let name = _.get(this.openapi, 'info.title');
+
+        if (_.isEmpty(name) || !_.isString(name)) {
+          name = COLLECTION_NAME;
+        }
+
         return cb(null, {
           result: true,
-          name: _.get(this.openapi, 'info.title', COLLECTION_NAME),
+          name: name,
           output: [{
             type: 'collection',
-            name: _.get(this.openapi, 'info.title', COLLECTION_NAME)
+            name: name
           }]
         });
       });
@@ -336,11 +348,17 @@ class SchemaPack {
         // Fix {scheme} and {path} vars in the URL to :scheme and :path
         openapi.baseUrl = schemaUtils.fixPathVariablesInUrl(openapi.baseUrl);
 
+        let name = _.get(this.openapi, 'info.title');
+
+        if (_.isEmpty(name) || !_.isString(name)) {
+          name = COLLECTION_NAME;
+        }
+
         // Creating a new instance of a Postman collection
         // All generated folders and requests will go inside this
         generatedStore.collection = new sdk.Collection({
           info: {
-            name: _.isEmpty(_.get(openapi, 'info.title')) ? COLLECTION_NAME : _.get(openapi, 'info.title')
+            name: name
           }
         });
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,7 @@
-const _ = require('lodash');
+const _ = require('lodash'),
+
+  // This is the default collection name if one can't be inferred from the OpenAPI spec
+  COLLECTION_NAME = 'Imported from OpenAPI';
 
 // this will have non-OAS-related utils
 
@@ -142,5 +145,19 @@ module.exports = {
       res.push(segment);
     }
     return res.join('/');
+  },
+
+  /**
+   * Provides collection name to be used for generated collection
+   *
+   * @param {*} title - Definition title
+   * @returns {String} - Collection name
+   */
+  getCollectionName: function (title) {
+    if (_.isEmpty(title) || !_.isString(title)) {
+      return COLLECTION_NAME;
+    }
+
+    return title;
   }
 };

--- a/libV2/helpers/collection/generateCollectionFromOpenAPI.js
+++ b/libV2/helpers/collection/generateCollectionFromOpenAPI.js
@@ -93,7 +93,7 @@ module.exports = function ({ openapi }) {
 
   const collectionVariables = resolveCollectionVariablesForBaseUrlFromServersObject(_.get(openapi, 'servers.0'));
 
-  let name = _.get(this.openapi, 'info.title');
+  let name = _.get(openapi, 'info.title');
 
   if (_.isEmpty(name) || !_.isString(name)) {
     name = COLLECTION_NAME;

--- a/libV2/helpers/collection/generateCollectionFromOpenAPI.js
+++ b/libV2/helpers/collection/generateCollectionFromOpenAPI.js
@@ -1,6 +1,6 @@
 const _ = require('lodash'),
+  utils = require('../../utils'),
   generateAuthrForCollectionFromOpenAPI = require('./generateAuthForCollectionFromOpenAPI'),
-  COLLECTION_NAME = 'Imported from OpenAPI',
 
   /**
    * Returns a description that's usable at the collection-level
@@ -93,16 +93,10 @@ module.exports = function ({ openapi }) {
 
   const collectionVariables = resolveCollectionVariablesForBaseUrlFromServersObject(_.get(openapi, 'servers.0'));
 
-  let name = _.get(openapi, 'info.title');
-
-  if (_.isEmpty(name) || !_.isString(name)) {
-    name = COLLECTION_NAME;
-  }
-
   return {
     data: {
       info: {
-        name: name,
+        name: utils.getCollectionName(_.get(openapi, 'info.title')),
         description: getCollectionDescription(openapi)
       },
       auth: generateAuthrForCollectionFromOpenAPI(openapi, openapi.security)

--- a/libV2/helpers/collection/generateCollectionFromOpenAPI.js
+++ b/libV2/helpers/collection/generateCollectionFromOpenAPI.js
@@ -1,6 +1,6 @@
 const _ = require('lodash'),
   generateAuthrForCollectionFromOpenAPI = require('./generateAuthForCollectionFromOpenAPI'),
-  COLLECTION_NAME = 'Imported from OpenAPI 3.0',
+  COLLECTION_NAME = 'Imported from OpenAPI',
 
   /**
    * Returns a description that's usable at the collection-level
@@ -93,10 +93,16 @@ module.exports = function ({ openapi }) {
 
   const collectionVariables = resolveCollectionVariablesForBaseUrlFromServersObject(_.get(openapi, 'servers.0'));
 
+  let name = _.get(this.openapi, 'info.title');
+
+  if (_.isEmpty(name) || !_.isString(name)) {
+    name = COLLECTION_NAME;
+  }
+
   return {
     data: {
       info: {
-        name: _.get(openapi, 'info.title', COLLECTION_NAME),
+        name: name,
         description: getCollectionDescription(openapi)
       },
       auth: generateAuthrForCollectionFromOpenAPI(openapi, openapi.security)

--- a/libV2/utils.js
+++ b/libV2/utils.js
@@ -1,5 +1,8 @@
 const sdk = require('postman-collection'),
   _ = require('lodash'),
+
+  // This is the default collection name if one can't be inferred from the OpenAPI spec
+  COLLECTION_NAME = 'Imported from OpenAPI',
   generatePmResponseObject = (response) => {
     const requestItem = generateRequestItemObject({ // eslint-disable-line no-use-before-define
         request: response.originalRequest
@@ -180,6 +183,20 @@ module.exports = {
       return '{' + p1 + '}';
     };
     return _.isString(url) ? url.replace(/(\{[^\/\{\}]+\})/g, replacer) : '';
+  },
+
+  /**
+   * Provides collection name to be used for generated collection
+   *
+   * @param {*} title - Definition title
+   * @returns {String} - Collection name
+   */
+  getCollectionName: function (title) {
+    if (_.isEmpty(title) || !_.isString(title)) {
+      return COLLECTION_NAME;
+    }
+
+    return title;
   },
 
   generatePmResponseObject,

--- a/test/data/valid_openapi/empty-title.yaml
+++ b/test/data/valid_openapi/empty-title.yaml
@@ -1,0 +1,127 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: ''
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - name: variable
+          in: query
+          description: random variable
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: variable2
+          in: query
+          description: another random variable
+          style: spaceDelimited
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int64
+      responses:
+        '200':
+          description: An paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:    
+              schema:
+                $ref: "https://postman-echo.com/get"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -758,6 +758,27 @@ describe('CONVERT FUNCTION TESTS ', function() {
       });
     });
 
+    it('Should return validation result for an definition with empty title field', function(done) {
+      var invalidNoInfo = path.join(__dirname, VALID_OPENAPI_PATH + '/empty-title.yaml'),
+        openapi = fs.readFileSync(invalidNoInfo, 'utf8');
+      Converter.getMetaData({ type: 'json', data: openapi }, (err, status) => {
+        if (err) {
+          expect.fail(null, null, err);
+        }
+        if (status.result) {
+          expect(status.result).to.be.eq(true);
+          expect(status.name).to.be.equal('Imported from OpenAPI');
+          expect(status.output[0].name).to.be.equal('Imported from OpenAPI');
+          expect(status.output[0].type).to.be.equal('collection');
+          done();
+        }
+        else {
+          expect.fail(null, null, status.reason);
+          done();
+        }
+      });
+    });
+
     it('Should return error for more than one root files', function(done) {
       let folderPath = path.join(__dirname, '../data/multiFile_with_two_root'),
         array = [
@@ -2144,6 +2165,25 @@ describe('CONVERT FUNCTION TESTS ', function() {
     </TxInfAndSts>
   </OrgnlPmtInfAndSts>
 </CstmrPmtStsRpt>`);
+        done();
+      });
+    });
+
+    it('Should convert definition with empty title field correctly with default name', function(done) {
+      const fileData = fs.readFileSync(path.join(__dirname, VALID_OPENAPI_PATH, 'empty-title.yaml'), 'utf8'),
+        input = {
+          type: 'string',
+          data: fileData
+        };
+
+      Converter.convert(input, { }, (error, result) => {
+        expect(error).to.be.null;
+        expect(result.result).to.equal(true);
+        expect(result.output.length).to.equal(1);
+        expect(result.output[0].type).to.have.equal('collection');
+        expect(result.output[0].data).to.have.property('info');
+        expect(result.output[0].data.info.name).to.eql('Imported from OpenAPI');
+        expect(result.output[0].data).to.have.property('item');
         done();
       });
     });

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -2310,4 +2310,23 @@ describe('The convert v2 Function', function() {
         done();
       });
   });
+
+  it('Should convert definition with empty title field correctly with default name', function(done) {
+    const fileData = fs.readFileSync(path.join(__dirname, VALID_OPENAPI_PATH, 'empty-title.yaml'), 'utf8'),
+      input = {
+        type: 'string',
+        data: fileData
+      };
+
+    Converter.convert(input, { }, (error, result) => {
+      expect(error).to.be.null;
+      expect(result.result).to.equal(true);
+      expect(result.output.length).to.equal(1);
+      expect(result.output[0].type).to.have.equal('collection');
+      expect(result.output[0].data).to.have.property('info');
+      expect(result.output[0].data.info.name).to.eql('Imported from OpenAPI');
+      expect(result.output[0].data).to.have.property('item');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
## Overview

This PR fixes issue where for definitions, when `title` field was mentioned as empty string. The generated collection did contain empty collection name rather than default collection name.