### PR TITLE
Fixed issue where collection generation took very large time.

### DIFF
--- a/assets/json-schema-faker.js
+++ b/assets/json-schema-faker.js
@@ -24188,7 +24188,14 @@ function extend() {
           var element = traverseCallback(value.items || sample, itemSubpath, resolve, null, seenSchemaCache);
           items.push(element);
       }
-      if (value.uniqueItems) {
+
+      /**
+       * Below condition puts more computation load to check unique data across multiple items by
+       * traversing through all data and making sure it's unique.
+       * As such only apply unique constraint when parameter resolution is set to "example".
+       * As in other case, i.e. "schema", generated value for will be same anyways.
+       */
+      if (value.uniqueItems && optionAPI('useExamplesValue')) {
           return unique(path.concat(['items']), items, value, sample, resolve, traverseCallback, seenSchemaCache);
       }
       return items;


### PR DESCRIPTION
## Overview

This PR fixes issue where certain definition were taking very large amount of time to generate collection. Specifically this was happening when `parametersResolution` option is set to `Schema`. When set to `Schema` conversion was taking >4 mins or so, meanwhile using `example` only took ~4 sec to convert.

## RCA

Upon further debugging, I found out that all time taken was by `json-schema-faker` library. And also, that too when corresponding schema that was being faked contained `uniqueItems: true` constraint.

When `uniqueItems` set to true, `json-schema-faker` library goes through faked data and tries to compare all items in array and only adds unique items to array. And in cases of very large and complex arrays, this process of comparison takes large amount of times especially when `Schema` as value to the option `parametersResolution` is used because essentially all items in array would be same and this comparison has to go through all data in the array.

As for `Example` value this process doesn't take long because at very starting of any array, some value will be unique due to random faked data. So process doesn't go through all elements of item.

## Fix

We'll be not going through the process of determining all items to be unique in case when `parametersResolution` is set to `Schema`.
