### PR TITLE
[CUE-5523] Fix Root file detection for multi-file OAS import

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -150,10 +150,10 @@ module.exports = {
 
     // there can be only one root file and the root file should not be referenced by any other file.
     if (rootFilesArray.length > 1) {
-      let fileRefPathArray = {};
+      let fileRefPathObj = {};
 
       rootFilesArray.forEach((file) => {
-        fileRefPathArray[file] = 0;
+        fileRefPathObj[file] = 0;
 
         let obj,
           oasObject,
@@ -174,15 +174,15 @@ module.exports = {
 
         refFilePaths = this.getRefFilePaths(oasObject, file);
         refFilePaths.forEach((refFilePath) => {
-          if (refFilePath in fileRefPathArray) {
-            fileRefPathArray[refFilePath] += 1;
+          if (refFilePath in fileRefPathObj) {
+            fileRefPathObj[refFilePath] += 1;
           }
         });
       });
 
       // Get the root files
-      rootFilesArray = Object.keys(fileRefPathArray).filter((file) => {
-        if (fileRefPathArray[file] === 0) {
+      rootFilesArray = Object.keys(fileRefPathObj).filter((file) => {
+        if (fileRefPathObj[file] === 0) {
           return file;
         }
       });

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -147,7 +147,91 @@ module.exports = {
         throw new Error(e.message);
       }
     });
+
+    // there can be only one root file and the root file should not be referenced by any other file.
+    if (rootFilesArray.length > 1) {
+      let fileRefPathArray = {};
+
+      rootFilesArray.forEach((file) => {
+        fileRefPathArray[file] = 0;
+
+        let obj,
+          oasObject,
+          refFilePaths;
+        // Use files map if present to read files.
+        if (!_.isEmpty(files)) {
+          obj = files[path.resolve(file)];
+        }
+        else if (allowReadingFS) {
+          obj = fs.readFileSync(file, 'utf8');
+        }
+
+        obj = this.getOasObject(obj);
+
+        if (obj.result) {
+          oasObject = obj.oasObject;
+        }
+
+        refFilePaths = this.getRefFilePaths(oasObject, file);
+        refFilePaths.forEach((refFilePath) => {
+          if (refFilePath in fileRefPathArray) {
+            fileRefPathArray[refFilePath] += 1;
+          }
+        });
+      });
+
+      // Get the root files
+      rootFilesArray = Object.keys(fileRefPathArray).filter((file) => {
+        if (fileRefPathArray[file] === 0) {
+          return file;
+        }
+      });
+    }
     return rootFilesArray;
+  },
+
+  /** Given an OAS object and a file path, returns the file paths of the referenced files
+   * @param {Object} oasObject OAS object
+   * @param {String} filePath file path
+   * @return {Array} refFilePaths
+   * */
+  getRefFilePaths: function (oasObject, filePath) {
+    let refFilePaths = [];
+    if (oasObject.hasOwnProperty('$ref')) {
+      refFilePaths.push(path.resolve(path.dirname(filePath), oasObject.$ref));
+    }
+    else {
+      let refFilePathsArray = [];
+      this.getRefFilePathsHelper(oasObject, filePath, refFilePathsArray);
+      refFilePaths = refFilePathsArray;
+    }
+    return refFilePaths;
+  },
+
+  /** Helper function for getRefFilePaths
+   * @param {Object} oasObject OAS object
+   * @param {String} filePath file path
+   * @param {Array} refFilePathsArray array to store file paths
+   * @return {Array} refFilePaths
+   * */
+  getRefFilePathsHelper: function (oasObject, filePath, refFilePathsArray) {
+    let refFilePaths = [];
+    if (oasObject.hasOwnProperty('$ref')) {
+      if (!oasObject.$ref.startsWith('#') && !oasObject.$ref.startsWith('http')) {
+        let resolvedFilePath = path.resolve(path.dirname(filePath), oasObject.$ref.split('#')[0]);
+        if (resolvedFilePath !== filePath) {
+          refFilePaths.push(resolvedFilePath);
+        }
+      }
+    }
+    else {
+      Object.keys(oasObject).forEach((key) => {
+        if (typeof oasObject[key] === 'object') {
+          this.getRefFilePathsHelper(oasObject[key], filePath, refFilePathsArray);
+        }
+      });
+    }
+    refFilePathsArray.push(...refFilePaths);
   },
 
   /**


### PR DESCRIPTION
## Summary
When the import folder contains a MultiFile OAS specification with multiple valid API files, the root file is assigned incorrectly.

## Fix
For fixing this issue I am assuming that when we have modular API specifications split across multiple files, then the ROOT file must be the one which is not being referenced by any other file.

## Issue
- [CUE-5523](https://postmanlabs.atlassian.net/browse/CUE-5523) Multi-file OAS Import assigning ROOT to the wrong file

[CUE-5523]: https://postmanlabs.atlassian.net/browse/CUE-5523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ