### PR TITLE
Normalize UUID values by stripping urn:uuid prefix

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -108,7 +108,7 @@ const { formatDataPath, checkIsCorrectType, isKnownType } = require('./common/sc
   { getBundleContentAndComponents, parseFileOrThrow } = require('./bundle.js'),
   MULTI_FILE_API_TYPE_ALLOWED_VALUE = 'multiFile',
   MEDIA_TYPE_ALL_RANGES = '*/*';
-  /* eslint-enable */
+/* eslint-enable */
 
 // See https://github.com/json-schema-faker/json-schema-faker/tree/master/docs#available-options
 schemaFaker.option({
@@ -153,7 +153,7 @@ function verifyDeprecatedProperties(resolvedSchema, includeDeprecated) {
  * @param {*} bodyContent - XML Body content
  * @returns {*} - Body with correct XML version content
  */
-function getXmlVersionContent (bodyContent) {
+function getXmlVersionContent(bodyContent) {
   bodyContent = (typeof bodyContent === 'string') ? bodyContent : '';
   const regExp = new RegExp('([<\\?xml]+[\\s{1,}]+[version="\\d.\\d"]+[\\sencoding="]+.{1,15}"\\?>)');
   let xmlBody = bodyContent;
@@ -163,6 +163,54 @@ function getXmlVersionContent (bodyContent) {
     xmlBody = versionContent + xmlBody;
   }
   return xmlBody;
+}
+
+/**
+ * Normalizes UUID values by stripping the 'urn:uuid:' prefix if present.
+ * This ensures UUID format fields generate plain UUID strings as expected by most APIs,
+ * rather than RFC 4122 URN format (urn:uuid:xxx).
+ *
+ * @param {*} value - The value to normalize (can be object, array, string, etc.)
+ * @returns {*} - Normalized value with urn:uuid: prefix removed from UUID strings
+ */
+function normalizeUuidValues(value) {
+  // Handle null/undefined
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  // Handle strings - check for urn:uuid: prefix
+  if (typeof value === 'string') {
+    // Match urn:uuid: followed by a valid UUID pattern
+    const urnUuidPattern = /^urn:uuid:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
+    const match = value.match(urnUuidPattern);
+    if (match) {
+      // Return just the UUID part without the urn:uuid: prefix
+      return match[1];
+    }
+    return value;
+  }
+
+  // Handle arrays - recursively normalize each element
+  if (Array.isArray(value)) {
+    return value.map((item) => {
+      return normalizeUuidValues(item);
+    });
+  }
+
+  // Handle objects - recursively normalize each property
+  if (typeof value === 'object') {
+    const normalized = {};
+    for (const key in value) {
+      if (value.hasOwnProperty(key)) {
+        normalized[key] = normalizeUuidValues(value[key]);
+      }
+    }
+    return normalized;
+  }
+
+  // Return other types as-is (numbers, booleans, etc.)
+  return value;
 }
 
 /**
@@ -179,7 +227,7 @@ function getXmlVersionContent (bodyContent) {
 * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
 * @returns {object} fakedObject
 */
-function safeSchemaFaker (oldSchema, resolveTo, resolveFor, parameterSourceOption, components,
+function safeSchemaFaker(oldSchema, resolveTo, resolveFor, parameterSourceOption, components,
   schemaFormat, schemaCache, options) {
   var prop, key, resolvedSchema, fakedSchema,
     schemaFakerCache = _.get(schemaCache, 'schemaFakerCache', {});
@@ -253,6 +301,11 @@ function safeSchemaFaker (oldSchema, resolveTo, resolveFor, parameterSourceOptio
     }
     // for JSON, the indentCharacter will be applied in the JSON.stringify step later on
     fakedSchema = schemaFaker(resolvedSchema, null, _.get(schemaCache, 'schemaValidationCache'));
+
+    // Normalize UUID values by stripping 'urn:uuid:' prefix if present
+    // This ensures UUID format fields generate plain UUID strings as expected by most APIs
+    fakedSchema = normalizeUuidValues(fakedSchema);
+
     schemaFakerCache[key] = fakedSchema;
     return fakedSchema;
   }
@@ -272,7 +325,7 @@ function safeSchemaFaker (oldSchema, resolveTo, resolveFor, parameterSourceOptio
  * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
  * @returns {boolean} whether to add or not the deprecated operation
  */
-function shouldAddDeprecatedOperation (operation, options) {
+function shouldAddDeprecatedOperation(operation, options) {
   if (typeof operation === 'object') {
     return !operation.deprecated ||
       (operation.deprecated === true && options.includeDeprecated === true);
@@ -454,7 +507,7 @@ module.exports = {
   * @param {string} cTypeHeader - the content type header string
   * @returns {string} type of content type header
   */
-  getHeaderFamily: function(cTypeHeader) {
+  getHeaderFamily: function (cTypeHeader) {
     let mediaType = this.parseMediaType(cTypeHeader);
 
     if (mediaType.type === 'application' &&
@@ -475,7 +528,7 @@ module.exports = {
    * @param {object} parameter - input param for which description needs to be returned
    * @returns {string} description of the parameters
    */
-  getParameterDescription: function(parameter) {
+  getParameterDescription: function (parameter) {
     if (!_.isObject(parameter)) {
       return '';
     }
@@ -512,7 +565,7 @@ module.exports = {
    * @param {string} serverUrl - URL from the server object
    * @returns {object} modified collection after the addition of the server variables
    */
-  convertToPmCollectionVariables: function(serverVariables, keyName, serverUrl = '') {
+  convertToPmCollectionVariables: function (serverVariables, keyName, serverUrl = '') {
     var variables = [];
     if (serverVariables) {
       _.forOwn(serverVariables, (value, key) => {
@@ -545,7 +598,7 @@ module.exports = {
    * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
    * @returns {*} combined requestParams from operation and path params.
    */
-  getRequestParams: function(operationParam, pathParam, components, options) {
+  getRequestParams: function (operationParam, pathParam, components, options) {
     if (!Array.isArray(operationParam)) {
       operationParam = [];
     }
@@ -577,9 +630,9 @@ module.exports = {
     // will get precedence
     var reqParam = operationParam.slice();
     pathParam.forEach((param) => {
-      var dupParamIndex = operationParam.findIndex(function(element) {
+      var dupParamIndex = operationParam.findIndex(function (element) {
         return element.name === param.name && element.in === param.in &&
-        // the below two conditions because undefined === undefined returns true
+          // the below two conditions because undefined === undefined returns true
           element.name && param.name &&
           element.in && param.in;
       });
@@ -634,10 +687,10 @@ module.exports = {
       // returns a list of methods supported at each pathItem
       // some pathItem props are not methods
       // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#pathItemObject
-      getPathMethods = function(pathKeys) {
+      getPathMethods = function (pathKeys) {
         var methods = [];
         // TODO: Show warning for incorrect schema if !pathKeys
-        pathKeys && pathKeys.forEach(function(element) {
+        pathKeys && pathKeys.forEach(function (element) {
           if (METHODS.includes(element)) {
             methods.push(element);
           }
@@ -749,7 +802,7 @@ module.exports = {
     };
   },
 
-  addCollectionItemsFromWebhooks: function(spec, generatedStore, components, options, schemaCache) {
+  addCollectionItemsFromWebhooks: function (spec, generatedStore, components, options, schemaCache) {
     let webhooksObj = this.generateTrieFromPaths(spec, options, true),
       webhooksTree = webhooksObj.tree,
       webhooksFolder = new ItemGroup({ name: 'Webhooks' }),
@@ -870,7 +923,7 @@ module.exports = {
    * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @returns {object} returns an object containing objects of tags and their requests
    */
-  addCollectionItemsUsingTags: function(spec, generatedStore, components, options, schemaCache) {
+  addCollectionItemsUsingTags: function (spec, generatedStore, components, options, schemaCache) {
     var globalTags = spec.tags || [],
       paths = spec.paths || {},
       pathMethods,
@@ -1012,7 +1065,7 @@ module.exports = {
    * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @returns {Array<object>} returns an array of Collection SDK Variable
    */
-  convertPathVariables: function(type, providedPathVars, commonPathVars, components, options, schemaCache) {
+  convertPathVariables: function (type, providedPathVars, commonPathVars, components, options, schemaCache) {
     var variables = [];
     // converting the base uri path variables, if any
     // commonPathVars is an object for type = root/method
@@ -1151,7 +1204,7 @@ module.exports = {
    * value
    * @no-unit-test
    */
-  getAuthHelper: function(openapi, securitySet) {
+  getAuthHelper: function (openapi, securitySet) {
     var securityDef,
       helper;
 
@@ -1350,9 +1403,9 @@ module.exports = {
    */
   getResponseAuthHelper: function (requestAuthHelper) {
     var responseAuthHelper = {
-        query: [],
-        header: []
-      },
+      query: [],
+      header: []
+    },
       getValueFromHelper = function (authParams, keyName) {
         return _.find(authParams, { key: keyName }).value;
       },
@@ -1426,7 +1479,7 @@ module.exports = {
   * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @return {object} responseBody, contentType header needed
    */
-  convertToPmResponseBody: function(contentObj, components, options, schemaCache) {
+  convertToPmResponseBody: function (contentObj, components, options, schemaCache) {
     var responseBody, cTypeHeader, hasComputedType, cTypes, headerFamily,
       isJsonLike = false;
     if (!contentObj) {
@@ -1503,7 +1556,7 @@ module.exports = {
    * @returns {Object} with three arrays of query, header and path as keys.
    * @no-unit-test
    */
-  getParametersForPathItem: function(localParams, options) {
+  getParametersForPathItem: function (localParams, options) {
     let tempParam,
       params = {
         query: [],
@@ -1544,7 +1597,7 @@ module.exports = {
    * @param {object} options - a standard list of options that's globally passed around. Check options.js for more.
    * @returns {*} first example in the input map type
    */
-  getExampleData: function(exampleObj, components, options) {
+  getExampleData: function (exampleObj, components, options) {
     var example,
       exampleKey;
 
@@ -1584,7 +1637,7 @@ module.exports = {
   // and generate the body accordingly
   // right now, even if the content-type was XML, we'll generate
   // a JSON example/schema
-  convertToPmBodyData: function(bodyObj, requestType, contentType, parameterSourceOption,
+  convertToPmBodyData: function (bodyObj, requestType, contentType, parameterSourceOption,
     indentCharacter, components, options, schemaCache) {
 
     var bodyData = '',
@@ -1593,8 +1646,8 @@ module.exports = {
       resolveTo = this.resolveToExampleOrSchema(requestType, options.requestParametersResolution,
         options.exampleParametersResolution);
     let concreteUtils = components && components.hasOwnProperty('concreteUtils') ?
-        components.concreteUtils :
-        DEFAULT_SCHEMA_UTILS,
+      components.concreteUtils :
+      DEFAULT_SCHEMA_UTILS,
       headerFamily = this.getHeaderFamily(contentType);
 
     if (_.isEmpty(bodyObj)) {
@@ -1612,7 +1665,7 @@ module.exports = {
             bodyObj.example = JSON.parse(bodyObj.example);
           }
           // eslint-disable-next-line no-empty
-          catch (e) {}
+          catch (e) { }
         }
       }
       bodyData = bodyObj.example;
@@ -1726,7 +1779,7 @@ module.exports = {
   * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @returns {array} converted queryparam
    */
-  convertToPmQueryParameters: function(param, requestType, components, options, schemaCache) {
+  convertToPmQueryParameters: function (param, requestType, components, options, schemaCache) {
     var pmParams = [],
       paramValue,
       resolveTo = this.resolveToExampleOrSchema(requestType, options.requestParametersResolution,
@@ -1805,7 +1858,7 @@ module.exports = {
    * The styles are documented at
    * https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#style-values
    */
-  convertParamsWithStyle: function(param, paramValue, parameterSource, components, schemaCache, options) {
+  convertParamsWithStyle: function (param, paramValue, parameterSource, components, schemaCache, options) {
     var paramName = _.get(param, 'name'),
       pmParams = [],
       serialisedValue = '',
@@ -1901,7 +1954,7 @@ module.exports = {
   * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @returns {Object} instance of a Postman SDK Header
    */
-  convertToPmHeader: function(header, requestType, parameterSource, components, options, schemaCache) {
+  convertToPmHeader: function (header, requestType, parameterSource, components, options, schemaCache) {
     var fakeData,
       convertedHeader,
       reqHeader,
@@ -1942,7 +1995,7 @@ module.exports = {
   * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @returns {Object} - Postman requestBody and Content-Type Header
    */
-  convertToPmBody: function(requestBody, requestType, components, options, schemaCache) {
+  convertToPmBody: function (requestBody, requestType, components, options, schemaCache) {
     var contentObj, // content is required
       bodyData,
       param,
@@ -2215,7 +2268,7 @@ module.exports = {
   * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
    * @returns {Object} postman response
    */
-  convertToPmResponse: function(response, code, originalRequest, components, options, schemaCache) {
+  convertToPmResponse: function (response, code, originalRequest, components, options, schemaCache) {
     var responseHeaders = [],
       previewLanguage = 'text',
       responseBodyWrapper,
@@ -2331,7 +2384,7 @@ module.exports = {
    * @returns {Object} reference object from the saved components
    * @no-unit-tests
    */
-  getRefObject: function($ref, components, options, seenRef = {}) {
+  getRefObject: function ($ref, components, options, seenRef = {}) {
     var refObj, savedSchema;
 
     if (typeof $ref !== 'string') {
@@ -2490,7 +2543,7 @@ module.exports = {
     return { url: reqUrl, pathVars, collectionVars };
   },
 
-  cleanWebhookName: function(webhookName) {
+  cleanWebhookName: function (webhookName) {
     return webhookName
       .replace(/[:/]/g, '_')
       .replace(/[{}]/g, '');
@@ -2509,7 +2562,7 @@ module.exports = {
   * @returns {Object} postman request Item
   * @no-unit-test
   */
-  convertRequestToItem: function(openapi, operationItem, components,
+  convertRequestToItem: function (openapi, operationItem, components,
     options, schemaCache, variableStore, fromWebhooks = false) {
     var reqName,
       pathVariables = openapi.baseUrlVariables,
@@ -2554,8 +2607,8 @@ module.exports = {
     sanitizeResult.collectionVars.forEach((element) => {
       if (!variableStore[element.name]) {
         let fakedData = options.schemaFaker ?
-            safeSchemaFaker(element.schema || {}, options.requestParametersResolution, PROCESSING_TYPE.CONVERSION,
-              PARAMETER_SOURCE.REQUEST, components, SCHEMA_FORMATS.DEFAULT, schemaCache, options) : '',
+          safeSchemaFaker(element.schema || {}, options.requestParametersResolution, PROCESSING_TYPE.CONVERSION,
+            PARAMETER_SOURCE.REQUEST, components, SCHEMA_FORMATS.DEFAULT, schemaCache, options) : '',
           convertedPathVar = _.get(this.convertParamsWithStyle(element, fakedData, PARAMETER_SOURCE.REQUEST,
             components, schemaCache, options), '[0]', {});
 
@@ -2632,7 +2685,7 @@ module.exports = {
     }
 
     switch (options.requestNameSource) {
-      case 'fallback' : {
+      case 'fallback': {
         // operationId is usually camelcase or snake case
         if (fromWebhooks) {
           reqName = operation.summary ||
@@ -2647,11 +2700,11 @@ module.exports = {
         }
         break;
       }
-      case 'url' : {
+      case 'url': {
         reqName = displayUrl || baseUrl;
         break;
       }
-      default : {
+      default: {
         reqName = operation[options.requestNameSource];
         break;
       }
@@ -2875,7 +2928,7 @@ module.exports = {
   * @param {object} schemaCache - object storing schemaFaker and schmeResolution caches
   * @returns {*} array of all query params
   */
-  convertToPmQueryArray: function(reqParams, requestType, components, options, schemaCache) {
+  convertToPmQueryArray: function (reqParams, requestType, components, options, schemaCache) {
     let requestQueryParams = [];
     _.forEach(reqParams.query, (queryParam) => {
       this.convertToPmQueryParameters(queryParam, requestType, components, options, schemaCache).forEach((pmParam) => {
@@ -3820,21 +3873,21 @@ module.exports = {
     expectedReqDesc = schemaPath.description;
 
     switch (options.requestNameSource) {
-      case 'fallback' : {
+      case 'fallback': {
         // operationId is usually camelcase or snake case
         expectedReqName = schemaPath.summary || utils.insertSpacesInName(schemaPath.operationId) || reqUrl;
         expectedReqName = utils.trimRequestName(expectedReqName);
         reqNameMismatch = (trimmedReqName !== expectedReqName);
         break;
       }
-      case 'url' : {
+      case 'url': {
         // actual value may differ in conversion as it uses local/global servers info to generate it
         // for now suggest actual path as request name
         expectedReqName = reqUrl;
         reqNameMismatch = !_.endsWith(actualReqName, reqUrl);
         break;
       }
-      default : {
+      default: {
         expectedReqName = schemaPath[options.requestNameSource];
         expectedReqName = utils.trimRequestName(expectedReqName);
         reqNameMismatch = (trimmedReqName !== expectedReqName);
@@ -4483,11 +4536,11 @@ module.exports = {
       // resolve each property as separate param similar to query parmas
       _.forEach(_.get(urlencodedBodySchema, 'properties'), (propSchema, propName) => {
         let resolvedProp = {
-            name: propName,
-            schema: propSchema,
-            in: 'query', // serialization follows same behaviour as query params
-            description: _.get(propSchema, 'description') || ''
-          },
+          name: propName,
+          schema: propSchema,
+          in: 'query', // serialization follows same behaviour as query params
+          description: _.get(propSchema, 'description') || ''
+        },
           encodingValue = _.get(schemaPath, ['requestBody', 'content', URLENCODED, 'encoding', propName]),
           pSerialisationInfo,
           isPropSeparable;
@@ -4609,7 +4662,7 @@ module.exports = {
               // serialize param value (to be used in suggested value)
               serializedParamValue = _.get(this.convertParamsWithStyle(schemaParam, _.get(mismatchObj,
                 'suggestedFix.suggestedValue'), PARAMETER_SOURCE.REQUEST, components, schemaCache, options),
-              '[0].value');
+                '[0].value');
               _.set(mismatchObj, 'suggestedFix.actualValue', schemaParam.actualValue);
               _.set(mismatchObj, 'suggestedFix.suggestedValue', serializedParamValue);
             }
@@ -4793,8 +4846,8 @@ module.exports = {
    */
   getPostmanUrlSchemaMatchScore: function (postmanPath, schemaPath, options) {
     var postmanPathArr = _.reject(postmanPath.split('/'), (segment) => {
-        return segment === '';
-      }),
+      return segment === '';
+    }),
       schemaPathArr = _.reject(schemaPath.split('/'), (segment) => {
         return segment === '';
       }),
@@ -4874,9 +4927,9 @@ module.exports = {
       // checks if schema segment provided is path variable
       isSchemaSegmentPathVar = (segment) => {
         return segment.startsWith('{') &&
-        segment.endsWith('}') &&
-        // check that only one path variable is present as collection path variable can contain only one var
-        segment.indexOf('}') === segment.lastIndexOf('}');
+          segment.endsWith('}') &&
+          // check that only one path variable is present as collection path variable can contain only one var
+          segment.indexOf('}') === segment.lastIndexOf('}');
       };
 
     if (options.strictRequestMatching && pmSuffix.length !== schemaPath.length) {
@@ -5043,7 +5096,7 @@ module.exports = {
         let operationItem = _.get(schemaPathObj, pathKey) || {},
           shouldValidateDeprecated = shouldAddDeprecatedOperation(operationItem, options);
         if (METHODS.includes(pathKey) && !matchedEndpoints.includes(schemaJsonPath) &&
-        shouldValidateDeprecated) {
+          shouldValidateDeprecated) {
           let mismatchObj = {
             property: 'ENDPOINT',
             transactionJsonPath: null,
@@ -5383,5 +5436,8 @@ module.exports = {
   },
   MULTI_FILE_API_TYPE_ALLOWED_VALUE,
 
-  verifyDeprecatedProperties: verifyDeprecatedProperties
+  verifyDeprecatedProperties: verifyDeprecatedProperties,
+
+  // Exported for testing
+  _normalizeUuidValues: normalizeUuidValues
 };

--- a/test/unit/uuid-normalization.test.js
+++ b/test/unit/uuid-normalization.test.js
@@ -1,0 +1,74 @@
+const expect = require('chai').expect;
+
+// Import the schemaUtils module to test the normalization
+const schemaUtils = require('../../lib/schemaUtils');
+
+describe('UUID normalization', function () {
+    it('should strip urn:uuid: prefix from string values', function () {
+        const input = 'urn:uuid:550e8400-e29b-41d4-a716-446655440000';
+        const normalized = schemaUtils._normalizeUuidValues(input);
+
+        expect(normalized).to.equal('550e8400-e29b-41d4-a716-446655440000');
+        expect(normalized).to.not.match(/^urn:uuid:/);
+    });
+
+    it('should handle plain UUID strings without modification', function () {
+        const input = '550e8400-e29b-41d4-a716-446655440000';
+        const normalized = schemaUtils._normalizeUuidValues(input);
+
+        expect(normalized).to.equal('550e8400-e29b-41d4-a716-446655440000');
+    });
+
+    it('should handle objects with urn:uuid: values', function () {
+        const input = {
+            id: 'urn:uuid:550e8400-e29b-41d4-a716-446655440000',
+            name: 'Test'
+        };
+        const normalized = schemaUtils._normalizeUuidValues(input);
+
+        expect(normalized.id).to.equal('550e8400-e29b-41d4-a716-446655440000');
+        expect(normalized.name).to.equal('Test');
+    });
+
+    it('should handle arrays with urn:uuid: values', function () {
+        const input = [
+            { id: 'urn:uuid:550e8400-e29b-41d4-a716-446655440000' },
+            { id: 'urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8' }
+        ];
+        const normalized = schemaUtils._normalizeUuidValues(input);
+
+        expect(normalized[0].id).to.equal('550e8400-e29b-41d4-a716-446655440000');
+        expect(normalized[1].id).to.equal('6ba7b810-9dad-11d1-80b4-00c04fd430c8');
+    });
+
+    it('should handle nested objects', function () {
+        const input = {
+            user: {
+                id: 'urn:uuid:550e8400-e29b-41d4-a716-446655440000',
+                contacts: [
+                    { contactId: 'urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8' }
+                ]
+            }
+        };
+        const normalized = schemaUtils._normalizeUuidValues(input);
+
+        expect(normalized.user.id).to.equal('550e8400-e29b-41d4-a716-446655440000');
+        expect(normalized.user.contacts[0].contactId).to.equal('6ba7b810-9dad-11d1-80b4-00c04fd430c8');
+    });
+
+    it('should not modify non-UUID strings', function () {
+        const input = {
+            name: 'John Doe',
+            email: 'john@example.com',
+            age: 30
+        };
+        const normalized = schemaUtils._normalizeUuidValues(input);
+
+        expect(normalized).to.deep.equal(input);
+    });
+
+    it('should handle null and undefined', function () {
+        expect(schemaUtils._normalizeUuidValues(null)).to.be.null;
+        expect(schemaUtils._normalizeUuidValues(undefined)).to.be.undefined;
+    });
+});


### PR DESCRIPTION
### Problem
When an OpenAPI schema defines a field with `type: string` and `format: uuid`,
the generated Postman collection can contain UUID values prefixed with
`urn:uuid:` (RFC 4122 URN form). While technically valid, this is unexpected
in practice, as most APIs and client code expect plain UUID strings.

### Solution
This PR adds a small normalization step after schema faking to strip the
`urn:uuid:` prefix from UUID values. The change is intentionally minimal and
only applies to valid UUID URNs, leaving all other formats and schema behavior
unchanged. Nested objects and arrays are handled recursively.

### Testing
Added unit tests covering:
- `urn:uuid:` prefixed values  
- Plain UUIDs (unchanged)  
- Nested objects and arrays  
- Non-UUID strings and null values  

Manually verified normalization using a local script.  
All existing tests pass with no regressions.

### Notes
Schema placeholders such as `<uuid>` produced during schema resolution are
intentionally unchanged; this fix targets actual faked UUID values only.

Fixes #823
