### PR TITLE
Fixed an issue where schemas under allOf keyword having additionalProperties set to false were not generating bodies correctly.

### DIFF
--- a/lib/deref.js
+++ b/lib/deref.js
@@ -131,6 +131,8 @@ module.exports = {
             { stack, seenRef: _.cloneDeep(seenRef), resolveFor, resolveTo, stackLimit, isAllOf: true, analytics });
         })
       }), {
+        // below option is required to make sure schemas with additionalProperties set to false are resolved correctly
+        ignoreAdditionalProperties: true,
         resolvers: {
           // for keywords in OpenAPI schema that are not standard defined JSON schema keywords, use default resolver
           defaultResolver: (compacted) => { return compacted[0]; },

--- a/libV2/schemaUtils.js
+++ b/libV2/schemaUtils.js
@@ -456,6 +456,8 @@ let QUERYPARAM = 'query',
           return resolveSchema(context, schema, stack, resolveFor, _.cloneDeep(seenRef));
         })
       }), {
+        // below option is required to make sure schemas with additionalProperties set to false are resolved correctly
+        ignoreAdditionalProperties: true,
         resolvers: {
           // for keywords in OpenAPI schema that are not standard defined JSON schema keywords, use default resolver
           defaultResolver: (compacted) => { return compacted[0]; },

--- a/test/data/valid_openapi/allOfAdditionalProperties.json
+++ b/test/data/valid_openapi/allOfAdditionalProperties.json
@@ -1,0 +1,157 @@
+{
+  "x-generator": "NSwag v14.0.3.0 (NJsonSchema v11.0.0.0 (Newtonsoft.Json v13.0.0.0))",
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Join API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/api/Membership": {
+      "post": {
+        "tags": [
+          "Membership"
+        ],
+        "operationId": "PostMember",
+        "requestBody": {
+          "x-name": "query",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StandardJoinCommand"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardJoinDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GetMemberDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "memberId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "comment": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "StandardJoinDto": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseJoinDto"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false
+          }
+        ]
+      },
+      "BaseJoinDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "memberId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "StandardJoinCommand": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseJoinCommandOfStandardJoinDto"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "email": {
+                "type": "string",
+                "nullable": true
+              },
+              "firstName": {
+                "type": "string",
+                "nullable": true
+              },
+              "lastName": {
+                "type": "string",
+                "nullable": true
+              },
+              "address1": {
+                "type": "string",
+                "nullable": true
+              },
+              "city": {
+                "type": "string",
+                "nullable": true
+              },
+              "state": {
+                "type": "string"
+              },
+              "countryCode": {
+                "type": "string",
+                "nullable": true
+              },
+              "zipCode": {
+                "type": "string",
+                "nullable": true
+              },
+              "phoneNumber": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          }
+        ]
+      },
+      "BaseJoinCommandOfStandardJoinDto": {
+        "type": "object",
+        "x-abstract": true,
+        "additionalProperties": false,
+        "properties": {
+          "campaignId": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -2091,6 +2091,28 @@ describe('The convert v2 Function', function() {
       });
     });
 
+    it('[GITHUB #417] - should convert file with allOf schemas containing additionalProperties as false ', function() {
+      const fileSource = path.join(__dirname, VALID_OPENAPI_PATH, 'allOfAdditionalProperties.json'),
+        fileData = fs.readFileSync(fileSource, 'utf8'),
+        input = {
+          type: 'string',
+          data: fileData
+        };
+
+      Converter.convertV2(input, {
+        optimizeConversion: false
+      }, (err, result) => {
+        const expectedRequestBody = JSON.parse(result.output[0].data.item[0].item[0].item[0].request.body.raw);
+
+        expect(err).to.be.null;
+        expect(result.result).to.be.true;
+
+        expect(expectedRequestBody).to.be.an('object');
+        expect(expectedRequestBody).to.have.keys(['phoneNumber', 'zipCode', 'countryCode', 'state', 'city',
+          'address1', 'lastName', 'firstName', 'email', 'campaignId']);
+      });
+    });
+
     it('Should convert a swagger document with XML example correctly', function(done) {
       const fileData = fs.readFileSync(path.join(__dirname, SWAGGER_20_FOLDER_YAML, 'xml_example.yaml'), 'utf8'),
         input = {

--- a/test/unit/deref.test.js
+++ b/test/unit/deref.test.js
@@ -516,6 +516,76 @@ describe('DEREF FUNCTION TESTS ', function() {
       });
       done();
     });
+
+    it('should resolve schemas under allOf keyword with additionalProperties set to false correctly', function (done) {
+      var schema = {
+        'allOf': [
+          {
+            'type': 'object',
+            'additionalProperties': false,
+            'properties': {
+              'source': {
+                'type': 'string',
+                'format': 'uuid'
+              },
+              'status': {
+                'type': 'string',
+                'enum': ['incomplete', 'completed', 'refunded']
+              },
+              'actionId': { 'type': 'integer', 'minimum': 5 },
+              'result': { 'type': 'object' }
+            },
+            'required': ['source', 'actionId', 'result']
+          },
+          {
+            'additionalProperties': false,
+            'properties': {
+              'result': {
+                'type': 'object',
+                'properties': {
+                  'err': { 'type': 'string' },
+                  'data': { 'type': 'object' }
+                }
+              },
+              'status': {
+                'type': 'string',
+                'enum': ['no_market', 'too_small', 'too_large']
+              }
+            }
+          }
+        ]
+      };
+
+      expect(deref.resolveAllOf(
+        schema,
+        'REQUEST',
+        { concreteUtils: schemaUtils30X },
+        { resolveTo: 'example' }
+      )).to.deep.equal({
+        type: 'object',
+        additionalProperties: false,
+        required: ['source', 'actionId', 'result'],
+        properties: {
+          source: {
+            type: 'string',
+            format: 'uuid'
+          },
+          status: {
+            type: 'string',
+            enum: ['incomplete', 'completed', 'refunded', 'no_market', 'too_small', 'too_large']
+          },
+          actionId: { 'type': 'integer', 'minimum': 5 },
+          result: {
+            type: 'object',
+            properties: {
+              err: { 'type': 'string' },
+              data: { 'type': 'object' }
+            }
+          }
+        }
+      });
+      done();
+    });
   });
 
   describe('_getEscaped should', function() {


### PR DESCRIPTION
## Overview

Issue reported by user: https://github.com/postmanlabs/openapi-to-postman/issues/417#issuecomment-2018756292

## RCA

Issue was with merging schemas under `allOf`, specifically having `additionalProperties: false`. Third-party library (https://github.com/mokkabonna/json-schema-merge-allof) used for this purpose was defaulting to resolving no properties in such case leaving the resolved schema body empty.

## Fix

We'll be using suggested option `ignoreAdditionalProperties` as `true` in such cases. This makes sure that we're keeping request data from schemas underlying `allOf` keywords correctly instead of considering `additionalProperties` in one of schema.

See more about this option here: https://github.com/mokkabonna/json-schema-merge-allof?tab=readme-ov-file#options