### PR TITLE
Enhance schema resolution logic for composite parameters in conversion with types

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -195,7 +195,6 @@
       "no-unneeded-ternary": "error",
       "no-whitespace-before-property": "error",
       "object-curly-spacing": ["error", "always"],
-      "one-var": ["error", "always"],
       "one-var-declaration-per-line": "error",
       "operator-assignment": "error",
       "operator-linebreak": ["error", "after"],

--- a/libV2/index.js
+++ b/libV2/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable one-var */
 const _ = require('lodash'),
   { Collection } = require('postman-collection/lib/collection/collection'),
   GraphLib = require('graphlib'),


### PR DESCRIPTION
This pull request enhances how composite schemas (such as `oneOf`, `anyOf`, and `allOf`) are resolved for OpenAPI parameters and headers, ensuring only the first option is extracted for types generation, while merging constraints for `allOf`. It also introduces a comprehensive unit test to verify this behavior and removes unnecessary ESLint disables for the `one-var` rule throughout the codebase.

**Composite schema resolution improvements:**

* Updated `libV2/schemaUtils.js` to extract only the first option from composite schemas (`oneOf`, `anyOf`, `allOf`) for query parameters, path parameters, request headers, and response headers, and to merge constraints for `allOf` during types generation. This prevents loss of schema information and improves type extraction accuracy. [[1]](diffhunk://#diff-d2a91c8370a4bdef207a0c7fd03f4e03d928c4baa87b0768d51093480c71f077R497-R511) [[2]](diffhunk://#diff-d2a91c8370a4bdef207a0c7fd03f4e03d928c4baa87b0768d51093480c71f077L2117-R2140) [[3]](diffhunk://#diff-d2a91c8370a4bdef207a0c7fd03f4e03d928c4baa87b0768d51093480c71f077L2166-R2194) [[4]](diffhunk://#diff-d2a91c8370a4bdef207a0c7fd03f4e03d928c4baa87b0768d51093480c71f077L2243-R2275) [[5]](diffhunk://#diff-d2a91c8370a4bdef207a0c7fd03f4e03d928c4baa87b0768d51093480c71f077L2403-R2440)

**Testing enhancements:**

* Added a new unit test to `test/unit/convertV2WithTypes.test.js` that verifies the extraction logic for composite schemas, ensuring only the first option is considered and constraints are merged as intended.

**Code quality and linting:**

* Removed unnecessary `eslint-disable one-var` comments from multiple files, including `libV2/index.js`, `libV2/schemaUtils.js`, and `test/unit/convertV2WithTypes.test.js`, and updated the `.eslintrc` configuration to no longer enforce the `one-var` rule. [[1]](diffhunk://#diff-e7e195d3d8fa5b82fa51ed952f3a179d429cbc46c0432ce1f7b357c54c162822L198) [[2]](diffhunk://#diff-7878084dd8cfe74b09bfddf19d17654605d8f053a7392ae4f6de27cb405afb17L1) [[3]](diffhunk://#diff-42dcdf94c4b96837d8481064c97a47dac2ca99675e70ef886cd46aeb093ffe64L4) [[4]](diffhunk://#diff-d2a91c8370a4bdef207a0c7fd03f4e03d928c4baa87b0768d51093480c71f077L556) [[5]](diffhunk://#diff-d2a91c8370a4bdef207a0c7fd03f4e03d928c4baa87b0768d51093480c71f077L631) [[6]](diffhunk://#diff-d2a91c8370a4bdef207a0c7fd03f4e03d928c4baa87b0768d51093480c71f077L1474)

These changes together improve the maintainability of the codebase and ensure more accurate OpenAPI type extraction for downstream consumers.