### PR TITLE
Fixed an issue where allOf schemas with both having enum were not resolved correctly.

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -133,7 +133,12 @@ module.exports = {
       }), {
         resolvers: {
           // for keywords in OpenAPI schema that are not standard defined JSON schema keywords, use default resolver
-          defaultResolver: (compacted) => { return compacted[0]; }
+          defaultResolver: (compacted) => { return compacted[0]; },
+
+          // Default resolver seems to fail for enum, so adding custom resolver that will return all unique enum values
+          enum: (values) => {
+            return _.uniq(_.concat(...values));
+          }
         }
       });
     }

--- a/libV2/schemaUtils.js
+++ b/libV2/schemaUtils.js
@@ -458,7 +458,10 @@ let QUERYPARAM = 'query',
       }), {
         resolvers: {
           // for keywords in OpenAPI schema that are not standard defined JSON schema keywords, use default resolver
-          defaultResolver: (compacted) => { return compacted[0]; }
+          defaultResolver: (compacted) => { return compacted[0]; },
+          enum: (values) => {
+            return _.uniq(_.concat(...values));
+          }
         }
       });
     }

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -2069,6 +2069,28 @@ describe('The convert v2 Function', function() {
       });
     });
 
+    it('[GITHUB #417] - should convert file with enum as conflicts while merging allOf keyword', function() {
+      const fileSource = path.join(__dirname, VALID_OPENAPI_PATH, 'enumAllOfConflicts.yaml'),
+        fileData = fs.readFileSync(fileSource, 'utf8'),
+        input = {
+          type: 'string',
+          data: fileData
+        };
+
+      Converter.convertV2(input, {
+        optimizeConversion: false
+      }, (err, result) => {
+        const expectedResponseBody = JSON.parse(result.output[0].data.item[0].item[0].response[0].body);
+        expect(err).to.be.null;
+        expect(result.result).to.be.true;
+        expect(expectedResponseBody).to.be.an('object');
+        expect(expectedResponseBody).to.have.property('status');
+        expect(expectedResponseBody.status).to.be.a('string');
+        expect(expectedResponseBody.status).to.be.oneOf(['no_market', 'too_small', 'too_large',
+          'incomplete', 'completed', 'refunded']);
+      });
+    });
+
     it('Should convert a swagger document with XML example correctly', function(done) {
       const fileData = fs.readFileSync(path.join(__dirname, SWAGGER_20_FOLDER_YAML, 'xml_example.yaml'), 'utf8'),
         input = {

--- a/test/unit/deref.test.js
+++ b/test/unit/deref.test.js
@@ -377,6 +377,10 @@ describe('DEREF FUNCTION TESTS ', function() {
                 'type': 'string',
                 'format': 'uuid'
               },
+              'status': {
+                'type': 'string',
+                'enum': ['incomplete', 'completed', 'refunded']
+              },
               'actionId': { 'type': 'integer', 'minimum': 5 },
               'result': { 'type': 'object' }
             },
@@ -390,6 +394,10 @@ describe('DEREF FUNCTION TESTS ', function() {
                   'err': { 'type': 'string' },
                   'data': { 'type': 'object' }
                 }
+              },
+              'status': {
+                'type': 'string',
+                'enum': ['no_market', 'too_small', 'too_large']
               }
             }
           }
@@ -407,6 +415,10 @@ describe('DEREF FUNCTION TESTS ', function() {
           source: {
             type: 'string',
             format: 'uuid'
+          },
+          status: {
+            type: 'string',
+            enum: ['incomplete', 'completed', 'refunded', 'no_market', 'too_small', 'too_large']
           },
           actionId: { 'type': 'integer', 'minimum': 5 },
           result: {


### PR DESCRIPTION
## Overview

Fixes: https://github.com/postmanlabs/openapi-to-postman/issues/417#issuecomment-1546416422

This PR solves issue, where in some cases while resolving/merging the `allOf` schema, the underlying library `json-schema-merge-allof` was throwing error when enums were present in both schemas.

With this PR, we're adding custom resolver for `enum` cases which will keep all unique enums from both schemas as result of resolve/merge.