### PR TITLE
Fixed issue with getOptions() API where default module version was still v1.

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -47,10 +47,12 @@ module.exports = {
    *
    * @param {string} [mode='document'] Describes use-case. 'document' will return an array
    * with all options being described. 'use' will return the default values of all options
-   * @param {Object} criteria Decribes required criteria for options to be returned. can have properties
-   *   external: <boolean>
-   *   usage: <array> (Array of supported usage type - CONVERSION, VALIDATION)
-   *   version: <string> ('3.0' by default, supported values: '3.0', '3.1')
+   * @param {Object} criteria Decribes required criteria for options to be returned.
+   * @param {string} criteria.version The version of the OpenAPI spec to be converted
+   *  (can be one of '2.0', '3.0', '3.1')
+   * @param {string} criteria.moduleVersion The version of the module (can be one of 'v1' or 'v2')
+   * @param {Array<string>} criteria.usage The usage of the option (values can be one of 'CONVERSION', 'VALIDATION')
+   * @param {boolean} criteria.external Whether the option is exposed to Postman App UI or not
    * @returns {mixed} An array or object (depending on mode) that describes available options
    */
   getOptions: function(mode = 'document', criteria = {}) {
@@ -408,7 +410,7 @@ module.exports = {
         }
 
         // Setting default value
-        criteria.moduleVersion = _.has(criteria, 'moduleVersion') ? criteria.moduleVersion : MODULE_VERSION.V1;
+        criteria.moduleVersion = _.has(criteria, 'moduleVersion') ? criteria.moduleVersion : MODULE_VERSION.V2;
 
         if (!_.includes(option.supportedModuleVersion, criteria.moduleVersion)) {
           return false;


### PR DESCRIPTION
## Overview

This PR updates default version for `getOptions()` API to be `v2` instead of current `v1`. Also adds more details around criteria usage.