### PR TITLE
Reduced collection size by keeping maximum generated elements for array as 1 for larger schemas.

### DIFF
--- a/assets/json-schema-faker.js
+++ b/assets/json-schema-faker.js
@@ -24165,11 +24165,11 @@ function extend() {
       var maxItems = value.maxItems;
 
       /**
-       * Json schema faker fakes exactly maxItems # of elements in array
-       *  Hence keeping maxItems as minimum and valid as possible for schema faking (to lessen faked items)
-       *  We have enforced limit to maxItems as 20, set by Json schema faker option
+       * Json schema faker fakes exactly maxItems # of elements in array if present.
+       * Hence we're keeping maxItems as minimum and valid as possible for schema faking (to lessen faked items)
+       * Maximum allowed maxItems is set to 20, set by Json schema faker option.
        */
-      // Override minItems to default (2) if no minItems present
+      // Override minItems to defaultMinItems if no minItems present
       if (typeof minItems !== 'number' && maxItems && maxItems >= optionAPI('defaultMinItems')) {
         minItems = optionAPI('defaultMinItems');
       }
@@ -24179,7 +24179,7 @@ function extend() {
         maxItems = minItems;
       }
 
-      // If no maxItems is defined than override with default (2)
+      // If no maxItems is defined than override with defaultMaxItems
       typeof maxItems !== 'number' && (maxItems = optionAPI('defaultMaxItems'));
 
       if (optionAPI('minItems') && minItems === undefined) {

--- a/assets/json-schema-faker.js
+++ b/assets/json-schema-faker.js
@@ -23585,6 +23585,8 @@ function extend() {
               data['requiredOnly'] = false;
               data['minItems'] = 0;
               data['maxItems'] = null;
+              data['defaultMinItems'] = 2;
+              data['defaultMaxItems'] = 2;
               data['maxLength'] = null;
               data['resolveJsonPath'] = false;
               data['reuseProperties'] = false;
@@ -24161,6 +24163,25 @@ function extend() {
       }
       var minItems = value.minItems;
       var maxItems = value.maxItems;
+
+      /**
+       * Json schema faker fakes exactly maxItems # of elements in array
+       *  Hence keeping maxItems as minimum and valid as possible for schema faking (to lessen faked items)
+       *  We have enforced limit to maxItems as 20, set by Json schema faker option
+       */
+      // Override minItems to default (2) if no minItems present
+      if (typeof minItems !== 'number' && maxItems && maxItems >= optionAPI('defaultMinItems')) {
+        minItems = optionAPI('defaultMinItems');
+      }
+
+      // Override maxItems to minItems if minItems is available
+      if (typeof minItems === 'number' && minItems > 0) {
+        maxItems = minItems;
+      }
+
+      // If no maxItems is defined than override with default (2)
+      typeof maxItems !== 'number' && (maxItems = optionAPI('defaultMaxItems'));
+
       if (optionAPI('minItems') && minItems === undefined) {
           // fix boundaries
           minItems = !maxItems


### PR DESCRIPTION
## Overview

This PR adds support for restricting the elements generated in collection from default 2 to 1 element based upon the schema size. Current threshold for this is for schemas larger than 50 KB.

## Solution

We've removed the part where `minItems` and `maxItems` were had coded into schema while resolution and added support for this in `json-schema-faker` library. In jsf library we've added similar logic by usage of options that can be configured while using this library. And while faking the schema, we use these options depending upon the schema size.