### PR TITLE
Added support for usage of XML examples of type string.

### DIFF
--- a/lib/xmlSchemaFaker.js
+++ b/lib/xmlSchemaFaker.js
@@ -50,7 +50,11 @@ function convertSchemaToXML(name, schema, attribute, indentChar, indent, resolve
     }
   }
   else if (schema.type === 'object') {
-    if (resolveTo === 'example' && typeof schemaExample !== 'undefined') {
+    // Use mentioned example in string directly as example
+    if (resolveTo === 'example' && typeof schemaExample === 'string') {
+      return '\n' + schemaExample;
+    }
+    else if (resolveTo === 'example' && typeof schemaExample === 'object') {
       const elementName = _.get(schema, 'items.xml.name', name || 'element'),
         fakedContent = js2xml({ [elementName]: schemaExample }, indentChar);
 
@@ -95,7 +99,11 @@ function convertSchemaToXML(name, schema, attribute, indentChar, indent, resolve
 
     schemaItemsWithXmlProps.xml = schema.xml;
 
-    if (resolveTo === 'example' && typeof schemaExample !== 'undefined') {
+    // Use mentioned example in string directly as example
+    if (resolveTo === 'example' && typeof schemaExample === 'string') {
+      return '\n' + schemaExample;
+    }
+    else if (resolveTo === 'example' && typeof schemaExample === 'object') {
       const fakedContent = js2xml({ [arrayElemName]: schemaExample }, indentChar);
 
       contents = '\n' + indentContent(fakedContent, cIndent);

--- a/libV2/xmlSchemaFaker.js
+++ b/libV2/xmlSchemaFaker.js
@@ -50,7 +50,11 @@ function convertSchemaToXML(name, schema, attribute, indentChar, indent, resolve
     }
   }
   else if (schema.type === 'object') {
-    if (resolveTo === 'example' && typeof schemaExample !== 'undefined') {
+    // Use mentioned example in string directly as example
+    if (resolveTo === 'example' && typeof schemaExample === 'string') {
+      return '\n' + schemaExample;
+    }
+    else if (resolveTo === 'example' && typeof schemaExample === 'object') {
       const elementName = _.get(schema, 'items.xml.name', name || 'element'),
         fakedContent = js2xml({ [elementName]: schemaExample }, indentChar);
 
@@ -95,7 +99,11 @@ function convertSchemaToXML(name, schema, attribute, indentChar, indent, resolve
 
     schemaItemsWithXmlProps.xml = schema.xml;
 
-    if (resolveTo === 'example' && typeof schemaExample !== 'undefined') {
+    // Use mentioned example in string directly as example
+    if (resolveTo === 'example' && typeof schemaExample === 'string') {
+      return '\n' + schemaExample;
+    }
+    else if (resolveTo === 'example' && typeof schemaExample === 'object') {
       const fakedContent = js2xml({ [arrayElemName]: schemaExample }, indentChar);
 
       contents = '\n' + indentContent(fakedContent, cIndent);

--- a/test/data/valid_openapi/xmlExampleWithString.yaml
+++ b/test/data/valid_openapi/xmlExampleWithString.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.3
+info:
+  title: My API
+  version: 1.0.0
+  contact: {}
+servers:
+  - url: "https://api.server.test/v1"
+paths:
+  /test:
+    post:
+      summary: /test
+      description: /test
+      operationId: test
+      requestBody:
+        content:
+          text/xml:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  issue:
+                    type: string
+                    description: information about the issue
+                    maxLength: 150
+                  action:
+                    type: string
+                    description: what corrective action needs to be taken to resolve the issue.
+                    maxLength: 150
+              example: |
+                <Errors>
+                  <error>
+                    <issue>Mandatory field are missing.</issue>
+                    <action>Resend request with valid values, any one of Hello or World.</action>
+                  </error>
+                </Errors>
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              examples:
+                OK:
+                  value: 
+                    Data: Postman
+tags: []

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -55,6 +55,7 @@ describe('CONVERT FUNCTION TESTS ', function() {
       valuePropInExample = path.join(__dirname, VALID_OPENAPI_PATH, '/valuePropInExample.yaml'),
       petstoreParamExample = path.join(__dirname, VALID_OPENAPI_PATH, '/petstoreParamExample.yaml'),
       xmlrequestBody = path.join(__dirname, VALID_OPENAPI_PATH, '/xmlExample.yaml'),
+      xmlrequestExampleBody = path.join(__dirname, VALID_OPENAPI_PATH, '/xmlExampleWithString.yaml'),
       queryParamWithEnumResolveAsExample =
         path.join(__dirname, VALID_OPENAPI_PATH, '/query_param_with_enum_resolve_as_example.json'),
       formDataParamDescription = path.join(__dirname, VALID_OPENAPI_PATH, '/form_data_param_description.yaml'),
@@ -1251,6 +1252,25 @@ describe('CONVERT FUNCTION TESTS ', function() {
               '      <ubiNum>500</ubiNum>\n    </NumberToWords>\n  </soap:Body>\n' +
               '</soap:Envelope>'
             );
+          done();
+        });
+    });
+
+    it('Should convert xml request body with complete string example correctly', function(done) {
+      const openapi = fs.readFileSync(xmlrequestExampleBody, 'utf8');
+      Converter.convert({ type: 'string', data: openapi },
+        { schemaFaker: true, requestParametersResolution: 'Example' }, (err, conversionResult) => {
+          expect(err).to.be.null;
+          expect(conversionResult.result).to.equal(true);
+          expect(conversionResult.output[0].data.item[0].request.body.raw)
+            .to.equal(`<?xml version="1.0" encoding="UTF-8"?>
+<Errors>
+  <error>
+    <issue>Mandatory field are missing.</issue>
+    <action>Resend request with valid values, any one of Hello or World.</action>
+  </error>
+</Errors>
+`);
           done();
         });
     });

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -48,6 +48,7 @@ const expect = require('chai').expect,
   valuePropInExample = path.join(__dirname, VALID_OPENAPI_PATH, '/valuePropInExample.yaml'),
   petstoreParamExample = path.join(__dirname, VALID_OPENAPI_PATH, '/petstoreParamExample.yaml'),
   xmlrequestBody = path.join(__dirname, VALID_OPENAPI_PATH, '/xmlExample.yaml'),
+  xmlrequestExampleBody = path.join(__dirname, VALID_OPENAPI_PATH, '/xmlExampleWithString.yaml'),
   queryParamWithEnumResolveAsExample =
     path.join(__dirname, VALID_OPENAPI_PATH, '/query_param_with_enum_resolve_as_example.json'),
   formDataParamDescription = path.join(__dirname, VALID_OPENAPI_PATH, '/form_data_param_description.yaml'),
@@ -1103,6 +1104,25 @@ describe('The convert v2 Function', function() {
             '      <ubiNum>500</ubiNum>\n    </NumberToWords>\n  </soap:Body>\n' +
             '</soap:Envelope>'
           );
+        done();
+      });
+  });
+
+  it('Should convert xml request body with complete string example correctly', function(done) {
+    const openapi = fs.readFileSync(xmlrequestExampleBody, 'utf8');
+    Converter.convert({ type: 'string', data: openapi },
+      { schemaFaker: true, requestParametersResolution: 'Example' }, (err, conversionResult) => {
+        expect(err).to.be.null;
+        expect(conversionResult.result).to.equal(true);
+        expect(conversionResult.output[0].data.item[0].request.body.raw)
+          .to.equal(`<?xml version="1.0" encoding="UTF-8"?>
+<Errors>
+  <error>
+    <issue>Mandatory field are missing.</issue>
+    <action>Resend request with valid values, any one of Hello or World.</action>
+  </error>
+</Errors>
+`);
         done();
       });
   });

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -1110,11 +1110,11 @@ describe('The convert v2 Function', function() {
 
   it('Should convert xml request body with complete string example correctly', function(done) {
     const openapi = fs.readFileSync(xmlrequestExampleBody, 'utf8');
-    Converter.convert({ type: 'string', data: openapi },
-      { schemaFaker: true, requestParametersResolution: 'Example' }, (err, conversionResult) => {
+    Converter.convertV2({ type: 'string', data: openapi },
+      { schemaFaker: true, parametersResolution: 'Example' }, (err, conversionResult) => {
         expect(err).to.be.null;
         expect(conversionResult.result).to.equal(true);
-        expect(conversionResult.output[0].data.item[0].request.body.raw)
+        expect(conversionResult.output[0].data.item[0].item[0].request.body.raw)
           .to.equal(`<?xml version="1.0" encoding="UTF-8"?>
 <Errors>
   <error>


### PR DESCRIPTION
## Overview

This PR adds support for usage of string type of XML examples even for complex types like object and array. Existing support for constructing example based on `xml` field will still continue to support but mentioning example at any schema level of type string will override the mentioned example to be used in generated collection.