### PR TITLE
CUE-6067: Make faker data generation more deterministic

### DIFF
--- a/assets/json-schema-faker.js
+++ b/assets/json-schema-faker.js
@@ -24547,6 +24547,11 @@ function extend() {
    * @returns {string}
    */
   function thunkGenerator(min, max) {
+      // For properties of type string without any specified examples or detailed properties,
+      // we want the generated value to be called "string".
+      // Hence our wordsGenerator returns a fixed array of ['string']. To help with the same,
+      // we set the fallback min length value as "6" since we don't want the value to be
+      // "strin", "st", "s" etc.
       if (min === void 0) { min = 6; }
       if (max === void 0) { max = 140; }
       var min = Math.max(0, min), max = random.number(min, max), result = produce();

--- a/assets/json-schema-faker.js
+++ b/assets/json-schema-faker.js
@@ -24547,7 +24547,7 @@ function extend() {
    * @returns {string}
    */
   function thunkGenerator(min, max) {
-      if (min === void 0) { min = 0; }
+      if (min === void 0) { min = 6; }
       if (max === void 0) { max = 140; }
       var min = Math.max(0, min), max = random.number(min, max), result = produce();
       // append until length is reached
@@ -24629,7 +24629,7 @@ function extend() {
       'json-pointer': `(/(?:${FRAGMENT.replace(']*', '/]*')}|~[01]))+`,
 
       // some types from https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#data-types (?)
-      uuid: '^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$',
+      uuid: '^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$',
   };
 
   regexps.iri = regexps['uri-reference'];


### PR DESCRIPTION
1. The generated strings are of random length -> Hence making it more specific to ensure it doesn't show random keywords
2. The regex used for generating UUIDs contained `urn:uuid:` in the prefix which is not required for UUID. Hence removing the same.

Test Scenarios after Integrating with postman-app:
1. Generated 100 UUIDs -> All are consistent without the `urn:uuid` prefix
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/1c50ef28-73c8-4e16-953b-3416445a666a" />

1. Generated 100 normal strings -> All show "string" in the generated example
<img width="1512" height="982" alt="Screenshot 2025-08-25 at 3 00 55 PM" src="https://github.com/user-attachments/assets/a9cd75ee-1dfd-40b7-825d-6de9fa960414" />

