### PR TITLE
Added support for readOnly and writeOnly keywords with v2 APIs.

### DIFF
--- a/libV2/schemaUtils.js
+++ b/libV2/schemaUtils.js
@@ -253,13 +253,43 @@ let QUERYPARAM = 'query',
   },
 
   /**
+   * Resets cache storing readOnly and writeOnly property map.
+   *
+   * @param {Object} context - Global context object
+   * @returns {void}
+   */
+  resetReadWritePropCache = (context) => {
+    context.readOnlyPropCache = {};
+    context.writeOnlyPropCache = {};
+  },
+
+  /**
+   * Merges provided readOnly writeOnly properties cache with existing cache present in context
+   *
+   * @param {Object} context - Global context object
+   * @param {Object} readOnlyPropCache - readOnly properties cache to be merged
+   * @param {Object} writeOnlyPropCache - writeOnly properties cache to be merged
+   * @param {Object} currentPath - Current path being resolved relative to original schema
+   * @returns {void}
+   */
+  mergeReadWritePropCache = (context, readOnlyPropCache, writeOnlyPropCache, currentPath = '') => {
+    _.forOwn(readOnlyPropCache, (value, key) => {
+      context.readOnlyPropCache[`${currentPath}${key}`] = true;
+    });
+
+    _.forOwn(writeOnlyPropCache, (value, key) => {
+      context.writeOnlyPropCache[`${currentPath}${key}`] = true;
+    });
+  },
+
+  /**
    * Resolve a given ref from the schema
    * @param {Object} context - Global context object
    * @param {Object} $ref - Ref that is to be resolved
    * @param {Number} stackDepth - Depth of the current stack for Ref resolution
    * @param {Object} seenRef - Seen Reference map
    *
-   * @returns {Object} Returns the object that staisfies the schema
+   * @returns {Object} Returns the object that satisfies the schema
    */
   resolveRefFromSchema = (context, $ref, stackDepth = 0, seenRef = {}) => {
     const { specComponents } = context,
@@ -273,7 +303,11 @@ let QUERYPARAM = 'query',
     seenRef[$ref] = true;
 
     if (context.schemaCache[$ref]) {
-      return context.schemaCache[$ref];
+      // Also merge readOnly and writeOnly prop cache from schemaCache to global context cache
+      mergeReadWritePropCache(context, context.schemaCache[$ref].readOnlyPropCache,
+        context.schemaCache[$ref].writeOnlyPropCache);
+
+      return context.schemaCache[$ref].schema;
     }
 
     if (!_.isFunction($ref.split)) {
@@ -329,7 +363,7 @@ let QUERYPARAM = 'query',
    * @param {Number} stackDepth - Depth of the current stack for Ref resolution
    * @param {Object} seenRef - Seen Reference map
    *
-   * @returns {Object} Returns the object that staisfies the schema
+   * @returns {Object} Returns the object that satisfies the schema
    */
   resolveRefForExamples = (context, $ref, stackDepth = 0, seenRef = {}) => {
     const { specComponents } = context,
@@ -343,7 +377,11 @@ let QUERYPARAM = 'query',
     seenRef[$ref] = true;
 
     if (context.schemaCache[$ref]) {
-      return context.schemaCache[$ref];
+      // Also merge readOnly and writeOnly prop cache from schemaCache to global context cache
+      mergeReadWritePropCache(context, context.schemaCache[$ref].readOnlyPropCache,
+        context.schemaCache[$ref].writeOnlyPropCache);
+
+      return context.schemaCache[$ref].schema;
     }
 
     if (!_.isFunction($ref.split)) {
@@ -390,7 +428,11 @@ let QUERYPARAM = 'query',
     }
 
     // Add the resolved schema to the global schema cache
-    context.schemaCache[$ref] = resolvedExample;
+    context.schemaCache[$ref] = {
+      schema: resolvedExample,
+      readOnlyPropCache: {},
+      writeOnlyPropCache: {}
+    };
 
     return resolvedExample;
   },
@@ -438,22 +480,23 @@ let QUERYPARAM = 'query',
   },
 
   /**
-   * Handle resoltion of allOf property of schema
+   * Handle resolution of allOf property of schema
    *
    * @param {Object} context - Global context object
    * @param {Object} schema - Schema to be resolved
    * @param {Number} [stack] - Current recursion depth
    * @param {*} resolveFor - resolve refs for flow validation/conversion (value to be one of VALIDATION/CONVERSION)
    * @param {Object} seenRef - Map of all the references that have been resolved
+   * @param {String} currentPath - Current path being resolved relative to original schema
    *
    * @returns {Object} Resolved schema
    */
-  resolveAllOfSchema = (context, schema, stack, resolveFor = CONVERSION, seenRef = {}) => {
+  resolveAllOfSchema = (context, schema, stack = 0, resolveFor = CONVERSION, seenRef = {}, currentPath = '') => {
     try {
       return mergeAllOf(_.assign(schema, {
         allOf: _.map(schema.allOf, (schema) => {
           // eslint-disable-next-line no-use-before-define
-          return resolveSchema(context, schema, stack, resolveFor, _.cloneDeep(seenRef));
+          return _resolveSchema(context, schema, stack, resolveFor, _.cloneDeep(seenRef), currentPath);
         })
       }), {
         // below option is required to make sure schemas with additionalProperties set to false are resolved correctly
@@ -479,13 +522,14 @@ let QUERYPARAM = 'query',
    * @param {Object} context - Global context
    * @param {Object} schema - Schema that is to be resolved
    * @param {Number} [stack] - Current recursion depth
-   * @param {String} resolveFor - For which action this resoltion is to be done
+   * @param {String} resolveFor - For which action this resolution is to be done
    * @param {Object} seenRef - Map of all the references that have been resolved
+   * @param {String} currentPath - Current path being resolved relative to original schema
    * @todo: Explore using a directed graph/tree for maintaining seen ref
    *
-   * @returns {Object} Returns the object that staisfies the schema
+   * @returns {Object} Returns the object that satisfies the schema
    */
-  resolveSchema = (context, schema, stack = 0, resolveFor = CONVERSION, seenRef = {}) => {
+  _resolveSchema = (context, schema, stack = 0, resolveFor = CONVERSION, seenRef = {}, currentPath = '') => {
     if (!schema) {
       return new Error('Schema is empty');
     }
@@ -522,16 +566,17 @@ let QUERYPARAM = 'query',
       });
 
       if (resolveFor === CONVERSION) {
-        return resolveSchema(context, compositeSchema[0], stack, resolveFor, _.cloneDeep(seenRef));
+        return _resolveSchema(context, compositeSchema[0], stack, resolveFor, _.cloneDeep(seenRef), currentPath);
       }
 
       return { [compositeKeyword]: _.map(compositeSchema, (schemaElement) => {
-        return resolveSchema(context, schemaElement, stack, resolveFor, _.cloneDeep(seenRef));
+        return _resolveSchema(context, schemaElement, stack, resolveFor, _.cloneDeep(seenRef),
+          `${currentPath}.${compositeKeyword}`);
       }) };
     }
 
     if (schema.allOf) {
-      return resolveAllOfSchema(context, schema, stack, resolveFor, _.cloneDeep(seenRef));
+      return resolveAllOfSchema(context, schema, stack, resolveFor, _.cloneDeep(seenRef), currentPath);
     }
 
     if (schema.$ref) {
@@ -546,14 +591,42 @@ let QUERYPARAM = 'query',
       seenRef[schemaRef] = true;
 
       if (context.schemaCache[schemaRef]) {
-        schema = context.schemaCache[schemaRef];
+        // Also merge readOnly and writeOnly prop cache from schemaCache to global context cache
+        mergeReadWritePropCache(context, context.schemaCache[schemaRef].readOnlyPropCache,
+          context.schemaCache[schemaRef].writeOnlyPropCache, currentPath);
+
+        schema = context.schemaCache[schemaRef].schema;
       }
       else {
+        const existingReadPropCache = context.readOnlyPropCache,
+          existingWritePropCache = context.writeOnlyPropCache;
+
         schema = resolveRefFromSchema(context, schemaRef, stack, _.cloneDeep(seenRef));
-        schema = resolveSchema(context, schema, stack, resolveFor, _.cloneDeep(seenRef));
+
+        /**
+         * Reset readOnly and writeOnly prop cache before resolving schema to make sure
+         * we have fresh cache for $ref resolution which will be stored as part of schemaCache
+         */
+        resetReadWritePropCache(context);
+        schema = _resolveSchema(context, schema, stack, resolveFor, _.cloneDeep(seenRef), '');
 
         // Add the resolved schema to the global schema cache
-        context.schemaCache[schemaRef] = schema;
+        context.schemaCache[schemaRef] = {
+          schema,
+          readOnlyPropCache: context.readOnlyPropCache,
+          writeOnlyPropCache: context.writeOnlyPropCache
+        };
+
+        // eslint-disable-next-line one-var
+        const newReadPropCache = context.readOnlyPropCache,
+          newWritePropCache = context.writeOnlyPropCache;
+
+        // Assign existing readOnly and writeOnly prop cache back to global context cache
+        context.readOnlyPropCache = existingReadPropCache;
+        context.writeOnlyPropCache = existingWritePropCache;
+
+        // Merge existing and current cache to make sure we have all the properties in cache
+        mergeReadWritePropCache(context, newReadPropCache, newWritePropCache, currentPath);
       }
       return schema;
     }
@@ -591,7 +664,19 @@ let QUERYPARAM = 'query',
           return;
         }
 
-        resolvedSchemaProps[propertyName] = resolveSchema(context, property, stack, resolveFor, _.cloneDeep(seenRef));
+        const currentPropPath = `${currentPath}.properties.${propertyName}`;
+
+        // Keep track of readOnly and writeOnly properties to resolve request and responses accordingly later.
+        if (property.readOnly) {
+          context.readOnlyPropCache[currentPropPath] = true;
+        }
+
+        if (property.writeOnly) {
+          context.writeOnlyPropCache[currentPropPath] = true;
+        }
+
+        resolvedSchemaProps[propertyName] = _resolveSchema(context, property, stack, resolveFor,
+          _.cloneDeep(seenRef), currentPropPath);
       });
 
       schema.properties = resolvedSchemaProps;
@@ -599,7 +684,8 @@ let QUERYPARAM = 'query',
     }
     // If schema is of type array
     else if (concreteUtils.compareTypes(schema.type, SCHEMA_TYPES.array) && schema.items) {
-      schema.items = resolveSchema(context, schema.items, stack, resolveFor, _.cloneDeep(seenRef));
+      schema.items = _resolveSchema(context, schema.items, stack, resolveFor, _.cloneDeep(seenRef),
+        `${currentPath}.items`);
     }
     // Any properties to ignored should not be available in schema
     else if (_.every(SCHEMA_PROPERTIES_TO_EXCLUDE, (schemaKey) => { return !schema.hasOwnProperty(schemaKey); })) {
@@ -631,7 +717,8 @@ let QUERYPARAM = 'query',
 
     if (schema.hasOwnProperty('additionalProperties')) {
       schema.additionalProperties = _.isBoolean(schema.additionalProperties) ? schema.additionalProperties :
-        resolveSchema(context, schema.additionalProperties, stack, resolveFor, _.cloneDeep(seenRef));
+        _resolveSchema(context, schema.additionalProperties, stack, resolveFor, _.cloneDeep(seenRef),
+          `${currentPath}.additionalProperties`);
       schema.type = schema.type || SCHEMA_TYPES.object;
     }
 
@@ -650,10 +737,57 @@ let QUERYPARAM = 'query',
   },
 
   /**
+   * Wrapper around _resolveSchema which resolves a given schema
+   *
+   * @param {Object} context - Global context
+   * @param {Object} schema - Schema that is to be resolved
+   * @param {Object} resolutionMeta - Metadata of resolution taking place
+   * @param {Number} resolutionMeta.stack - Current recursion depth
+   * @param {String} resolutionMeta.resolveFor - For which action this resolution is to be done
+   * @param {Object} resolutionMeta.seenRef - Map of all the references that have been resolved
+   * @param {Boolean} resolutionMeta.isResponseSchema - Whether schema is from response or not
+   *
+   * @returns {Object} Returns the object that satisfies the schema
+   */
+  resolveSchema = (context, schema,
+    { stack = 0, resolveFor = CONVERSION, seenRef = {}, isResponseSchema = false } = {}
+  ) => {
+    // reset readOnly and writeOnly prop cache before resolving schema to make sure we have fresh cache
+    resetReadWritePropCache(context);
+
+    let resolvedSchema = _resolveSchema(context, schema, stack, resolveFor, seenRef);
+
+    /**
+     * If readOnly or writeOnly properties are present in the schema, we need to clone original schema first.
+     * Because we modify original resolved schema and delete readOnly or writeOnly properties from it
+     * depending upon if schema belongs to Request or Response.
+     * This is done to avoid modifying original schema object and to keep it intact for future use.
+     */
+    if (!_.isEmpty(context.readOnlyPropCache) || !_.isEmpty(context.writeOnlyPropCache)) {
+      resolvedSchema = _.cloneDeep(resolvedSchema);
+    }
+
+    if (isResponseSchema) {
+      _.forOwn(context.writeOnlyPropCache, (value, key) => {
+        _.unset(resolvedSchema, key.substring(1));
+      });
+    }
+    else {
+      _.forOwn(context.readOnlyPropCache, (value, key) => {
+        _.unset(resolvedSchema, key.substring(1));
+      });
+    }
+
+    return resolvedSchema;
+  },
+
+  /**
    * Provides information regarding serialisation of param
    *
    * @param {Object} context - Required context from related SchemaPack function
    * @param {Object} param - OpenAPI Parameter object
+   * @param {Object} options - Options object
+   * @param {Boolean} options.isResponseSchema - Whether schema is from response or not
    * @returns {Object} - Information regarding parameter serialisation. Contains following properties.
    * {
    *  style - style property defined/inferred from schema
@@ -664,7 +798,7 @@ let QUERYPARAM = 'query',
    *  isExplodable - whether params can be exploded (serialised value can contain key and value)
    * }
    */
-  getParamSerialisationInfo = (context, param) => {
+  getParamSerialisationInfo = (context, param, { isResponseSchema = false } = {}) => {
     let paramName = _.get(param, 'name'),
       paramSchema,
       style, // style property defined/inferred from schema
@@ -682,7 +816,7 @@ let QUERYPARAM = 'query',
     }
 
     // Resolve the ref and composite schemas
-    paramSchema = resolveSchema(context, param.schema);
+    paramSchema = resolveSchema(context, param.schema, { isResponseSchema });
 
     isExplodable = paramSchema.type === 'object';
 
@@ -796,16 +930,20 @@ let QUERYPARAM = 'query',
    *
    * @param {Object} context - Required context from related SchemaPack function
    * @param {Object} param - Parameter that is to be resolved from schema
-   * @param {String} schemaFormat - Corresponding schema format (can be one of xml/default)
+   * @param {Object} options - Addition options
+   * @param {String} options.schemaFormat - Corresponding schema format (can be one of xml/default)
+   * @param {Boolean} options.isResponseSchema - Whether schema is from response or not
    * @returns {*} Value of the parameter
    */
-  resolveValueOfParameter = (context, param, schemaFormat = SCHEMA_FORMATS.DEFAULT) => {
+  resolveValueOfParameter = (context, param,
+    { schemaFormat = SCHEMA_FORMATS.DEFAULT, isResponseSchema = false } = {}
+  ) => {
     if (!param || !param.hasOwnProperty('schema')) {
       return '';
     }
 
     const { indentCharacter } = context.computedOptions,
-      resolvedSchema = resolveSchema(context, param.schema),
+      resolvedSchema = resolveSchema(context, param.schema, { isResponseSchema }),
       { parametersResolution } = context.computedOptions,
       shouldGenerateFromExample = parametersResolution === 'example',
       hasExample = param.example !== undefined ||
@@ -918,9 +1056,19 @@ let QUERYPARAM = 'query',
       (parameter.enum ? ' (This can only be one of ' + parameter.enum + ')' : '');
   },
 
-  serialiseParamsBasedOnStyle = (context, param, paramValue) => {
+  /**
+   * Serialise Param based on mentioned style field in schema object
+   *
+   * @param {Object} context - Global context object
+   * @param {Object} param - OpenAPI Parameter object
+   * @param {*} paramValue - Value of the parameter
+   * @param {Object} options - Additional options for serialisation
+   * @param {Boolean} options.isResponseSchema - Whether schema is from response or not
+   * @returns {Array} - Array of key-value pairs for the parameter
+   */
+  serialiseParamsBasedOnStyle = (context, param, paramValue, { isResponseSchema = false } = {}) => {
     const { style, explode, startValue, propSeparator, keyValueSeparator, isExplodable } =
-      getParamSerialisationInfo(context, param),
+      getParamSerialisationInfo(context, param, { isResponseSchema }),
       { enableOptionalParameters } = context.computedOptions;
 
     let serialisedValue = '',
@@ -1265,7 +1413,7 @@ let QUERYPARAM = 'query',
     }
 
     if (requestBodySchema.$ref) {
-      requestBodySchema = resolveSchema(context, requestBodySchema);
+      requestBodySchema = resolveSchema(context, requestBodySchema, { isResponseSchema: isExampleBody });
     }
 
     /**
@@ -1314,7 +1462,7 @@ let QUERYPARAM = 'query',
     examples = requestBodySchema.examples || _.get(requestBodySchema, 'schema.examples');
 
     requestBodySchema = requestBodySchema.schema || requestBodySchema;
-    requestBodySchema = resolveSchema(context, requestBodySchema);
+    requestBodySchema = resolveSchema(context, requestBodySchema, { isResponseSchema: isExampleBody });
 
     // If schema object has example defined, try to use that if no example is defiend at request body level
     if (example === undefined && _.get(requestBodySchema, 'example') !== undefined) {
@@ -1339,7 +1487,7 @@ let QUERYPARAM = 'query',
       requestBodySchema = requestBodySchema.schema || requestBodySchema;
 
       if (requestBodySchema.$ref) {
-        requestBodySchema = resolveSchema(context, requestBodySchema);
+        requestBodySchema = resolveSchema(context, requestBodySchema, { isResponseSchema: isExampleBody });
       }
 
       if (isBodyTypeXML) {
@@ -1912,7 +2060,7 @@ let QUERYPARAM = 'query',
     }
 
     if (responseBody.$ref) {
-      responseBody = resolveSchema(context, responseBody);
+      responseBody = resolveSchema(context, responseBody, { isResponseSchema: true });
     }
 
     responseContent = responseBody.content;
@@ -1973,7 +2121,7 @@ let QUERYPARAM = 'query',
       { includeDeprecated } = context.computedOptions;
 
     if (_.has(responseHeaders, '$ref')) {
-      responseHeaders = resolveSchema(context, responseHeaders);
+      responseHeaders = resolveSchema(context, responseHeaders, { isResponseSchema: true });
     }
 
     _.forOwn(responseHeaders, (value, headerName) => {
@@ -1985,7 +2133,7 @@ let QUERYPARAM = 'query',
         return;
       }
 
-      let headerValue = resolveValueOfParameter(context, value);
+      let headerValue = resolveValueOfParameter(context, value, { isResponseSchema: true });
 
       if (typeof headerValue === 'number' || typeof headerValue === 'boolean') {
         // the SDK will keep the number-ness,
@@ -1996,7 +2144,7 @@ let QUERYPARAM = 'query',
       }
 
       const headerData = Object.assign({}, value, { name: headerName }),
-        serialisedHeader = serialiseParamsBasedOnStyle(context, headerData, headerValue);
+        serialisedHeader = serialiseParamsBasedOnStyle(context, headerData, headerValue, { isResponseSchema: true });
 
       headers.push(...serialisedHeader);
     });
@@ -2097,7 +2245,7 @@ let QUERYPARAM = 'query',
     // store all request examples which will be used for creation of examples with correct request and response matching
     if (typeof requestBody === 'object') {
       if (requestBody.$ref) {
-        requestBody = resolveSchema(context, requestBody);
+        requestBody = resolveSchema(context, requestBody, { isResponseSchema: true });
       }
 
       requestContent = requestBody.content;
@@ -2116,7 +2264,8 @@ let QUERYPARAM = 'query',
                 const exampleData = getExampleData(context, { [name]: exampleObj });
 
                 if (isBodyTypeXML) {
-                  let bodyData = getXMLExampleData(context, exampleData, resolveSchema(context, content.schema));
+                  let bodyData = getXMLExampleData(context, exampleData, resolveSchema(context, content.schema,
+                    { isResponseSchema: true }));
 
                   exampleObj.value = getXmlVersionContent(bodyData);
                 }
@@ -2134,7 +2283,8 @@ let QUERYPARAM = 'query',
     }
 
     _.forOwn(operationItem.responses, (responseObj, code) => {
-      let responseSchema = _.has(responseObj, '$ref') ? resolveSchema(context, responseObj) : responseObj,
+      let responseSchema = _.has(responseObj, '$ref') ?
+          resolveSchema(context, responseObj, { isResponseSchema: true }) : responseObj,
         { includeAuthInfoInExample } = context.computedOptions,
         auth = request.auth,
         resolvedExamples = resolveResponseBody(context, responseSchema, requestBodyExamples, code) || {},

--- a/libV2/utils.js
+++ b/libV2/utils.js
@@ -1,4 +1,5 @@
 const _ = require('lodash'),
+  jsonPointer = require('json-pointer'),
   { Item } = require('postman-collection/lib/collection/item'),
   { Response } = require('postman-collection/lib/collection/response'),
 
@@ -198,6 +199,48 @@ module.exports = {
     }
 
     return title;
+  },
+
+  /**
+   * Adds provided property array to the given JSON path
+   *
+   * @param {string} jsonPath - JSON path to which properties should be added
+   * @param {array} propArray - Array of properties to be added to JSON path
+   * @returns {string} - Combined JSON path
+   */
+  addToJsonPath: function (jsonPath, propArray) {
+    const jsonPathArray = jsonPointer.parse(jsonPath),
+      escapedPropArray = _.map(propArray, (prop) => {
+        return jsonPointer.escape(prop);
+      });
+
+    return jsonPointer.compile(jsonPathArray.concat(escapedPropArray));
+  },
+
+  /**
+   * Merges two JSON paths. i.e. Parent JSON path and Child JSON path
+   *
+   * @param {string} parentJsonPath - Parent JSON path
+   * @param {string} childJsonPath - Child JSON path
+   * @returns {string} - Merged JSON path
+   */
+  mergeJsonPath: function (parentJsonPath, childJsonPath) {
+    let jsonPathArray = jsonPointer.parse(parentJsonPath);
+
+    // Merges childJsonPath with parentJsonPath
+    jsonPathArray = jsonPathArray.concat(jsonPointer.parse(childJsonPath));
+
+    return jsonPointer.compile(jsonPathArray);
+  },
+
+  /**
+   * Gets JSON path in array from string JSON path
+   *
+   * @param {string} jsonPath - input JSON path
+   * @returns {array} - Parsed JSON path (each part is distributed in an array)
+   */
+  getJsonPathArray: function (jsonPath) {
+    return jsonPointer.parse(jsonPointer.unescape(jsonPath));
   },
 
   generatePmResponseObject,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "commander": "2.20.3",
         "graphlib": "2.1.8",
         "js-yaml": "4.1.0",
+        "json-pointer": "0.6.2",
         "json-schema-merge-allof": "0.8.1",
         "lodash": "4.17.21",
         "oas-resolver-browser": "2.5.6",
@@ -1809,6 +1810,11 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/foreach": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
+      "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg=="
+    },
     "node_modules/foreground-child": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
@@ -2903,6 +2909,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/json-pointer": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.2.tgz",
+      "integrity": "sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==",
+      "dependencies": {
+        "foreach": "^2.0.4"
       }
     },
     "node_modules/json-schema-compare": {
@@ -7009,6 +7023,11 @@
         "is-callable": "^1.1.3"
       }
     },
+    "foreach": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
+      "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg=="
+    },
     "foreground-child": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
@@ -7780,6 +7799,14 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
+    },
+    "json-pointer": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.2.tgz",
+      "integrity": "sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==",
+      "requires": {
+        "foreach": "^2.0.4"
+      }
     },
     "json-schema-compare": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "async": "3.2.4",
     "commander": "2.20.3",
     "js-yaml": "4.1.0",
+    "json-pointer": "0.6.2",
     "json-schema-merge-allof": "0.8.1",
     "lodash": "4.17.21",
     "oas-resolver-browser": "2.5.6",

--- a/test/data/valid_openapi/readOnly.json
+++ b/test/data/valid_openapi/readOnly.json
@@ -20,7 +20,21 @@
 								"schema": {
 									"type": "array",
 									"items": {
-										"$ref": "#/components/schemas/Pet"
+										"type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "readOnly": true
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "tag": {
+                        "type": "string",
+                        "writeOnly": true
+                      }
+                    }
 									}
 								}
 							}
@@ -33,7 +47,20 @@
 					"content": {
 						"application/json": {
 							"schema": {
-								"$ref": "#/components/schemas/Pet"
+								"properties": {
+									"id": {
+										"type": "integer",
+										"format": "int64",
+										"readOnly": true
+									},
+									"name": {
+										"type": "string"
+									},
+									"tag": {
+										"type": "string",
+										"writeOnly": true
+									}
+								}
 							}
 						}
 					}
@@ -41,26 +68,6 @@
 				"responses": {
 					"200": {
 						"description": "Successfully created a pet"
-					}
-				}
-			}
-		}
-	},
-	"components": {
-		"schemas": {
-			"Pet": {
-				"properties": {
-					"id": {
-						"type": "integer",
-						"format": "int64",
-						"readOnly": true
-					},
-					"name": {
-						"type": "string"
-					},
-					"tag": {
-						"type": "string",
-						"writeOnly": true
 					}
 				}
 			}

--- a/test/data/valid_openapi/readOnly.json
+++ b/test/data/valid_openapi/readOnly.json
@@ -20,7 +20,6 @@
 								"schema": {
 									"type": "array",
 									"items": {
-										"type": "object",
 										"$ref": "#/components/schemas/Pet"
 									}
 								}
@@ -34,20 +33,7 @@
 					"content": {
 						"application/json": {
 							"schema": {
-								"properties": {
-									"id": {
-										"type": "integer",
-										"format": "int64",
-										"readOnly": true
-									},
-									"name": {
-										"type": "string"
-									},
-									"tag": {
-										"type": "string",
-										"writeOnly": true
-									}
-								}
+								"$ref": "#/components/schemas/Pet"
 							}
 						}
 					}

--- a/test/data/valid_openapi/readOnlyAllOf.json
+++ b/test/data/valid_openapi/readOnlyAllOf.json
@@ -1,0 +1,95 @@
+{
+	"openapi": "3.0.0",
+	"info": {
+		"version": "1.0.0",
+		"title": "Swagger Petstore"
+	},
+	"servers": [
+		{
+			"url": "http://petstore.swagger.io/v1"
+		}
+	],
+	"paths": {
+		"/pets": {
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Successfull",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/UserPet"
+									}
+								}
+							}
+						}
+					}
+				}
+			},
+      "post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+                "$ref": "#/components/schemas/UserPet"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Successfully created a pet"
+					}
+				}
+			}
+		}
+	},
+	"components": {
+		"schemas": {
+			"Pet": {
+				"properties": {
+					"id": {
+						"type": "integer",
+						"format": "int64",
+						"readOnly": true
+					},
+					"name": {
+						"type": "string"
+					},
+					"tag": {
+						"type": "string",
+						"writeOnly": true
+					}
+				}
+			},
+      "User": {
+				"properties": {
+					"user.id": {
+						"type": "integer",
+						"format": "int64",
+						"readOnly": true
+					},
+					"user.name": {
+						"type": "string"
+					},
+					"user.tag": {
+						"type": "string",
+						"writeOnly": true
+					}
+				}
+			},
+      "UserPet": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "$ref": "#/components/schemas/User"
+          }
+        ]
+      }
+		}
+	}
+}

--- a/test/data/valid_openapi/readOnlyNested.json
+++ b/test/data/valid_openapi/readOnlyNested.json
@@ -1,0 +1,101 @@
+{
+	"openapi": "3.0.0",
+	"info": {
+		"version": "1.0.0",
+		"title": "Swagger Petstore"
+	},
+	"servers": [
+		{
+			"url": "http://petstore.swagger.io/v1"
+		}
+	],
+	"paths": {
+		"/pets": {
+      "get": {
+				"responses": {
+					"200": {
+						"description": "Successfull",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/User"
+								}
+							}
+						}
+					}
+				}
+			},
+      "post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+                "$ref": "#/components/schemas/Pet"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Successfully created a pet"
+					}
+				}
+			}
+		}
+	},
+	"components": {
+		"schemas": {
+			"Pet": {
+				"properties": {
+					"id": {
+						"type": "integer",
+						"format": "int64",
+						"readOnly": true
+					},
+					"name": {
+						"type": "string"
+					},
+					"tag": {
+						"type": "string",
+						"writeOnly": true
+					},
+          "address": {
+            "type": "object",
+            "properties": {
+              "addressCode": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  }
+                },
+                "readOnly": true
+              },
+              "city": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string",
+                "writeOnly": true
+              }
+            }
+          }
+				},
+        "additionalProperties": {
+          "type": "string",
+          "writeOnly": true
+        }
+			},
+      "User": {
+				"properties": {
+					"name": {
+            "type": "string"
+          },
+          "pet": {
+            "$ref": "#/components/schemas/Pet"
+          }
+				}
+			}
+		}
+	}
+}

--- a/test/data/valid_openapi/readOnlyOneOf.json
+++ b/test/data/valid_openapi/readOnlyOneOf.json
@@ -1,0 +1,95 @@
+{
+	"openapi": "3.0.0",
+	"info": {
+		"version": "1.0.0",
+		"title": "Swagger Petstore"
+	},
+	"servers": [
+		{
+			"url": "http://petstore.swagger.io/v1"
+		}
+	],
+	"paths": {
+		"/pets": {
+      "get": {
+				"responses": {
+					"200": {
+						"description": "Successfull",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/UserPet"
+									}
+								}
+							}
+						}
+					}
+				}
+			},
+      "post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+                "$ref": "#/components/schemas/UserPet"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Successfully created a pet"
+					}
+				}
+			}
+		}
+	},
+	"components": {
+		"schemas": {
+			"Pet": {
+				"properties": {
+					"id": {
+						"type": "integer",
+						"format": "int64",
+						"readOnly": true
+					},
+					"name": {
+						"type": "string"
+					},
+					"tag": {
+						"type": "string",
+						"writeOnly": true
+					}
+				}
+			},
+      "User": {
+				"properties": {
+					"user/id": {
+						"type": "integer",
+						"format": "int64",
+						"readOnly": true
+					},
+					"user/name": {
+						"type": "string"
+					},
+					"user/tag": {
+						"type": "string",
+						"writeOnly": true
+					}
+				}
+			},
+      "UserPet": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/User"
+          },
+          {
+            "$ref": "#/components/schemas/Pet"
+          }
+        ]
+      }
+		}
+	}
+}

--- a/test/data/valid_openapi/readOnlyRef.json
+++ b/test/data/valid_openapi/readOnlyRef.json
@@ -1,0 +1,69 @@
+{
+	"openapi": "3.0.0",
+	"info": {
+		"version": "1.0.0",
+		"title": "Swagger Petstore"
+	},
+	"servers": [
+		{
+			"url": "http://petstore.swagger.io/v1"
+		}
+	],
+	"paths": {
+		"/pets": {
+			"get": {
+				"responses": {
+					"200": {
+						"description": "Successfull",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/Pet"
+									}
+								}
+							}
+						}
+					}
+				}
+			},
+			"post": {
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Pet"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Successfully created a pet"
+					}
+				}
+			}
+		}
+	},
+	"components": {
+		"schemas": {
+			"Pet": {
+				"properties": {
+					"id": {
+						"type": "integer",
+						"format": "int64",
+						"readOnly": true
+					},
+					"name": {
+						"type": "string"
+					},
+					"tag": {
+						"type": "string",
+						"writeOnly": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -110,7 +110,9 @@ const expect = require('chai').expect,
   multiExampleResponseCodeMatching =
     path.join(__dirname, VALID_OPENAPI_PATH, '/multiExampleResponseCodeMatching.json'),
   duplicateCollectionVars =
-    path.join(__dirname, VALID_OPENAPI_PATH, '/duplicateCollectionVars.json');
+    path.join(__dirname, VALID_OPENAPI_PATH, '/duplicateCollectionVars.json'),
+  readOnlySpec =
+    path.join(__dirname, VALID_OPENAPI_PATH, '/readOnly.json');
 
 
 describe('The convert v2 Function', function() {
@@ -2819,4 +2821,20 @@ describe('The convert v2 Function', function() {
         done();
       });
   });
+
+  it('[Github #12255] Should respects readOnly and writeOnly properties in requestBody or response schema',
+    function(done) {
+      var openapi = fs.readFileSync(readOnlySpec, 'utf8'),
+        options = { schemaFaker: true, exampleParametersResolution: 'schema' };
+      Converter.convert({ type: 'string', data: openapi }, options, (err, conversionResult) => {
+        let requestBody = conversionResult.output[0].data.item[0].item[1].request.body.raw,
+          responseBody = conversionResult.output[0].data.item[0].item[0].response[0].body;
+        expect(err).to.be.null;
+        expect(requestBody).to.equal('{\n  "name": "<string>",\n  "tag": "<string>"\n}');
+        expect(responseBody).to.equal('[\n  {\n    "id": "<long>",\n    "name": "<string>"\n  }' +
+        ',\n  {\n    "id": "<long>",\n    "name": "<string>"\n  }\n]');
+
+        done();
+      });
+    });
 });


### PR DESCRIPTION
## Overview

Fixes https://github.com/postmanlabs/postman-app-support/issues/12255 and #98.

This PR adds correct support for resolution of readOnly and writeOnly keywords while generating collections from it. i.e. readOnly properties will not be present in request part anymore and writeOnly properties will not be present in responses.

To read up more on working of readOnly and writeOnly, take a look [here.](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#fixed-fields-20)

## Implementation details

To optimize the schema resolution that happens for each schema object mentioned in OpenAPI, we use function `resolveSchema` and also make sure that resolved schemas are cached for further usage.

Now in case of `readOnly` and `writeOnly` properties case, if we don't resolve certain property based on where it's at within request or response, we'll end up with incorrect schema based on where it might be used again from cache.

With this PR, we're adding support for caching where exactly `readOnly` and `writeOnly` properties are present and we'll be using it further to make sure correct schema is returned as return value of `resolveSchema`. To do this, we're making sure that we don't change the schema we cached and only change return value base on if there were any `readOnly` and/or `writeOnly` properties were found or not making sure no performance overhead for usecases without `readOnly` and `writeOnly` props.

For storing the location of `readOnly` and `writeOnly` that are cached, we're using [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901). We're also appropriately escaping and unescaping related special characters.