### PR TITLE
[AB-1798] Feature/use first example for examples + [AB-1852] Add format in anyOf/oneOf/allOf

### DIFF
--- a/libV2/schemaUtils.js
+++ b/libV2/schemaUtils.js
@@ -895,7 +895,9 @@ let QUERYPARAM = 'query',
           else if (propValue.properties) {
             let processedProperties = processSchema(propValue);
             propertyDetails.properties = processedProperties.properties;
-            processedProperties.required && (propertyDetails.required = processedProperties.required);
+            if (processedProperties.required) {
+              propertyDetails.required = processedProperties.required;
+            }
           }
           else if (propValue.type === 'array' && propValue.items) {
             propertyDetails.items = processSchema(propValue.items);

--- a/libV2/schemaUtils.js
+++ b/libV2/schemaUtils.js
@@ -1475,7 +1475,7 @@ let QUERYPARAM = 'query',
       return _.get(responseExample, 'value.description') ||
         _.get(responseExample, 'value.summary') ||
         (responseExample.key !== '_default' && responseExample.key) ||
-        (_.isNil(responseExample.responseCode) ? undefined : String(responseExample.responseCode));
+        (!_.isNil(responseExample.responseCode) ? String(responseExample.responseCode) : undefined);
     };
 
     let matchedKeys = _.intersectionBy(responseExampleKeys, requestBodyExampleKeys, _.toLower),
@@ -2776,7 +2776,7 @@ let QUERYPARAM = 'query',
 
         const responseDescription = _.get(responseSchema, 'description'),
           responseDescriptionTrimmed = _.isString(responseDescription) ? responseDescription.trim() : '',
-          codeName = String(_.isNil(code) ? DEFAULT_RESPONSE_CODE_IN_OAS : code);
+          codeName = String(!_.isNil(code) ? code : DEFAULT_RESPONSE_CODE_IN_OAS);
 
         // response-name priority:
         // 1) response-level description

--- a/libV2/schemaUtils.js
+++ b/libV2/schemaUtils.js
@@ -814,6 +814,7 @@ let QUERYPARAM = 'query',
         title: resolvedSchema.title,
         description: resolvedSchema.description,
         example: resolvedSchema.example,
+        format: resolvedSchema.format,
         anyOf: resolvedSchema.anyOf.map((schema) => {
           return processSchema(schema);
         })
@@ -825,6 +826,7 @@ let QUERYPARAM = 'query',
         title: resolvedSchema.title,
         description: resolvedSchema.description,
         example: resolvedSchema.example,
+        format: resolvedSchema.format,
         oneOf: resolvedSchema.oneOf.map((schema) => {
           return processSchema(schema);
         })
@@ -836,6 +838,7 @@ let QUERYPARAM = 'query',
         title: resolvedSchema.title,
         description: resolvedSchema.description,
         example: resolvedSchema.example,
+        format: resolvedSchema.format,
         allOf: resolvedSchema.allOf.map((schema) => {
           return processSchema(schema);
         })
@@ -847,7 +850,8 @@ let QUERYPARAM = 'query',
         description: resolvedSchema.description,
         title: resolvedSchema.title,
         type: resolvedSchema.type,
-        example: resolvedSchema.example
+        example: resolvedSchema.example,
+        format: resolvedSchema.format
       };
 
       // Only include properties if they exist in the original schema
@@ -891,9 +895,7 @@ let QUERYPARAM = 'query',
           else if (propValue.properties) {
             let processedProperties = processSchema(propValue);
             propertyDetails.properties = processedProperties.properties;
-            if (processedProperties.required) {
-              propertyDetails.required = processedProperties.required;
-            }
+            processedProperties.required && (propertyDetails.required = processedProperties.required);
           }
           else if (propValue.type === 'array' && propValue.items) {
             propertyDetails.items = processSchema(propValue.items);
@@ -925,7 +927,8 @@ let QUERYPARAM = 'query',
       type: resolvedSchema.type,
       description: resolvedSchema.description,
       title: resolvedSchema.title,
-      example: resolvedSchema.example
+      example: resolvedSchema.example,
+      format: resolvedSchema.format
     };
   },
 

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -2552,7 +2552,7 @@ describe('The convert v2 Function', function() {
           });
           // Should only generate 1 response (using first request example)
           expect(item.response).to.have.lengthOf(1);
-          expect(item.response[0].name).to.eql('valid-request');
+          expect(item.response[0].name).to.eql('None');
           expect(item.response[0]._postman_previewlanguage).to.eql('json');
           expect(JSON.parse(item.response[0].body)).to.eql({ hello: 'world' });
           expect(JSON.parse(item.response[0].originalRequest.body.raw)).to.eql({
@@ -2683,13 +2683,13 @@ describe('The convert v2 Function', function() {
           expect(JSON.parse(item.request.body.raw)).to.eql(okReqExample);
           // Should only generate 2 responses (1 per response code, using first request example)
           expect(item.response).to.have.lengthOf(2);
-          expect(item.response[0].name).to.eql('ok_example');
+          expect(item.response[0].name).to.eql('Ok');
           expect(item.response[0].code).to.eql(200);
           expect(item.response[0]._postman_previewlanguage).to.eql('json');
           expect(JSON.parse(item.response[0].originalRequest.body.raw)).to.eql(okReqExample);
           expect(JSON.parse(item.response[0].body)).to.eql(okResExample);
 
-          expect(item.response[1].name).to.eql('ok_example');
+          expect(item.response[1].name).to.eql('unexpected error');
           expect(item.response[1].code).to.eql(undefined);
           expect(item.response[1]._postman_previewlanguage).to.eql('json');
           expect(JSON.parse(item.response[1].originalRequest.body.raw)).to.eql(okReqExample);
@@ -2770,7 +2770,6 @@ describe('The convert v2 Function', function() {
           expect(JSON.parse(item.response[0].originalRequest.body.raw)).to.eql(defaultReqBody);
           expect(JSON.parse(item.response[0].body)).to.eql({ userId: 12 });
 
-          expect(item.response[1].name).to.eql('400');
           expect(item.response[1].code).to.eql(400);
           expect(item.response[1]._postman_previewlanguage).to.eql('json');
           expect(JSON.parse(item.response[1].originalRequest.body.raw)).to.eql(defaultReqBody);

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -2581,7 +2581,7 @@ describe('The convert v2 Function', function() {
           expect(JSON.parse(item.request.body.raw)).to.eql({ hello: 'world' });
           // Should only generate 1 response (using first response example)
           expect(item.response).to.have.lengthOf(1);
-          expect(item.response[0].name).to.eql('valid-request');
+          expect(item.response[0].name).to.eql('None');
           expect(item.response[0]._postman_previewlanguage).to.eql('json');
           expect(JSON.parse(item.response[0].body)).to.eql({
             user: 1,
@@ -2617,7 +2617,7 @@ describe('The convert v2 Function', function() {
              * as we only use the first example from each
              */
             expect(item.response).to.have.lengthOf(1);
-            expect(item.response[0].name).to.eql('Complete request');
+            expect(item.response[0].name).to.eql('None');
             expect(item.response[0]._postman_previewlanguage).to.eql('json');
             expect(JSON.parse(item.response[0].body)).to.eql({
               user: 1,
@@ -2651,7 +2651,7 @@ describe('The convert v2 Function', function() {
             });
             // Should only generate 1 response (using first examples from both request and response)
             expect(item.response).to.have.lengthOf(1);
-            expect(item.response[0].name).to.eql('Request with only required params');
+            expect(item.response[0].name).to.eql('None');
             expect(item.response[0]._postman_previewlanguage).to.eql('json');
             expect(JSON.parse(item.response[0].body)).to.eql({
               user: 1
@@ -2717,19 +2717,19 @@ describe('The convert v2 Function', function() {
           expect(JSON.parse(item.request.body.raw)).to.eql(reqBody1);
           // Should only generate 3 responses (1 per response code, using first example from each)
           expect(item.response).to.have.lengthOf(3);
-          expect(item.response[0].name).to.eql('Request with only required params');
+          expect(item.response[0].name).to.eql('None');
           expect(item.response[0].code).to.eql(200);
           expect(item.response[0]._postman_previewlanguage).to.eql('json');
           expect(JSON.parse(item.response[0].originalRequest.body.raw)).to.eql(reqBody1);
           expect(JSON.parse(item.response[0].body)).to.eql({ user: 1 });
 
-          expect(item.response[1].name).to.eql('Request with only bad params');
+          expect(item.response[1].name).to.eql('None');
           expect(item.response[1].code).to.eql(400);
           expect(item.response[1]._postman_previewlanguage).to.eql('json');
           expect(JSON.parse(item.response[1].originalRequest.body.raw)).to.eql(reqBody1);
           expect(JSON.parse(item.response[1].body)).to.eql({ eyeColor: 'gray' });
 
-          expect(item.response[2].name).to.eql('Failed request - Negative user');
+          expect(item.response[2].name).to.eql('None');
           expect(item.response[2].code).to.eql(500);
           expect(item.response[2]._postman_previewlanguage).to.eql('json');
           expect(JSON.parse(item.response[2].originalRequest.body.raw)).to.eql(reqBody1);

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -2530,7 +2530,7 @@ describe('The convert v2 Function', function() {
     });
   });
 
-  describe('Should generate multiple examples when', function() {
+  describe('Should generate only first example when', function() {
     it('request body contains multiple examples but request body has single example', function(done) {
       var openapi = fs.readFileSync(multiExampleRequest, 'utf8');
       Converter.convertV2({ type: 'string', data: openapi }, { parametersResolution: 'Example' },
@@ -2550,7 +2550,8 @@ describe('The convert v2 Function', function() {
             height: 168,
             weight: 44
           });
-          expect(item.response).to.have.lengthOf(2);
+          // Should only generate 1 response (using first request example)
+          expect(item.response).to.have.lengthOf(1);
           expect(item.response[0].name).to.eql('valid-request');
           expect(item.response[0]._postman_previewlanguage).to.eql('json');
           expect(JSON.parse(item.response[0].body)).to.eql({ hello: 'world' });
@@ -2558,13 +2559,6 @@ describe('The convert v2 Function', function() {
             user: 1,
             height: 168,
             weight: 44
-          });
-
-          expect(item.response[1].name).to.eql('missing-required-parameter');
-          expect(item.response[1]._postman_previewlanguage).to.eql('json');
-          expect(JSON.parse(item.response[1].body)).to.eql({ hello: 'world' });
-          expect(JSON.parse(item.response[1].originalRequest.body.raw)).to.eql({
-            user: 1
           });
           done();
         });
@@ -2585,7 +2579,8 @@ describe('The convert v2 Function', function() {
           const item = conversionResult.output[0].data.item[0].item[0];
 
           expect(JSON.parse(item.request.body.raw)).to.eql({ hello: 'world' });
-          expect(item.response).to.have.lengthOf(2);
+          // Should only generate 1 response (using first response example)
+          expect(item.response).to.have.lengthOf(1);
           expect(item.response[0].name).to.eql('valid-request');
           expect(item.response[0]._postman_previewlanguage).to.eql('json');
           expect(JSON.parse(item.response[0].body)).to.eql({
@@ -2594,11 +2589,6 @@ describe('The convert v2 Function', function() {
             weight: 44
           });
           expect(JSON.parse(item.response[0].originalRequest.body.raw)).to.eql({ hello: 'world' });
-
-          expect(item.response[1].name).to.eql('missing-required-parameter');
-          expect(item.response[1]._postman_previewlanguage).to.eql('json');
-          expect(JSON.parse(item.response[1].body)).to.eql({ user: 1 });
-          expect(JSON.parse(item.response[1].originalRequest.body.raw)).to.eql({ hello: 'world' });
           done();
         });
     });
@@ -2623,10 +2613,10 @@ describe('The convert v2 Function', function() {
             });
 
             /**
-             * Even though both req and res has 3 examples, only 2 example should be present
-             * as only 2 examples have matching keys
+             * Even though both req and res has 3 examples, only 1 example should be present
+             * as we only use the first example from each
              */
-            expect(item.response).to.have.lengthOf(2);
+            expect(item.response).to.have.lengthOf(1);
             expect(item.response[0].name).to.eql('Complete request');
             expect(item.response[0]._postman_previewlanguage).to.eql('json');
             expect(JSON.parse(item.response[0].body)).to.eql({
@@ -2636,13 +2626,6 @@ describe('The convert v2 Function', function() {
             });
             expect(JSON.parse(item.response[0].originalRequest.body.raw)).to.eql({
               includedFields: ['user', 'height', 'weight']
-            });
-
-            expect(item.response[1].name).to.eql('Request with only required params');
-            expect(item.response[1]._postman_previewlanguage).to.eql('json');
-            expect(JSON.parse(item.response[1].body)).to.eql({ user: 1 });
-            expect(JSON.parse(item.response[1].originalRequest.body.raw)).to.eql({
-              includedFields: ['user']
             });
             done();
           });
@@ -2666,7 +2649,8 @@ describe('The convert v2 Function', function() {
             expect(JSON.parse(item.request.body.raw)).to.eql({
               includedFields: ['user', 'height', 'weight']
             });
-            expect(item.response).to.have.lengthOf(2);
+            // Should only generate 1 response (using first examples from both request and response)
+            expect(item.response).to.have.lengthOf(1);
             expect(item.response[0].name).to.eql('Request with only required params');
             expect(item.response[0]._postman_previewlanguage).to.eql('json');
             expect(JSON.parse(item.response[0].body)).to.eql({
@@ -2674,17 +2658,6 @@ describe('The convert v2 Function', function() {
             });
             expect(JSON.parse(item.response[0].originalRequest.body.raw)).to.eql({
               includedFields: ['user', 'height', 'weight']
-            });
-
-            expect(item.response[1].name).to.eql('Complete request');
-            expect(item.response[1]._postman_previewlanguage).to.eql('json');
-            expect(JSON.parse(item.response[1].body)).to.eql({
-              user: 1,
-              height: 168,
-              weight: 44
-            });
-            expect(JSON.parse(item.response[1].originalRequest.body.raw)).to.eql({
-              includedFields: ['user']
             });
             done();
           });
@@ -2704,35 +2677,23 @@ describe('The convert v2 Function', function() {
 
           const item = conversionResult.output[0].data.item[0].item[0],
             okReqExample = { message: 'ok' },
-            failReqExample = { message: 'fail' },
             okResExample = { message: 'Found', code: 200123 },
             failResExample = { message: 'Not Found' };
 
           expect(JSON.parse(item.request.body.raw)).to.eql(okReqExample);
-          expect(item.response).to.have.lengthOf(4);
+          // Should only generate 2 responses (1 per response code, using first request example)
+          expect(item.response).to.have.lengthOf(2);
           expect(item.response[0].name).to.eql('ok_example');
           expect(item.response[0].code).to.eql(200);
           expect(item.response[0]._postman_previewlanguage).to.eql('json');
           expect(JSON.parse(item.response[0].originalRequest.body.raw)).to.eql(okReqExample);
           expect(JSON.parse(item.response[0].body)).to.eql(okResExample);
 
-          expect(item.response[1].name).to.eql('not_ok_example');
-          expect(item.response[1].code).to.eql(200);
+          expect(item.response[1].name).to.eql('ok_example');
+          expect(item.response[1].code).to.eql(undefined);
           expect(item.response[1]._postman_previewlanguage).to.eql('json');
-          expect(JSON.parse(item.response[1].originalRequest.body.raw)).to.eql(failReqExample);
-          expect(JSON.parse(item.response[1].body)).to.eql(okResExample);
-
-          expect(item.response[2].name).to.eql('ok_example');
-          expect(item.response[2].code).to.eql(undefined);
-          expect(item.response[2]._postman_previewlanguage).to.eql('json');
-          expect(JSON.parse(item.response[2].originalRequest.body.raw)).to.eql(okReqExample);
-          expect(JSON.parse(item.response[2].body)).to.eql(failResExample);
-
-          expect(item.response[3].name).to.eql('not_ok_example');
-          expect(item.response[3].code).to.eql(undefined);
-          expect(item.response[3]._postman_previewlanguage).to.eql('json');
-          expect(JSON.parse(item.response[3].originalRequest.body.raw)).to.eql(failReqExample);
-          expect(JSON.parse(item.response[3].body)).to.eql(failResExample);
+          expect(JSON.parse(item.response[1].originalRequest.body.raw)).to.eql(okReqExample);
+          expect(JSON.parse(item.response[1].body)).to.eql(failResExample);
           done();
         });
     });
@@ -2751,11 +2712,11 @@ describe('The convert v2 Function', function() {
           expect(conversionResult.output[0].data.item[0].item.length).to.equal(1);
 
           const item = conversionResult.output[0].data.item[0].item[0],
-            reqBody1 = { includedFields: ['user', 'height', 'weight'] },
-            reqBody2 = { includedFields: ['eyeColor'] };
+            reqBody1 = { includedFields: ['user', 'height', 'weight'] };
 
           expect(JSON.parse(item.request.body.raw)).to.eql(reqBody1);
-          expect(item.response).to.have.lengthOf(4);
+          // Should only generate 3 responses (1 per response code, using first example from each)
+          expect(item.response).to.have.lengthOf(3);
           expect(item.response[0].name).to.eql('Request with only required params');
           expect(item.response[0].code).to.eql(200);
           expect(item.response[0]._postman_previewlanguage).to.eql('json');
@@ -2765,7 +2726,7 @@ describe('The convert v2 Function', function() {
           expect(item.response[1].name).to.eql('Request with only bad params');
           expect(item.response[1].code).to.eql(400);
           expect(item.response[1]._postman_previewlanguage).to.eql('json');
-          expect(JSON.parse(item.response[1].originalRequest.body.raw)).to.eql(reqBody2);
+          expect(JSON.parse(item.response[1].originalRequest.body.raw)).to.eql(reqBody1);
           expect(JSON.parse(item.response[1].body)).to.eql({ eyeColor: 'gray' });
 
           expect(item.response[2].name).to.eql('Failed request - Negative user');
@@ -2773,12 +2734,6 @@ describe('The convert v2 Function', function() {
           expect(item.response[2]._postman_previewlanguage).to.eql('json');
           expect(JSON.parse(item.response[2].originalRequest.body.raw)).to.eql(reqBody1);
           expect(JSON.parse(item.response[2].body)).to.eql({ user: -99 });
-
-          expect(item.response[3].name).to.eql('Failed request - All negatives');
-          expect(item.response[3].code).to.eql(500);
-          expect(item.response[3]._postman_previewlanguage).to.eql('json');
-          expect(JSON.parse(item.response[3].originalRequest.body.raw)).to.eql(reqBody2);
-          expect(JSON.parse(item.response[3].body)).to.eql({ user: -999, height: -168, weight: -44 });
           done();
         });
     });
@@ -2804,9 +2759,11 @@ describe('The convert v2 Function', function() {
               }
             };
 
+          // Should use first request example for all responses
           expect(JSON.parse(item.request.body.raw)).to.eql(defaultReqBody);
           expect(item.response).to.have.lengthOf(5);
 
+          // All responses should use the first request example (200)
           expect(item.response[0].name).to.eql('200');
           expect(item.response[0].code).to.eql(200);
           expect(item.response[0]._postman_previewlanguage).to.eql('json');
@@ -2816,9 +2773,7 @@ describe('The convert v2 Function', function() {
           expect(item.response[1].name).to.eql('400');
           expect(item.response[1].code).to.eql(400);
           expect(item.response[1]._postman_previewlanguage).to.eql('json');
-          expect(JSON.parse(item.response[1].originalRequest.body.raw)).to.eql({
-            userDetail: { roleId: null, department: 'Admin 1', email: '' }
-          });
+          expect(JSON.parse(item.response[1].originalRequest.body.raw)).to.eql(defaultReqBody);
           expect(JSON.parse(item.response[1].body)).to.eql({
             hasErrorMessage: true,
             errorMessage: 'Bad Request',
@@ -2828,25 +2783,19 @@ describe('The convert v2 Function', function() {
           expect(item.response[2].name).to.eql('404');
           expect(item.response[2].code).to.eql(404);
           expect(item.response[2]._postman_previewlanguage).to.eql('json');
-          expect(JSON.parse(item.response[2].originalRequest.body.raw)).to.eql({
-            userDetail: { roleId: 0, department: 'Admin 0', email: '123@gmail.com' }
-          });
+          expect(JSON.parse(item.response[2].originalRequest.body.raw)).to.eql(defaultReqBody);
           expect(JSON.parse(item.response[2].body)).to.eql({ message: 'AddUserDetailsCommand : User Role Not Found' });
 
           expect(item.response[3].name).to.eql('409');
           expect(item.response[3].code).to.eql(409);
           expect(item.response[3]._postman_previewlanguage).to.eql('json');
-          expect(JSON.parse(item.response[3].originalRequest.body.raw)).to.eql({
-            userDetail: { roleId: 1, department: 'Admin 1', email: '123@gmail.com' }
-          });
+          expect(JSON.parse(item.response[3].originalRequest.body.raw)).to.eql(defaultReqBody);
           expect(JSON.parse(item.response[3].body)).to.eql({ message: 'AddUserDetailsCommand : Duplicate' });
 
           expect(item.response[4].name).to.eql('500');
           expect(item.response[4].code).to.eql(500);
           expect(item.response[4]._postman_previewlanguage).to.eql('json');
-          expect(JSON.parse(item.response[4].originalRequest.body.raw)).to.eql({
-            userDetail: { roleId: 0, department: null, email: null }
-          });
+          expect(JSON.parse(item.response[4].originalRequest.body.raw)).to.eql(defaultReqBody);
           expect(JSON.parse(item.response[4].body)).to.eql({ message: 'AddUserDetailsCommand : System Error message' });
           done();
         });

--- a/test/unit/convertV2WithTypes.test.js
+++ b/test/unit/convertV2WithTypes.test.js
@@ -557,14 +557,14 @@ describe('convertV2WithTypes', function() {
                           type: 'object',
                           example: { name: 'John Doe' },
                           properties: {
-                            name: { type: 'string', example: 'Jane' }
+                            name: { type: 'string', format: 'email', example: 'Jane' }
                           }
                         },
                         {
                           type: 'object',
                           example: { id: 123 },
                           properties: {
-                            id: { type: 'integer', example: 456 }
+                            id: { type: 'integer', format: 'int32', example: 456 }
                           }
                         }
                       ]
@@ -605,9 +605,11 @@ describe('convertV2WithTypes', function() {
         expect(parsedRequestBody.example).to.deep.equal({ name: 'default example' });
         expect(parsedRequestBody.anyOf[0]).to.have.property('example');
         expect(parsedRequestBody.anyOf[0].example).to.deep.equal({ name: 'John Doe' });
+        expect(parsedRequestBody.anyOf[0].properties.name).to.have.property('format', 'email');
         expect(parsedRequestBody.anyOf[0].properties.name).to.have.property('example', 'Jane');
         expect(parsedRequestBody.anyOf[1]).to.have.property('example');
         expect(parsedRequestBody.anyOf[1].example).to.deep.equal({ id: 123 });
+        expect(parsedRequestBody.anyOf[1].properties.id).to.have.property('format', 'int32');
         expect(parsedRequestBody.anyOf[1].properties.id).to.have.property('example', 456);
 
         done();
@@ -629,13 +631,13 @@ describe('convertV2WithTypes', function() {
                       schema: {
                         example: 'default response',
                         oneOf: [
-                          { type: 'string', example: 'success' },
-                          { type: 'integer', example: 200 },
+                          { type: 'string', format: 'uuid', example: 'success' },
+                          { type: 'integer', format: 'int64', example: 200 },
                           {
                             type: 'object',
                             example: { message: 'OK' },
                             properties: {
-                              message: { type: 'string', example: 'All good' }
+                              message: { type: 'string', format: 'hostname', example: 'All good' }
                             }
                           }
                         ]
@@ -665,9 +667,12 @@ describe('convertV2WithTypes', function() {
 
         expect(parsedResponseBody).to.have.property('example', 'default response');
         expect(parsedResponseBody.oneOf[0]).to.have.property('example', 'success');
+        expect(parsedResponseBody.oneOf[0]).to.have.property('format', 'uuid');
         expect(parsedResponseBody.oneOf[1]).to.have.property('example', 200);
+        expect(parsedResponseBody.oneOf[1]).to.have.property('format', 'int64');
         expect(parsedResponseBody.oneOf[2]).to.have.property('example');
         expect(parsedResponseBody.oneOf[2].example).to.deep.equal({ message: 'OK' });
+        expect(parsedResponseBody.oneOf[2].properties.message).to.have.property('format', 'hostname');
         expect(parsedResponseBody.oneOf[2].properties.message).to.have.property('example', 'All good');
 
         done();
@@ -691,14 +696,14 @@ describe('convertV2WithTypes', function() {
                           type: 'object',
                           example: { baseField: 'example base' },
                           properties: {
-                            baseField: { type: 'string', example: 'field example' }
+                            baseField: { type: 'string', format: 'uuid', example: 'field example' }
                           }
                         },
                         {
                           type: 'object',
                           example: { extensionField: 200 },
                           properties: {
-                            extensionField: { type: 'integer', example: 300 }
+                            extensionField: { type: 'integer', format: 'int32', example: 300 }
                           }
                         }
                       ]
@@ -718,7 +723,7 @@ describe('convertV2WithTypes', function() {
                             type: 'object',
                             example: { id: '456' },
                             properties: {
-                              id: { type: 'string', example: '789' }
+                              id: { type: 'string', format: 'uuid', example: '789' }
                             }
                           },
                           {
@@ -756,9 +761,11 @@ describe('convertV2WithTypes', function() {
         expect(parsedRequestBody.example).to.deep.equal({ baseField: 'base', extensionField: 100 });
         expect(parsedRequestBody.allOf[0]).to.have.property('example');
         expect(parsedRequestBody.allOf[0].example).to.deep.equal({ baseField: 'example base' });
+        expect(parsedRequestBody.allOf[0].properties.baseField).to.have.property('format', 'uuid');
         expect(parsedRequestBody.allOf[0].properties.baseField).to.have.property('example', 'field example');
         expect(parsedRequestBody.allOf[1]).to.have.property('example');
         expect(parsedRequestBody.allOf[1].example).to.deep.equal({ extensionField: 200 });
+        expect(parsedRequestBody.allOf[1].properties.extensionField).to.have.property('format', 'int32');
         expect(parsedRequestBody.allOf[1].properties.extensionField).to.have.property('example', 300);
 
         // Check response body
@@ -774,9 +781,11 @@ describe('convertV2WithTypes', function() {
         expect(parsedResponseBody.example).to.deep.equal({ id: 'res123', timestamp: '2024-01-01' });
         expect(parsedResponseBody.allOf[0]).to.have.property('example');
         expect(parsedResponseBody.allOf[0].example).to.deep.equal({ id: '456' });
+        expect(parsedResponseBody.allOf[0].properties.id).to.have.property('format', 'uuid');
         expect(parsedResponseBody.allOf[0].properties.id).to.have.property('example', '789');
         expect(parsedResponseBody.allOf[1]).to.have.property('example');
         expect(parsedResponseBody.allOf[1].example).to.deep.equal({ timestamp: '2024-12-22T00:00:00Z' });
+        expect(parsedResponseBody.allOf[1].properties.timestamp).to.have.property('format', 'date-time');
         expect(parsedResponseBody.allOf[1].properties.timestamp).to.have.property('example', '2025-01-01T00:00:00Z');
 
         done();

--- a/test/unit/convertV2WithTypes.test.js
+++ b/test/unit/convertV2WithTypes.test.js
@@ -2667,33 +2667,23 @@ describe('convertV2WithTypes', function() {
 
         const collection = conversionResult.output[0].data;
 
-        // Find the POST request
-        const findRequest = (items) => {
-          for (let item of items) {
-            if (item.request) {
-              return item;
-            }
-            if (item.item) {
-              const found = findRequest(item.item);
-              if (found) { return found; }
-            }
-          }
-          return null;
-        };
-
-        const request = findRequest(collection.item);
-        expect(request, 'POST request should exist').to.not.be.null;
+        // Fixture has a single path with a single POST operation.
+        const request = collection.item[0].item[0];
+        expect(request, 'POST request should exist').to.exist;
+        expect(request.request.method).to.equal('POST');
 
         // CRITICAL: Should generate exactly 2 responses (one for 201, one for 400)
-        // NOT 6 responses (3 examples × 2 response codes) or 3 responses (3 examples for 201 code)
         expect(request.response).to.be.an('array').with.length(2);
 
-        // Verify we have one response for each status code
-        const responseCodes = request.response.map((r) => { return r.code; });
-        expect(responseCodes).to.include(201);
-        expect(responseCodes).to.include(400);
+        // Verify response code and names
+        const responsesSortedByCode = request.response.slice().sort((a, b) => { return a.code - b.code; });
+        expect(responsesSortedByCode[0].code).to.equal(201);
+        expect(responsesSortedByCode[0].name).to.equal('Created');
+        expect(responsesSortedByCode[1].code).to.equal(400);
+        expect(responsesSortedByCode[1].name).to.equal('Bad Request');
 
         // Verify no duplicate response codes
+        const responseCodes = request.response.map((r) => { return r.code; });
         const uniqueCodes = [...new Set(responseCodes)];
         expect(uniqueCodes.length).to.equal(2);
 


### PR DESCRIPTION
[[AB-1798] ](https://postmanlabs.atlassian.net/browse/AB-1798)
 - Use first example for examples. -> If there are examples in the responses in the spec, multiple examples are getting created in the collection instead and the main response object description is getting changed and hence the ref can get expanded.

[[AB-1852](https://postmanlabs.atlassian.net/browse/AB-1852)]
- Add format in anyOf/oneOf/allOf


[AB-1798]: https://postmanlabs.atlassian.net/browse/AB-1798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AB-1852]: https://postmanlabs.atlassian.net/browse/AB-1852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ