### PR TITLE
Fixed an issue where duplicate collection variables were generated for certain definitions.

### DIFF
--- a/lib/common/versionUtils.js
+++ b/lib/common/versionUtils.js
@@ -212,9 +212,10 @@ function getSpecVersion({ type, data, specificationVersion }) {
   const openapi30 = getVersionRegexp(VERSION_30),
     openapi31 = getVersionRegexp(VERSION_31),
     openapi20 = getVersionRegexp(VERSION_20),
-    is30 = data.match(openapi30),
-    is31 = data.match(openapi31),
-    is20 = data.match(openapi20);
+    is30 = typeof data === 'string' && data.match(openapi30),
+    is31 = typeof data === 'string' && data.match(openapi31),
+    is20 = typeof data === 'string' && data.match(openapi20);
+
   let version = DEFAULT_SPEC_VERSION;
 
   if (is30) {

--- a/libV2/index.js
+++ b/libV2/index.js
@@ -213,6 +213,11 @@ module.exports = {
       }
     });
 
+    // Remove duplicate variables as different requests could end up creating same variables
+    if (!_.isEmpty(collection.variable)) {
+      collection.variable = _.uniqBy(collection.variable, 'key');
+    }
+
     return cb(null, {
       result: true,
       output: [{

--- a/test/data/valid_openapi/duplicateCollectionVars.json
+++ b/test/data/valid_openapi/duplicateCollectionVars.json
@@ -1,0 +1,56 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "MyTitle",
+    "description": "My Description",
+    "version": "1.0.0",
+    "x-ms-generated-by": {
+      "toolName": "Microsoft.OpenApi.OData",
+      "toolVersion": "1.0.9.0"
+    }
+  },
+  "paths": {
+    "/Path1({MyParam})": {
+      "description": "My path1 description",
+      "get": {
+        "tags": [
+          "MyTag"
+        ],
+        "summary": "does path1",
+        "operationId": "Path1",
+        "parameters": [
+          {
+            "name": "MyParam",
+            "in": "path",
+            "description": "My Param",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          }
+        ]
+      }
+    },
+    "/Path2({MyParam})": {
+      "description": "My path2 description",
+      "get": {
+        "tags": [
+          "MyTag"
+        ],
+        "summary": "does path2",
+        "operationId": "Path2",
+        "parameters": [
+          {
+            "name": "MyParam",
+            "in": "path",
+            "description": "My Param",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -106,7 +106,9 @@ const expect = require('chai').expect,
   multiContentTypesMultiExample =
     path.join(__dirname, VALID_OPENAPI_PATH, '/multiContentTypesMultiExample.json'),
   multiExampleRequestVariousResponse =
-    path.join(__dirname, VALID_OPENAPI_PATH, '/multiExampleRequestVariousResponse.yaml');
+    path.join(__dirname, VALID_OPENAPI_PATH, '/multiExampleRequestVariousResponse.yaml'),
+  duplicateCollectionVars =
+    path.join(__dirname, VALID_OPENAPI_PATH, '/duplicateCollectionVars.json');
 
 
 describe('The convert v2 Function', function() {
@@ -2727,5 +2729,23 @@ describe('The convert v2 Function', function() {
           done();
         });
     });
+  });
+
+  it('[Github #11884] Should not contain duplicate variables created from requests path', function (done) {
+    const openapi = fs.readFileSync(duplicateCollectionVars, 'utf8');
+    Converter.convertV2({ type: 'string', data: openapi }, { parametersResolution: 'Example' },
+      (err, conversionResult) => {
+        expect(err).to.be.null;
+        expect(conversionResult.result).to.equal(true);
+        expect(conversionResult.output.length).to.equal(1);
+        expect(conversionResult.output[0].type).to.equal('collection');
+        expect(conversionResult.output[0].data).to.have.property('info');
+        expect(conversionResult.output[0].data).to.have.property('item');
+        expect(conversionResult.output[0].data).to.have.property('variable');
+        expect(conversionResult.output[0].data.variable).to.have.lengthOf(2);
+        expect(conversionResult.output[0].data.variable[0]).to.have.property('key', 'baseUrl');
+        expect(conversionResult.output[0].data.variable[1]).to.have.property('key', 'MyParam');
+        done();
+      });
   });
 });


### PR DESCRIPTION
## Overview

Fixes: https://github.com/postmanlabs/postman-app-support/issues/11884

This PR fixes an issue where duplicate collection variables were present when requests contained variables in path that's not completely separated by path separator.