### PR TITLE
831: Fixed bug for Readme file contents links not pointing to the doc sect…

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 ---
 ---
 
-## 💭 Getting Started
+## Getting Started
 
 To use the converter as a Node module, you need to have a copy of the NodeJS runtime. The easiest way to do this is through npm. If you have NodeJS installed you have npm installed as well.
 
@@ -48,7 +48,7 @@ $ npm i -g openapi-to-postmanv2
 ```
 
 
-## 📖 Command Line Interface
+## Command Line Interface
 
 The converter can be used as a CLI tool as well. The following [command line options](#options) are available.
 
@@ -107,7 +107,7 @@ $ openapi2postmanv2 --test
 ```
 
 
-## 🛠 Using the converter as a NodeJS module
+## Using the converter as a NodeJS module
 
 In order to use the convert in your node application, you need to import the package using `require`.
 
@@ -219,7 +219,7 @@ The validate function is synchronous and returns a status object which conforms 
 
 - `reason` - Provides a reason for an unsuccessful validation of the specification
 
-## 🧭 Conversion Schema
+## Conversion Schema
 
 | *postman* | *openapi* | *related options* |
 | --- | --- | :---: |


### PR DESCRIPTION
Fixes #831 

An emoji in the heading can cause issues with internal linking in Markdown. Emojis are treated as special characters, and they can disrupt the automatic generation of section IDs.