### PR TITLE
Updated "postman-collection" usage to be specific to part of module being used.

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2,13 +2,18 @@
  * This file contains util functions that need OAS-awareness
  * utils.js contains other util functions
  */
-
-const { ParseError } = require('./common/ParseError.js');
-
 const { formatDataPath, checkIsCorrectType, isKnownType } = require('./common/schemaUtilsCommon.js'),
   { getConcreteSchemaUtils, isSwagger, validateSupportedVersion } = require('./common/versionUtils.js'),
   async = require('async'),
-  sdk = require('postman-collection'),
+  { Variable } = require('postman-collection/lib/collection/variable'),
+  { QueryParam } = require('postman-collection/lib/collection/query-param'),
+  { Header } = require('postman-collection/lib/collection/header'),
+  { ItemGroup } = require('postman-collection/lib/collection/item-group'),
+  { Item } = require('postman-collection/lib/collection/item'),
+  { FormParam } = require('postman-collection/lib/collection/form-param'),
+  { RequestAuth } = require('postman-collection/lib/collection/request-auth'),
+  { Response } = require('postman-collection/lib/collection/response'),
+  { RequestBody } = require('postman-collection/lib/collection/request-body'),
   schemaFaker = require('../assets/json-schema-faker.js'),
   deref = require('./deref.js'),
   _ = require('lodash'),
@@ -20,6 +25,7 @@ const { formatDataPath, checkIsCorrectType, isKnownType } = require('./common/sc
   { validateSchema } = require('./ajValidation/ajvValidation'),
   inputValidation = require('./30XUtils/inputValidation'),
   traverseUtility = require('traverse'),
+  { ParseError } = require('./common/ParseError.js'),
   SCHEMA_FORMATS = {
     DEFAULT: 'default', // used for non-request-body data and json
     XML: 'xml' // used for request-body XMLs
@@ -511,7 +517,7 @@ module.exports = {
     if (serverVariables) {
       _.forOwn(serverVariables, (value, key) => {
         let description = this.getParameterDescription(value);
-        variables.push(new sdk.Variable({
+        variables.push(new Variable({
           key: key,
           value: value.default || '',
           description: description
@@ -519,7 +525,7 @@ module.exports = {
       });
     }
     if (keyName) {
-      variables.push(new sdk.Variable({
+      variables.push(new Variable({
         key: keyName,
         value: serverUrl,
         type: 'string'
@@ -739,7 +745,7 @@ module.exports = {
   addCollectionItemsFromWebhooks: function(spec, generatedStore, components, options, schemaCache) {
     let webhooksObj = this.generateTrieFromPaths(spec, options, true),
       webhooksTree = webhooksObj.tree,
-      webhooksFolder = new sdk.ItemGroup({ name: 'Webhooks' }),
+      webhooksFolder = new ItemGroup({ name: 'Webhooks' }),
       variableStore = {},
       webhooksVariables = [];
 
@@ -752,7 +758,7 @@ module.exports = {
         webhooksTree.root.children.hasOwnProperty(child) &&
         webhooksTree.root.children[child].requestCount > 0
       ) {
-        webhooksVariables.push(new sdk.Variable({
+        webhooksVariables.push(new Variable({
           key: this.cleanWebhookName(child),
           value: '/',
           type: 'string'
@@ -838,7 +844,7 @@ module.exports = {
       // variableStore contains all the kinds of variable created.
       // Add only the variables with type 'collection' to generatedStore.collection.variables
       if (variableStore[key].type === 'collection') {
-        const collectionVar = new sdk.Variable(variableStore[key]);
+        const collectionVar = new Variable(variableStore[key]);
         generatedStore.collection.variables.add(collectionVar);
       }
     }
@@ -961,7 +967,7 @@ module.exports = {
     // Add all folders created from tags and corresponding operations
     // Iterate from bottom to top order to maintain tag order in spec
     _.forEachRight(tagFolders, (tagFolder, tagName) => {
-      var itemGroup = new sdk.ItemGroup({
+      var itemGroup = new ItemGroup({
         name: tagName,
         description: tagFolder.description
       });
@@ -981,7 +987,7 @@ module.exports = {
     // Add only the variables with type 'collection' to generatedStore.collection.variables
     _.forEach(variableStore, (variable) => {
       if (variable.type === 'collection') {
-        const collectionVar = new sdk.Variable(variable);
+        const collectionVar = new Variable(variable);
         generatedStore.collection.variables.add(collectionVar);
       }
     });
@@ -997,7 +1003,7 @@ module.exports = {
    * resolve references while generating params.
    * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
    * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
-   * @returns {Array<object>} returns an array of sdk.Variable
+   * @returns {Array<object>} returns an array of Collection SDK Variable
    */
   convertPathVariables: function(type, providedPathVars, commonPathVars, components, options, schemaCache) {
     var variables = [];
@@ -1067,7 +1073,7 @@ module.exports = {
     if (resource.requestCount > 1) {
       // only return a Postman folder if this folder has>1 children in its subtree
       // otherwise we can end up with 10 levels of folders with 1 request in the end
-      itemGroup = new sdk.ItemGroup({
+      itemGroup = new ItemGroup({
         name: resource.name
         // TODO: have to add auth here (but first, auth to be put into the openapi tree)
       });
@@ -1308,9 +1314,9 @@ module.exports = {
    */
   generateSdkParam: function (param, location) {
     const sdkElementMap = {
-      'query': sdk.QueryParam,
-      'header': sdk.Header,
-      'path': sdk.Variable
+      'query': QueryParam,
+      'header': Header,
+      'path': Variable
     };
 
     let generatedParam = {
@@ -1913,7 +1919,7 @@ module.exports = {
     convertedHeader = _.get(this.convertParamsWithStyle(header, fakeData, parameterSource,
       components, schemaCache, options), '[0]');
 
-    reqHeader = new sdk.Header(convertedHeader);
+    reqHeader = new Header(convertedHeader);
     reqHeader.description = this.getParameterDescription(header);
 
     return reqHeader;
@@ -1936,7 +1942,7 @@ module.exports = {
       originalParam,
       paramArray = [],
       updateOptions = {},
-      reqBody = new sdk.RequestBody(),
+      reqBody = new RequestBody(),
       contentHeader,
       contentTypes = {},
       rDataMode,
@@ -2021,7 +2027,7 @@ module.exports = {
       };
 
       // add a content type header for each media type for the request body
-      contentHeader = new sdk.Header({
+      contentHeader = new Header({
         key: 'Content-Type',
         value: URLENCODED
       });
@@ -2088,14 +2094,14 @@ module.exports = {
           originalParam.type === 'string' &&
           originalParam.format === 'binary'
         ) {
-          param = new sdk.FormParam({
+          param = new FormParam({
             key: key,
             value: '',
             type: 'file'
           });
         }
         else {
-          param = new sdk.FormParam({
+          param = new FormParam({
             key: key,
             value: value,
             type: 'text'
@@ -2112,7 +2118,7 @@ module.exports = {
         formdata: paramArray
       };
       // add a content type header for the pertaining media type
-      contentHeader = new sdk.Header({
+      contentHeader = new Header({
         key: 'Content-Type',
         value: FORM_DATA
       });
@@ -2177,7 +2183,7 @@ module.exports = {
         };
       }
 
-      contentHeader = new sdk.Header({
+      contentHeader = new Header({
         key: 'Content-Type',
         value: bodyType
       });
@@ -2246,7 +2252,7 @@ module.exports = {
     responseMediaTypes = _.keys(response.content);
 
     if (responseMediaTypes.length > 0) {
-      let acceptHeader = new sdk.Header({
+      let acceptHeader = new Header({
         key: 'Accept',
         value: responseMediaTypes[0]
       });
@@ -2256,7 +2262,7 @@ module.exports = {
       }
     }
 
-    sdkResponse = new sdk.Response({
+    sdkResponse = new Response({
       name: response.description,
       code: code || 500,
       header: responseHeaders,
@@ -2654,7 +2660,7 @@ module.exports = {
     }
 
     // creating the request object
-    item = new sdk.Item({
+    item = new Item({
       name: reqName,
       request: {
         description: operation.description,
@@ -2672,7 +2678,7 @@ module.exports = {
       };
 
       thisAuthObject[authMap[authMeta.currentHelper]] = authMeta.helperAttributes;
-      item.request.auth = new sdk.RequestAuth(thisAuthObject);
+      item.request.auth = new RequestAuth(thisAuthObject);
     }
     else {
       item.request.auth = authHelper;

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -6,7 +6,8 @@ const { getConcreteSchemaUtils } = require('./common/versionUtils.js'),
   Ajv = require('ajv'),
   addFormats = require('ajv-formats'),
   async = require('async'),
-  sdk = require('postman-collection'),
+  { Collection } = require('postman-collection/lib/collection/collection'),
+  { Url } = require('postman-collection/lib/collection/url'),
   OasResolverOptions = {
     resolve: true, // Resolve external references
     jsonSchema: true // Treat $ref like JSON Schema and convert to OpenAPI Schema Objects
@@ -340,7 +341,7 @@ class SchemaPack {
 
         // Creating a new instance of a Postman collection
         // All generated folders and requests will go inside this
-        generatedStore.collection = new sdk.Collection({
+        generatedStore.collection = new Collection({
           info: {
             name: utils.getCollectionName(_.get(openapi, 'info.title'))
           }
@@ -530,7 +531,7 @@ class SchemaPack {
           });
 
           // SDK URL object. Get raw string representation.
-          requestUrl = (new sdk.Url(requestUrl)).toString();
+          requestUrl = (new Url(requestUrl)).toString();
         }
 
         // 1. Look at transaction.request.URL + method, and find matching request from schema

--- a/libV2/index.js
+++ b/libV2/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable one-var */
 const _ = require('lodash'),
-  sdk = require('postman-collection'),
+  { Collection } = require('postman-collection/lib/collection/collection'),
   GraphLib = require('graphlib'),
   generateSkeletonTreeFromOpenAPI = require('./helpers/collection/generateSkeletionTreeFromOpenAPI'),
   generateCollectionFromOpenAPI = require('./helpers/collection/generateCollectionFromOpenAPI'),
@@ -45,7 +45,7 @@ module.exports = {
         case 'collection': {
           // dummy collection to be generated.
           const { data, variables } = generateCollectionFromOpenAPI(context, node);
-          collection = new sdk.Collection(data);
+          collection = new Collection(data);
 
           collection = collection.toJSON();
 

--- a/libV2/utils.js
+++ b/libV2/utils.js
@@ -1,5 +1,6 @@
-const sdk = require('postman-collection'),
-  _ = require('lodash'),
+const _ = require('lodash'),
+  { Item } = require('postman-collection/lib/collection/item'),
+  { Response } = require('postman-collection/lib/collection/response'),
 
   // This is the default collection name if one can't be inferred from the OpenAPI spec
   COLLECTION_NAME = 'Imported from OpenAPI',
@@ -30,7 +31,7 @@ const sdk = require('postman-collection'),
     response.code = response.code.replace(/X|x/g, '0');
     response.code = response.code === 'default' ? 500 : _.toSafeInteger(response.code);
 
-    let sdkResponse = new sdk.Response({
+    let sdkResponse = new Response({
       name: response.name,
       code: response.code,
       header: response.headers,
@@ -50,7 +51,7 @@ const sdk = require('postman-collection'),
     return sdkResponse;
   },
   generateRequestItemObject = (requestObject) => {
-    const requestItem = new sdk.Item(requestObject),
+    const requestItem = new Item(requestObject),
       queryParams = _.get(requestObject, 'request.params.queryParams'),
       pathParams = _.get(requestObject, 'request.params.pathParams', []),
       headers = _.get(requestObject, 'request.headers', []),

--- a/libV2/validationUtils.js
+++ b/libV2/validationUtils.js
@@ -2,7 +2,10 @@
 // TODO: REMOVE THIS ☝🏻
 
 const _ = require('lodash'),
-  sdk = require('postman-collection'),
+  { Header } = require('postman-collection/lib/collection/header'),
+  { QueryParam } = require('postman-collection/lib/collection/query-param'),
+  { Url } = require('postman-collection/lib/collection/url'),
+  { Variable } = require('postman-collection/lib/collection/variable'),
   async = require('async'),
   crypto = require('crypto'),
   schemaFaker = require('../assets/json-schema-faker.js'),
@@ -853,9 +856,9 @@ function checkContentTypeHeader (headers, transactionPathPrefix, schemaPathPrefi
  */
 function generateSdkParam (param, location) {
   const sdkElementMap = {
-    'query': sdk.QueryParam,
-    'header': sdk.Header,
-    'path': sdk.Variable
+    'query': QueryParam,
+    'header': Header,
+    'path': Variable
   };
 
   let generatedParam = {
@@ -1012,7 +1015,7 @@ function convertToPmCollectionVariables (serverVariables, keyName, serverUrl = '
   if (serverVariables) {
     _.forOwn(serverVariables, (value, key) => {
       let description = getParameterDescription(value);
-      variables.push(new sdk.Variable({
+      variables.push(new Variable({
         key: key,
         value: value.default || '',
         description: description
@@ -1020,7 +1023,7 @@ function convertToPmCollectionVariables (serverVariables, keyName, serverUrl = '
     });
   }
   if (keyName) {
-    variables.push(new sdk.Variable({
+    variables.push(new Variable({
       key: keyName,
       value: serverUrl,
       type: 'string'
@@ -2535,7 +2538,7 @@ module.exports = {
       queryParams = [...(requestUrl.query || [])];
 
       // SDK URL object. Get raw string representation.
-      requestUrl = (new sdk.Url(requestUrl)).toString();
+      requestUrl = (new Url(requestUrl)).toString();
     }
 
     // 1. Look at transaction.request.URL + method, and find matching request from schema

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "oas-resolver-browser": "2.5.6",
         "object-hash": "3.0.0",
         "path-browserify": "1.0.1",
-        "postman-collection": "4.2.1",
+        "postman-collection": "^4.4.0",
         "swagger2openapi": "7.0.8",
         "traverse": "0.6.6",
         "yaml": "1.10.2"
@@ -4285,9 +4285,9 @@
       }
     },
     "node_modules/postman-collection": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.2.1.tgz",
-      "integrity": "sha512-DFLt3/yu8+ldtOTIzmBUctoupKJBOVK4NZO0t68K2lIir9smQg7OdQTBjOXYy+PDh7u0pSDvD66tm93eBHEPHA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.4.0.tgz",
+      "integrity": "sha512-2BGDFcUwlK08CqZFUlIC8kwRJueVzPjZnnokWPtJCd9f2J06HBQpGL7t2P1Ud1NEsK9NHq9wdipUhWLOPj5s/Q==",
       "dependencies": {
         "@faker-js/faker": "5.5.3",
         "file-type": "3.9.0",
@@ -8837,9 +8837,9 @@
       }
     },
     "postman-collection": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.2.1.tgz",
-      "integrity": "sha512-DFLt3/yu8+ldtOTIzmBUctoupKJBOVK4NZO0t68K2lIir9smQg7OdQTBjOXYy+PDh7u0pSDvD66tm93eBHEPHA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.4.0.tgz",
+      "integrity": "sha512-2BGDFcUwlK08CqZFUlIC8kwRJueVzPjZnnokWPtJCd9f2J06HBQpGL7t2P1Ud1NEsK9NHq9wdipUhWLOPj5s/Q==",
       "requires": {
         "@faker-js/faker": "5.5.3",
         "file-type": "3.9.0",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "object-hash": "3.0.0",
     "graphlib": "2.1.8",
     "path-browserify": "1.0.1",
-    "postman-collection": "4.2.1",
+    "postman-collection": "^4.4.0",
     "swagger2openapi": "7.0.8",
     "traverse": "0.6.6",
     "yaml": "1.10.2"

--- a/test/system/repository.test.js
+++ b/test/system/repository.test.js
@@ -77,13 +77,10 @@ describe('project repository', function () {
         expect(json.dependencies).to.be.a('object');
       });
 
-      // Unskip before merging
-      it('must point to a valid and precise (no * or ^) semver', function () {
-        json.dependencies && Object.keys(json.dependencies).forEach(function (item) {
-          expect(json.dependencies[item]).to.match(new RegExp('(^((\\d+)\\.(\\d+)\\.(\\d+)|' +
-          '(^npm:[\\dA-Za-z\\-]+@(\\d+)\\.(\\d+)\\.(\\d+)))(?:-([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?' +
-                      '(?:\\+([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?)$'));
-        });
+      it('should have a valid version string in form of <major>.<minor>.<revision>', function () {
+        expect(json.version)
+          // eslint-disable-next-line max-len, security/detect-unsafe-regex
+          .to.match(/^((\d+)\.(\d+)\.(\d+))(?:-([\dA-Za-z-]+(?:\.[\dA-Za-z-]+)*))?(?:\+([\dA-Za-z-]+(?:\.[\dA-Za-z-]+)*))?$/);
       });
     });
 
@@ -92,11 +89,11 @@ describe('project repository', function () {
         expect(json.devDependencies).to.be.a('object');
       });
 
-      it('must point to a valid and precise (no * or ^) semver', function () {
-        json.devDependencies && Object.keys(json.devDependencies).forEach(function (item) {
-          expect(json.devDependencies[item]).to.match(new RegExp('(^((\\d+)\\.(\\d+)\\.(\\d+)|' +
-            '(^npm:[\\dA-Za-z\\-]+@(\\d+)\\.(\\d+)\\.(\\d+)))(?:-([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?' +
-                        '(?:\\+([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?)$'));
+      it('should point to a valid semver', function () {
+        Object.keys(json.devDependencies).forEach(function (dependencyName) {
+          // eslint-disable-next-line security/detect-non-literal-regexp
+          expect(json.devDependencies[dependencyName]).to.match(new RegExp('((\\d+)\\.(\\d+)\\.(\\d+))(?:-' +
+            '([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?(?:\\+([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?$'));
         });
       });
 


### PR DESCRIPTION
## Overview

This PR updates "postman-collection" version used to latest. We're also now making sure that we're only requiring the part of SDK that's used in codebase by requiring specific files.


This means if we use say `Response` from `postman-collection` module then instead of requiring it like below,

```
const { Response } = require('postman-collection');
```

we will be requiring Response from specific module exporting it like below.

```
const { Response } = require('postman-collection/lib/collection/response');
```