### PR TITLE
Added simplified request and response body matching in case of multiple examples.

### DIFF
--- a/libV2/schemaUtils.js
+++ b/libV2/schemaUtils.js
@@ -1082,7 +1082,16 @@ let QUERYPARAM = 'query',
 
   /**
    * Generates postman equivalent examples which contains request and response mappings of
-   * each example based on examples mentioned ind definition
+   * each example based on examples mentioned in definition
+   *
+   * This matching between request bodies and response bodies are done in following order.
+   * 1. Try matching keys from request and response examples
+   * 2. If any key matching is found, we'll generate example from it and ignore non-matching keys
+   * 3. If no matching key is found, we'll generate examples based on positional matching.
+   *
+   * Positional matching means first example in request body will be matched with first example
+   * in response body and so on. Any left over request or response body for which
+   * positional matching is not found, we'll use first req/res example.
    *
    * @param {Object} context - Global context object
    * @param {Object} responseExamples - Examples defined in the response
@@ -1101,10 +1110,7 @@ let QUERYPARAM = 'query',
         return _.toLower(example.key) === _.toLower(key);
       };
 
-    /**
-     * To generate examples, we first try to do matching of request and response examples based on example keys,
-     * If there is any matching found, we'll create example from it and ignore non-matching keys
-     */
+    // Do keys matching first and ignore any leftover req/res body for which matching is not found
     if (matchedKeys.length) {
       _.forEach(matchedKeys, (key) => {
         const matchedRequestExamples = _.filter(requestBodyExamples, (example) => {
@@ -1139,6 +1145,7 @@ let QUERYPARAM = 'query',
       return pmExamples;
     }
 
+    // No key matching between req and res were found, so perform positional matching now
     _.forEach(responseExamples, (responseExample, index) => {
 
       if (!_.isObject(responseExample)) {
@@ -1185,6 +1192,7 @@ let QUERYPARAM = 'query',
     let responseExample,
       responseExampleData;
 
+    // Add any left over request body examples with first response body as matching
     for (let i = 0; i < requestBodyExamples.length; i++) {
 
       if (!usedRequestExamples[i] || pmExamples.length === 0) {

--- a/libV2/schemaUtils.js
+++ b/libV2/schemaUtils.js
@@ -1153,19 +1153,13 @@ let QUERYPARAM = 'query',
       }
 
       let responseExampleData = getExampleData(context, { [responseExample.key]: responseExample.value }),
-        requestExample,
-        matchedRequestBodyExamples = _.filter(requestBodyExamples, ['contentType', responseExample.contentType]);
-
-      // If content-types are not matching, match with any present content-types
-      if (_.isEmpty(matchedRequestBodyExamples)) {
-        matchedRequestBodyExamples = requestBodyExamples;
-      }
+        requestExample;
 
       if (isXMLExample) {
         responseExampleData = getXMLExampleData(context, responseExampleData, responseBodySchema);
       }
 
-      if (_.isEmpty(matchedRequestBodyExamples)) {
+      if (_.isEmpty(requestBodyExamples)) {
         pmExamples.push({
           response: responseExampleData,
           name: _.get(responseExample, 'value.summary') || responseExample.key
@@ -1384,7 +1378,15 @@ let QUERYPARAM = 'query',
           };
         });
       }
-      return generateExamples(context, responseExamples, requestBodyExamples, requestBodySchema, isBodyTypeXML);
+
+      let matchedRequestBodyExamples = _.filter(requestBodyExamples, ['contentType', bodyType]);
+
+      // If content-types are not matching, match with any present content-types
+      if (_.isEmpty(matchedRequestBodyExamples)) {
+        matchedRequestBodyExamples = requestBodyExamples;
+      }
+
+      return generateExamples(context, responseExamples, matchedRequestBodyExamples, requestBodySchema, isBodyTypeXML);
     }
 
     return [{ [bodyKey]: bodyData }];

--- a/test/data/valid_openapi/multiContentTypesMultiExample.json
+++ b/test/data/valid_openapi/multiContentTypesMultiExample.json
@@ -1,0 +1,127 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "servers": [{
+    "url": "http://petstore.swagger.io/v1"
+  }],
+  "paths": {
+    "/pets": {
+      "post": {
+        "summary": "List all pets",
+        "operationId": "pets - updated",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [{
+          "name": "limit1",
+          "in": "query",
+          "description": "How many items to return at one time (max 100)",
+          "schema": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }],
+        "requestBody": {
+          "content": {
+            "application/json": {
+             "schema": {
+              "$ref": "#/components/schemas/Error"
+             },
+             "examples": {
+               "ok_example": {
+                 "value": {
+                    "message": "ok"
+                 }
+               },
+               "not_ok_example": {
+                 "value": {
+                  "message": "fail"
+                 }
+               }
+             }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              },
+              "examples": {
+                "ok_example": {
+                  "value": {
+                     "message": "ok"
+                  }
+                },
+                "not_ok_example": {
+                  "value": {
+                   "message": "fail"
+                  }
+                }
+              }
+             }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "message": "Not Found"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "message": "Not Found"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "message": "Found",
+                  "code": 200123
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/data/valid_openapi/multiExampleRequestVariousResponse.yaml
+++ b/test/data/valid_openapi/multiExampleRequestVariousResponse.yaml
@@ -21,10 +21,6 @@ paths:
               missing-required-parameter:
                 value:
                   includedFields:
-                    - user
-              extra-value:
-                value:
-                  includedFields:
                     - eyeColor
       responses:
         200:
@@ -35,23 +31,54 @@ paths:
                 $ref: "#/components/schemas/Request"
               examples:
                 valid-request:
-                  summary: Complete request
-                  value:
-                    {
-                      "user": 1,
-                      "height": 168,
-                      "weight": 44
-                    }
-                missing-required-parameter:
                   summary: Request with only required params
                   value:
                     {
                       "user": 1
                     }
-                extra-value-2:
+                not-matching-key:
+                  summary: Complete request
                   value:
-                    includedFields:
-                      - eyeColor
+                    {
+                      "user": 99,
+                      "height": 168,
+                      "weight": 44
+                    }
+        400:
+          description: None
+          content:
+            'application/json':
+              schema:
+                $ref: "#/components/schemas/Request"
+              examples:
+                missing-required-parameter:
+                  summary: Request with only bad params
+                  value:
+                    {
+                      "eyeColor": "gray"
+                    }
+        500:
+          description: None
+          content:
+            'application/json':
+              schema:
+                $ref: "#/components/schemas/Request"
+              examples:
+                not-matching-key-1:
+                  summary: Failed request - Negative user
+                  value:
+                    {
+                      "user": -99
+                    }
+                not-matching-key-2:
+                  summary: Failed request - All negatives
+                  value:
+                    {
+                      "user": -999,
+                      "height": -168,
+                      "weight": -44
+                    }
+
 components:
   schemas:
     World:
@@ -75,3 +102,5 @@ components:
         weight:
           type: integer
           description: None
+        eyeColor:
+          type: string


### PR DESCRIPTION
## Overview

This PR simplifies the logic to generate the request examples in case when multiple request and response body examples are mentioned in definition.

## What's changing?

We've removed functionality where if example was used in one response code, it wasn't being used in other response code examples. This was intended before but it creates a lot of confusion to users.

We are also changing how the matching of request and response bodies happens to create examples in below order.

* Check if request and response body have examples with matching keys. ([Example Key](https://drive.google.com/drive/folders/1js3XaZZpeUMIB1BWT3PiMFeI9GPecyjC?usp=sharing))
* If we find any matching, we'll create example with matching keys (request and response example) and ignore other examples with non matching keys.
* If no matching could be found, we'll switch to matching based on Positions. i.e. First response example with first request example, second response example with second request example and so on.
    * If there are req/res examples left for which positional match could not be found, then we'll default to using the first example of counter part.