### PR TITLE
Conversion - Select request body content-type as ordered in OpenAPI

### DIFF
--- a/libV2/schemaUtils.js
+++ b/libV2/schemaUtils.js
@@ -1659,15 +1659,17 @@ let QUERYPARAM = 'query',
       };
     }
 
-    if (requestContent[URLENCODED]) {
-      return resolveUrlEncodedRequestBodyForPostmanRequest(context, requestContent[URLENCODED]);
+    for (const contentType in requestContent) {
+      if (contentType === URLENCODED) {
+        return resolveUrlEncodedRequestBodyForPostmanRequest(context, requestContent[contentType]);
+      }
+      else if (contentType === FORM_DATA) {
+        return resolveFormDataRequestBodyForPostmanRequest(context, requestContent[contentType]);
+      }
+      else {
+        return resolveRawModeRequestBodyForPostmanRequest(context, requestContent);
+      }
     }
-
-    if (requestContent[FORM_DATA]) {
-      return resolveFormDataRequestBodyForPostmanRequest(context, requestContent[FORM_DATA]);
-    }
-
-    return resolveRawModeRequestBodyForPostmanRequest(context, requestContent);
   },
 
   resolvePathItemParams = (context, operationParam, pathParam) => {


### PR DESCRIPTION
Linked to #801

Currently the request body used for creating the Postman request is a fixed content-type mapping, where the following logic applies:
1. if present, the 'x-www-form-urlencoded' is taken 
2. ELSE if the  'form-data' is taken
3. ELSE fallback to 'raw'

This PR uses the order of the request body content-types as ordered in the OpenAPI spec, meaning which ever is found first will be taken.

Example OpenAPI:

```yaml
openapi: 3.0.0
info:
  version: v1
  title: 601-RequestBody TcPCM Gateway API
  description: TcPCM Gateway API
  license:
    name: Privacy Policy
    url: https://www.plm.automation.siemens.com/global/en/legal/privacy-policy.html
paths:
  "/api/v1/administration/samAuth/users/{userName}":
    put:
      tags:
        - "Administration: Users"
      summary: Create or Update Sam Auth User
      operationId: CreateSamAuthUser_CreateOrUpdateSamAuthUser
      parameters:
        - name: userName
          in: path
          description: User name
          required: true
          schema:
            type: string
        - name: Authorization
          in: header
          description: bearer token
          required: true
          schema:
            type: string
      requestBody:
        content:
          application/json:
            schema:
              $ref: "#/components/schemas/CreateSamAuthUserRequestModel"
          text/json:
            schema:
              $ref: "#/components/schemas/CreateSamAuthUserRequestModel"
          application/xml:
            schema:
              $ref: "#/components/schemas/CreateSamAuthUserRequestModel"
          text/xml:
            schema:
              $ref: "#/components/schemas/CreateSamAuthUserRequestModel"
          application/x-www-form-urlencoded:
            schema:
              $ref: "#/components/schemas/CreateSamAuthUserRequestModel"
        description: The request represents that the user with {userName} will either be
          created or updated depending on whether the {userName} exists or not.
        required: true
      responses:
        "200":
          description: OK
          content:
            application/json:
              schema:
                type: object
            text/json:
              schema:
                type: object
            application/xml:
              schema:
                type: object
            text/xml:
              schema:
                type: object
```

Current result:
![image](https://github.com/postmanlabs/openapi-to-postman/assets/952446/7c03d333-0768-40cf-9de1-90a780e05c41)

PR result:
<img width="958" alt="image" src="https://github.com/postmanlabs/openapi-to-postman/assets/952446/317b640d-ca08-4a5b-bf4e-112d0a913abb">
