### PR TITLE
Checking that values should not be null or undefined before using

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -634,7 +634,7 @@ module.exports = {
     Object.assign(specComponentsAndUtils, concreteUtils.getRequiredData(spec));
 
     for (path in paths) {
-      if (paths.hasOwnProperty(path)) {
+      if (paths.hasOwnProperty(path) && (paths[path] !== undefined || paths[path] !== null)) {
         currentPathObject = paths[path];
 
         // discard the leading slash, if it exists

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -634,7 +634,7 @@ module.exports = {
     Object.assign(specComponentsAndUtils, concreteUtils.getRequiredData(spec));
 
     for (path in paths) {
-      if (paths.hasOwnProperty(path) && paths[path] && typeof paths[path] === 'object') {
+      if (paths.hasOwnProperty(path) && typeof paths[path] === 'object' && paths[path]) {
         currentPathObject = paths[path];
 
         // discard the leading slash, if it exists

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -634,7 +634,7 @@ module.exports = {
     Object.assign(specComponentsAndUtils, concreteUtils.getRequiredData(spec));
 
     for (path in paths) {
-      if (paths.hasOwnProperty(path) && typeof paths[path] === 'object') {
+      if (paths.hasOwnProperty(path) && paths[path] && typeof paths[path] === 'object') {
         currentPathObject = paths[path];
 
         // discard the leading slash, if it exists

--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -634,7 +634,7 @@ module.exports = {
     Object.assign(specComponentsAndUtils, concreteUtils.getRequiredData(spec));
 
     for (path in paths) {
-      if (paths.hasOwnProperty(path) && (paths[path] !== undefined || paths[path] !== null)) {
+      if (paths.hasOwnProperty(path) && typeof paths[path] === 'object') {
         currentPathObject = paths[path];
 
         // discard the leading slash, if it exists

--- a/lib/xmlSchemaFaker.js
+++ b/lib/xmlSchemaFaker.js
@@ -14,6 +14,10 @@ function convertSchemaToXML(name, schema, attribute, indentChar, indent, resolve
     cIndent = _.times(indent, _.constant(indentChar)).join(''),
     retVal = '';
 
+  if (schema === null || typeof schema === 'undefined') {
+    return retVal;
+  }
+
   const schemaExample = typeof schema === 'object' && (schema.example);
 
   name = _.get(schema, 'xml.name', name || 'element');

--- a/libV2/xmlSchemaFaker.js
+++ b/libV2/xmlSchemaFaker.js
@@ -14,6 +14,10 @@ function convertSchemaToXML(name, schema, attribute, indentChar, indent, resolve
     cIndent = _.times(indent, _.constant(indentChar)).join(''),
     retVal = '';
 
+  if (schema === null || typeof schema === 'undefined') {
+    return retVal;
+  }
+
   const schemaExample = typeof schema === 'object' && (schema.example);
 
   name = _.get(schema, 'xml.name', name || 'element');


### PR DESCRIPTION
Added checks for null and undefined values for these errors:-
- Cannot read properties of undefined (reading 'type')
- Cannot read properties of null (reading 'hasOwnProperty')