### PR TITLE
Copy path variable description to generated collection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "oas-resolver-browser": "2.5.6",
         "object-hash": "3.0.0",
         "path-browserify": "1.0.1",
-        "postman-collection": "4.1.5",
+        "postman-collection": "4.2.1",
         "swagger2openapi": "7.0.8",
         "traverse": "0.6.6",
         "yaml": "1.10.2"
@@ -4253,9 +4253,9 @@
       }
     },
     "node_modules/postman-collection": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.1.5.tgz",
-      "integrity": "sha512-BY3NfP7EYExZG5ER9P82r0ZRc17z88WZAzn121EpWC8FM3HYtFwWJpXOsZk+2MKFn3agCq4JPRhnWw3G6XBXgw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.2.1.tgz",
+      "integrity": "sha512-DFLt3/yu8+ldtOTIzmBUctoupKJBOVK4NZO0t68K2lIir9smQg7OdQTBjOXYy+PDh7u0pSDvD66tm93eBHEPHA==",
       "dependencies": {
         "@faker-js/faker": "5.5.3",
         "file-type": "3.9.0",
@@ -4266,7 +4266,7 @@
         "mime-format": "2.0.1",
         "mime-types": "2.1.35",
         "postman-url-encoder": "3.0.5",
-        "semver": "7.3.7",
+        "semver": "7.5.4",
         "uuid": "8.3.2"
       },
       "engines": {
@@ -4296,9 +4296,9 @@
       }
     },
     "node_modules/postman-collection/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -8776,9 +8776,9 @@
       }
     },
     "postman-collection": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.1.5.tgz",
-      "integrity": "sha512-BY3NfP7EYExZG5ER9P82r0ZRc17z88WZAzn121EpWC8FM3HYtFwWJpXOsZk+2MKFn3agCq4JPRhnWw3G6XBXgw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.2.1.tgz",
+      "integrity": "sha512-DFLt3/yu8+ldtOTIzmBUctoupKJBOVK4NZO0t68K2lIir9smQg7OdQTBjOXYy+PDh7u0pSDvD66tm93eBHEPHA==",
       "requires": {
         "@faker-js/faker": "5.5.3",
         "file-type": "3.9.0",
@@ -8789,7 +8789,7 @@
         "mime-format": "2.0.1",
         "mime-types": "2.1.35",
         "postman-url-encoder": "3.0.5",
-        "semver": "7.3.7",
+        "semver": "7.5.4",
         "uuid": "8.3.2"
       },
       "dependencies": {
@@ -8810,9 +8810,9 @@
           }
         },
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "object-hash": "3.0.0",
     "graphlib": "2.1.8",
     "path-browserify": "1.0.1",
-    "postman-collection": "4.1.5",
+    "postman-collection": "4.2.1",
     "swagger2openapi": "7.0.8",
     "traverse": "0.6.6",
     "yaml": "1.10.2"

--- a/test/data/valid_openapi/description-test.yaml
+++ b/test/data/valid_openapi/description-test.yaml
@@ -1,0 +1,37 @@
+openapi: "3.0.0"
+info:
+  version: "1.0.0"
+  title: "Sample API"
+  description: Buy or rent spacecrafts
+
+paths:
+  /space/{spacecraftId}:
+    get:
+      parameters:
+        - name: spacecraftId
+          description: PATH_PARAM_DESCRIPTION
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: QUERY_PARAM_DESCRIPTION
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - name: page
+          in: header
+          description: "HEADER_DESCRIPTION_NOT_PRESENT"
+          required: false
+          schema:
+            type: string
+      summary: Read a spacecraft
+      responses:
+        "201":
+          description: The spacecraft corresponding to the provided `spacecraftId`
+          content:
+            application/json:
+              schema:
+                type: string

--- a/test/data/valid_openapi/description-test.yaml
+++ b/test/data/valid_openapi/description-test.yaml
@@ -9,24 +9,44 @@ paths:
     get:
       parameters:
         - name: spacecraftId
-          description: PATH_PARAM_DESCRIPTION
+          description: "Required spacecraftId path param"
           in: path
           required: true
           schema:
             type: string
+        - name: pathParamOptional
+          description: "Path param optional description"
+          in: path
+          required: false
+          schema:
+            type: string
         - name: limit
           in: query
-          description: QUERY_PARAM_DESCRIPTION
+          description: "QUERY PARAM DESCRIPTION"
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - name: optionalQueryParam
+          in: query
+          description: "QUERY PARAM Optional"
           required: false
           schema:
             type: integer
             format: int32
         - name: page
           in: header
-          description: "HEADER_DESCRIPTION_NOT_PRESENT"
+          description: "HEADER PARAM DESCRIPTION"
+          required: true
+          schema:
+            type: string
+        - name: offset
+          in: header
+          description: "HEADER PARAM Optional"
           required: false
           schema:
             type: string
+
       summary: Read a spacecraft
       responses:
         "201":

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -1176,12 +1176,12 @@ describe('The convert v2 Function', function() {
 
     Converter.convertV2({ type: 'string', data: openapi },
       {}, (err, conversionResult) => {
-        expect(conversionResult.output[0].data.item[0].item[0].item[0].request.url.query[0].description.content).to.equal(
-          '(Required) QUERY PARAM DESCRIPTION'
-        );
-        expect(conversionResult.output[0].data.item[0].item[0].item[0].request.url.query[1].description.content).to.equal(
-          'QUERY PARAM Optional'
-        );
+        expect(
+          conversionResult.output[0].data.item[0].item[0].item[0].request.url.query[0].description.content)
+          .to.equal('(Required) QUERY PARAM DESCRIPTION');
+        expect(
+          conversionResult.output[0].data.item[0].item[0].item[0].request.url.query[1].description.content)
+          .to.equal('QUERY PARAM Optional');
         expect(conversionResult.output[0].data.item[0].item[0].item[0].request.url.variable[0].description).to.equal(
           '(Required) Required spacecraftId path param'
         );

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -54,6 +54,7 @@ const expect = require('chai').expect,
     path.join(__dirname, VALID_OPENAPI_PATH, '/query_param_with_enum_resolve_as_example.json'),
   formDataParamDescription = path.join(__dirname, VALID_OPENAPI_PATH, '/form_data_param_description.yaml'),
   allHTTPMethodsSpec = path.join(__dirname, VALID_OPENAPI_PATH, '/all-http-methods.yaml'),
+  descriptionTestSpec = path.join(__dirname, VALID_OPENAPI_PATH, '/description-test.yaml'),
   invalidNullInfo = path.join(__dirname, INVALID_OPENAPI_PATH, '/invalid-null-info.json'),
   invalidNullInfoTitle = path.join(__dirname, INVALID_OPENAPI_PATH, '/invalid-info-null-title.json'),
   invalidNullInfoVersion = path.join(__dirname, INVALID_OPENAPI_PATH, '/invalid-info-null-version.json'),
@@ -1166,6 +1167,24 @@ describe('The convert v2 Function', function() {
           .to.equal('Request param description');
         expect(conversionResult.output[0].data.item[0].item[0].request.body.formdata[0].key).to.equal('requestParam');
         expect(conversionResult.output[0].data.item[0].item[0].request.body.formdata[0].value).to.be.a('string');
+        done();
+      });
+  });
+
+  it('description test', function(done) {
+    var openapi = fs.readFileSync(descriptionTestSpec, 'utf8');
+
+    Converter.convertV2({ type: 'string', data: openapi },
+      {}, (err, conversionResult) => {
+        expect(conversionResult.output[0].data.item[0].item[0].item[0].request.url.query[0].description.content).to.equal(
+          'QUERY PARAM DESCRIPTION'
+        );
+        expect(conversionResult.output[0].data.item[0].item[0].item[0].request.url.variable[0].description).to.equal(
+          'PATH PARAM DESCRIPTION'
+        );
+        expect(conversionResult.output[0].data.item[0].item[0].item[0].request.url.header[0].description).to.equal(
+          'HEADER PARAM DESCRIPTION'
+        );
         done();
       });
   });

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -1171,7 +1171,7 @@ describe('The convert v2 Function', function() {
       });
   });
 
-  it('description test', function(done) {
+  it('should generate a collection with description for Query Params, Path variables and Headers', function(done) {
     var openapi = fs.readFileSync(descriptionTestSpec, 'utf8');
 
     Converter.convertV2({ type: 'string', data: openapi },

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -1177,13 +1177,22 @@ describe('The convert v2 Function', function() {
     Converter.convertV2({ type: 'string', data: openapi },
       {}, (err, conversionResult) => {
         expect(conversionResult.output[0].data.item[0].item[0].item[0].request.url.query[0].description.content).to.equal(
-          'QUERY PARAM DESCRIPTION'
+          '(Required) QUERY PARAM DESCRIPTION'
+        );
+        expect(conversionResult.output[0].data.item[0].item[0].item[0].request.url.query[1].description.content).to.equal(
+          'QUERY PARAM Optional'
         );
         expect(conversionResult.output[0].data.item[0].item[0].item[0].request.url.variable[0].description).to.equal(
-          'PATH PARAM DESCRIPTION'
+          '(Required) Required spacecraftId path param'
         );
-        expect(conversionResult.output[0].data.item[0].item[0].item[0].request.url.header[0].description).to.equal(
-          'HEADER PARAM DESCRIPTION'
+        expect(conversionResult.output[0].data.item[0].item[0].item[0].request.url.variable[1].description).to.equal(
+          'Path param optional description'
+        );
+        expect(conversionResult.output[0].data.item[0].item[0].item[0].request.header[0].description.content).to.equal(
+          '(Required) HEADER PARAM DESCRIPTION'
+        );
+        expect(conversionResult.output[0].data.item[0].item[0].item[0].request.header[1].description.content).to.equal(
+          'HEADER PARAM Optional'
         );
         done();
       });


### PR DESCRIPTION
Earlier version of `postman-collection` did not support updating the description of a Path variable via the assimilate method of PropertyList.
Hence, the generated collection would never have the description of path variables.

The issue has been fixed in postman-collection and updating to the newer version fixes the issue.
Verified by unit test and attaching a screenshot of the generated collection for reference:
<img width="1512" alt="Screenshot 2023-09-11 at 6 56 48 PM" src="https://github.com/postmanlabs/openapi-to-postman/assets/3127114/9de5ae0c-9793-4cf1-8664-a38bcd8422b8">

<img width="1512" alt="Screenshot 2023-09-11 at 6 56 51 PM" src="https://github.com/postmanlabs/openapi-to-postman/assets/3127114/11e8eb9c-dcaa-4c0f-a0a8-1974cca2dcf7">


---

A similar issue didn't exist for Query params or Headers because there are different interfaces for the same which forwarded those properties without any cleanup. But just added unit tests for future reference


