### PR TITLE
[AB-1671] Fix bundling when common components have local $refs

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -87,23 +87,12 @@ function calculatePath(parentFileName, referencePath) {
    * @returns {object} - Detect root files result object
    */
 function findNodeFromPath(referencePath, allData) {
-  const isReferenceRemoteURL = stringIsAValidUrl(referencePath),
-    partialComponents = referencePath.split(localPointer),
-    isPartial = partialComponents.length > 1;
+  const partialComponents = referencePath.split(localPointer),
+    basePath = partialComponents[0];
 
-  let node = allData.find((node) => {
-    if (isPartial && !isReferenceRemoteURL) {
-      referencePath = partialComponents[0];
-    }
-
-    if (isReferenceRemoteURL) {
-      return _.startsWith(node.path, referencePath);
-    }
-
-    return comparePaths(node.fileName, referencePath);
+  return allData.find((node) => {
+    return comparePaths(node.fileName, basePath);
   });
-
-  return node;
 }
 
 /**
@@ -355,16 +344,19 @@ async function getReferences (currentNode, isOutOfRoot, pathSolver, parentFilena
 
             try {
               let contentFromRemote = await remoteRefResolver(property.$ref),
+                baseRef = tempRef.split(localPointer)[0],
                 nodeTemp = {
-                  fileName: tempRef,
-                  path: tempRef,
+                  fileName: baseRef,
+                  path: baseRef,
                   content: convertToJSONString(contentFromRemote),
                   href: property.$ref
                 };
 
               remoteRefContentMap.set(tempRef, contentFromRemote);
 
-              allData.push(nodeTemp);
+              if (!allData.find((entry) => { return comparePaths(entry.fileName, baseRef); })) {
+                allData.push(nodeTemp);
+              }
             }
             catch (err) {
               // swallow the err
@@ -388,9 +380,9 @@ async function getReferences (currentNode, isOutOfRoot, pathSolver, parentFilena
       hasReferenceTypeKey = Object.keys(property)
         .find(
           (key) => {
-            const isLocalOutOfRoot = isOutOfRoot && isLocalRef(property, key),
+            const isLocalAndOutOfRoot = isOutOfRoot && isLocalRef(property, key),
               isExternal = isExtRef(property, key),
-              isReferenciable = isLocalOutOfRoot || isExternal;
+              isReferenciable = isLocalAndOutOfRoot || isExternal;
             return isReferenciable;
           }
         );
@@ -536,7 +528,11 @@ async function getReferences (currentNode, isOutOfRoot, pathSolver, parentFilena
           mainKeys[componentKey] = tempRef;
 
           if (!added(property.$ref, referencesInNode)) {
-            referencesInNode.push({ path: pathSolver(property), keyInComponents: nodeTrace, newValue: this.node });
+            referencesInNode.push({ 
+              path: pathSolver(property), 
+              keyInComponents: nodeTrace, 
+              newValue: this.node 
+            });
           }
         };
 
@@ -557,7 +553,7 @@ async function getReferences (currentNode, isOutOfRoot, pathSolver, parentFilena
    * @param {string} version - The current version
    * @param {object} rootMainKeys - A dictionary with the component keys in local components object and its mainKeys
    * @param {string} commonPathFromData - The common path in the file's paths
-   * @param {object} globalReferences - The accumulated global refernces from all nodes
+   * @param {object} globalReferences - The accumulated global references from all nodes
    * @param {function} remoteRefResolver - The function that would be called to fetch remote ref contents
    * @returns {object} - Detect root files result object
    */

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -380,9 +380,9 @@ async function getReferences (currentNode, isOutOfRoot, pathSolver, parentFilena
       hasReferenceTypeKey = Object.keys(property)
         .find(
           (key) => {
-            const isLocalAndOutOfRoot = isOutOfRoot && isLocalRef(property, key),
+            const isLocalOutOfRoot = isOutOfRoot && isLocalRef(property, key),
               isExternal = isExtRef(property, key),
-              isReferenciable = isLocalAndOutOfRoot || isExternal;
+              isReferenciable = isLocalOutOfRoot || isExternal;
             return isReferenciable;
           }
         );
@@ -528,11 +528,7 @@ async function getReferences (currentNode, isOutOfRoot, pathSolver, parentFilena
           mainKeys[componentKey] = tempRef;
 
           if (!added(property.$ref, referencesInNode)) {
-            referencesInNode.push({ 
-              path: pathSolver(property), 
-              keyInComponents: nodeTrace, 
-              newValue: this.node 
-            });
+            referencesInNode.push({ path: pathSolver(property), keyInComponents: nodeTrace, newValue: this.node });
           }
         };
 

--- a/test/data/toBundleExamples/remote_url_refs/expected_4.json
+++ b/test/data/toBundleExamples/remote_url_refs/expected_4.json
@@ -1,0 +1,63 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Sample API",
+    "description": "Buy or rent spacecrafts"
+  },
+  "paths": {
+    "/spacecrafts": {
+      "get": {
+        "summary": "Read a spacecraft",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/https_components.pstmn.io_postman_Default_response2_1.0.y-_components_responses_sampleError"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Api-Key"
+      }
+    },
+    "responses": {
+      "https_components.pstmn.io_postman_Default_response2_1.0.y-_components_responses_sampleError": {
+        "description": "A sample error response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "description": "A sample user response",
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "email"
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "ApiKey": []
+    }
+  ]
+}

--- a/test/data/toBundleExamples/remote_url_refs/root_4.json
+++ b/test/data/toBundleExamples/remote_url_refs/root_4.json
@@ -1,0 +1,34 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Sample API",
+    "description": "Buy or rent spacecrafts"
+  },
+  "paths": {
+    "/spacecrafts": {
+      "get": {
+        "summary": "Read a spacecraft",
+        "responses": {
+          "200": {
+            "$ref": "https://components.pstmn.io/postman/Default_response2/1.0.y#/components/responses/sampleError"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Api-Key"
+      }
+    }
+  },
+  "security": [
+    {
+      "ApiKey": []
+    }
+  ]
+}

--- a/test/data/toBundleExamples/remote_url_refs/schemas/sampleComponents.json
+++ b/test/data/toBundleExamples/remote_url_refs/schemas/sampleComponents.json
@@ -1,0 +1,38 @@
+{
+  "components": {
+    "schemas": {
+      "sampleUser": {
+        "description": "A sample user response",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "email"
+        ]
+      }
+    },
+    "responses": {
+      "sampleError": {
+        "description": "A sample error response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/sampleUser"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/unit/bundle.test.js
+++ b/test/unit/bundle.test.js
@@ -53,7 +53,7 @@ let expect = require('chai').expect,
   schemaCircularRef = path.join(__dirname, BUNDLES_FOLDER + '/circular_reference'),
   schemaCircularRefInline = path.join(__dirname, BUNDLES_FOLDER + '/circular_reference_inline');
 
-describe('bundle files method - 3.0', function () {
+describe.only('bundle files method - 3.0', function () {
   it('Should return bundled file as json - schema_from_response', async function () {
     let contentRootFile = fs.readFileSync(schemaFromResponse + '/root.yaml', 'utf8'),
       user = fs.readFileSync(schemaFromResponse + '/schemas/user.yaml', 'utf8'),
@@ -2985,6 +2985,44 @@ describe('bundle files method - 3.0', function () {
     expect(res.output.specification.version).to.equal('3.0');
     expect(JSON.stringify(JSON.parse(res.output.data[0].bundledContent), null, 2)).to.be.equal(expected);
   });
+
+  it('Should return bundled file as json with internal refs inside remote component - remote_url_refs',
+    async function () {
+      let contentRootFile = fs.readFileSync(remoteURLRefExamples + '/root_4.json', 'utf8'),
+        sampleComponents = fs.readFileSync(remoteURLRefExamples + '/schemas/sampleComponents.json', 'utf8'),
+
+        remoteRefResolver = async (refURL) => {
+          if (refURL.includes('components.pstmn.io')) {
+            return JSON.parse(sampleComponents);
+          }
+        },
+        expected = fs.readFileSync(remoteURLRefExamples + '/expected_4.json', 'utf8'),
+        input = {
+          type: 'multiFile',
+          specificationVersion: '3.0',
+          rootFiles: [
+            {
+              path: 'root.json'
+            }
+          ],
+          data: [
+            {
+              path: 'root.json',
+              content: contentRootFile
+            }
+          ],
+          options: {},
+          bundleFormat: 'JSON',
+          remoteRefResolver
+        };
+
+      const res = await Converter.bundle(input);
+
+      expect(res).to.not.be.empty;
+      expect(res.result).to.be.true;
+      expect(res.output.specification.version).to.equal('3.0');
+      expect(JSON.stringify(JSON.parse(res.output.data[0].bundledContent), null, 2)).to.be.equal(expected);
+    });
 });
 
 describe('getReferences method when node does not have any reference', function() {

--- a/test/unit/bundle.test.js
+++ b/test/unit/bundle.test.js
@@ -53,7 +53,7 @@ let expect = require('chai').expect,
   schemaCircularRef = path.join(__dirname, BUNDLES_FOLDER + '/circular_reference'),
   schemaCircularRefInline = path.join(__dirname, BUNDLES_FOLDER + '/circular_reference_inline');
 
-describe.only('bundle files method - 3.0', function () {
+describe('bundle files method - 3.0', function () {
   it('Should return bundled file as json - schema_from_response', async function () {
     let contentRootFile = fs.readFileSync(schemaFromResponse + '/root.yaml', 'utf8'),
       user = fs.readFileSync(schemaFromResponse + '/schemas/user.yaml', 'utf8'),


### PR DESCRIPTION
When a remoteReference (like a common component) has a local reference, bundling the spec is producing non-desirable results.

Slack discussion thread : https://postman.slack.com/archives/C09LHC7956G/p1773688016742729?thread_ts=1765355105.661399&cid=C09LHC7956G


# Bug Fix: Remote Components with Internal $refs

## What does bundling do?

Bundling takes a multi-file OpenAPI spec (or one with remote references) and produces a **single self-contained file**. Every external `$ref` is resolved and the referenced content is placed inline or inside the `components` section of the output.

---

## Example Setup

**API spec (root file):**

```yaml
paths:
  /spacecrafts:
    get:
      responses:
        "200":
          $ref: 'https://components.pstmn.io/postman/MyComponents/v1#/components/responses/sampleError'
```

**Remote component file** (fetched from the URL above):

```yaml
components:
  schemas:
    sampleUser:
      type: object
      properties:
        id:
          type: string
        name:
          type: string
  responses:
    sampleError:
      description: A sample error response
      content:
        application/json:
          schema:
            $ref: '#/components/schemas/sampleUser'    # <-- internal ref within the same file
```

Notice: `sampleError` has an internal `$ref` pointing to `sampleUser` in the same file.

---

## How Bundling Works

```
                    ┌─────────────────────────────────┐
                    │  Step 1: FETCH REMOTE FILES      │
                    │                                   │
                    │  Scan the root spec for remote    │
                    │  URLs. Fetch each file and store  │
                    │  it in a data store with a key.   │
                    └──────────────┬────────────────────┘
                                   │
                                   ▼
                    ┌─────────────────────────────────┐
                    │  Step 2: TRAVERSE (DFS)           │
                    │                                   │
                    │  Walk every file starting from    │
                    │  root. For each $ref found:       │
                    │    - Record metadata       │
                    │    - Mark the referenced file as  │
                    │      "to be visited next"         │
                    │                                   │
                    │  The file to visit is looked up   │
                    │  from the data store by key.      │
                    └──────────────┬────────────────────┘
                                   │
                                   ▼
                    ┌─────────────────────────────────┐
                    │  Step 3: ASSEMBLE OUTPUT          │
                    │                                   │
                    │  Using the metadata collected,    │
                    │  look up each file's content from │
                    │  the data store (again, by key),  │
                    │  extract the specific fragment,   │
                    │  and place the resolved content   │
                    │  into the output — either inside  │
                    │  components or inlined directly.  │
                    └─────────────────────────────────┘
```

The **data store** is central to all the steps. Files are stored as:

```
KEY (identifier)  →  VALUE (file content)
```

---

## The Bug: Key Mismatch

### How the key was built (before the fix)

When a remote `$ref` like this was encountered:

```
https://components.pstmn.io/.../v1#/components/responses/sampleError
                                  │
                         ┌────────┴────────┐
                    base URL          fragment (JSON pointer)
```

The file was stored in the data store with the **full URL including the fragment** as the key:

```
┌─────────────────────────────────────────────────────────────────────┐
│  DATA STORE (before fix)                                            │
├─────────────────────────────────────────────────────────────────────┤
│  KEY: "https://.../v1#/components/responses/sampleError"            │
│  VALUE: { entire remote file content }                              │
└─────────────────────────────────────────────────────────────────────┘
```

### Where it broke — the internal $ref

When DFS traverses the remote file, it encounters the **internal `$ref`**:

```yaml
schema:
  $ref: '#/components/schemas/sampleUser'
```

To resolve this, the system needs to build a lookup key for the file that contains `sampleUser`. Since this is a same-file reference (`#/...`), the key is built by appending the internal ref to the current file's identifier:

```
current file's key  +  internal ref
─────────────────      ─────────────
"https://.../v1#/components/responses/sampleError"  +  "#/components/schemas/sampleUser"
```

Result: a key with **two `#` fragments**:

```
"https://.../v1#/components/responses/sampleError#/components/schemas/sampleUser"
                ▲                                 ▲
                first #                           second # (BROKEN!)
```

### The cascade of failures

**Step 2 (Traverse):** The system tries to look up this double-`#` key in the data store. The old lookup function used **prefix matching** (`startsWith`) for remote URLs — it checked if any stored key *starts with* the lookup key. Since the stored key (`url#/responses/sampleError`) does NOT start with the double-`#` lookup key (`url#/responses/sampleError#/schemas/sampleUser`), the match fails. The file is treated as "missing" and DFS cannot visit it.

**Step 3 (Assemble):** When building the final output, the system splits the key at `#` to separate the file identifier from the fragment. But with two `#` signs, the split produces the wrong file identifier — only the part before the first `#` is used as the file key, while everything after it (including the second `#`) is treated as the fragment. The content lookup using this corrupted fragment fails, and the system falls back to emitting the **raw double-`#` key as an unresolved `$ref`**.

### What the broken output looked like

```yaml
paths:
  /spacecrafts:
    get:
      responses:
        '200':
          $ref: '#/components/responses/https_components.pstmn.io_..._sampleError'
components:
  securitySchemes:
    ApiKey:
      type: apiKey
      in: header
      name: X-Api-Key
  responses:
    https_components.pstmn.io_..._sampleError:
      description: A sample error response
      content:
        application/json:
          schema:
            $ref: 'https://.../v1#/components/responses/sampleError#/components/schemas/sampleUser'
            #                    ▲                                  ▲
            #               first #                            second # (unresolved!)
```

Notice: the `sampleError` response itself was resolved, but its internal `schema` ended up as a **raw unresolved `$ref` with the corrupted double-`#` key** — instead of the actual `sampleUser` content.

---

## The Fix

### Root cause

The file was stored with the **full URL + fragment** as the key. But a file's identity is just its URL — the fragment is only a pointer to a specific part *within* that file. Two refs to the same file with different fragments should map to the **same** data store entry.

This is consistent with how **local files** already work — a file like `schemas.yaml` is stored once by its file path, regardless of how many different `#/...` fragments point into it.

### What we changed

**Change 1: Store remote files by base URL only**

```
BEFORE:  key = "https://.../v1#/components/responses/sampleError"    (full URL + fragment)
AFTER:   key = "https://.../v1"                                       (base URL only)
```

Also added a deduplication check — if two refs point to the same base URL with different fragments, the file is stored only once.

**Change 2: Simplify the data store lookup**

The lookup function previously had **different matching strategies** depending on reference type:

- For local files: strip the `#` fragment, then do an exact match
- For remote URLs: use **prefix matching** (`startsWith`) against the full key

This inconsistency meant remote lookups could match the wrong entry or fail entirely when the lookup key was longer than the stored key (as in the double-`#` case).

We unified it: **always strip the `#` fragment first, then do an exact match on the base path**. Same logic for both local and remote files.

### Why this fixes the internal $ref

Now when DFS processes the internal `$ref: '#/components/schemas/sampleUser'`:

```
current file's key  +  internal ref
─────────────────      ─────────────
"https://.../v1"    +  "#/components/schemas/sampleUser"
```

Result: `"https://.../v1#/components/schemas/sampleUser"` — **single `#`**, clean key.

Lookup strips the fragment → searches for `"https://.../v1"` → finds the file in the data store.

Content extraction uses the fragment `"/components/schemas/sampleUser"` → finds `sampleUser` inside the file.

### Correct output after the fix

```yaml
components:
  responses:
    sampleError:
      description: A sample error response
      content:
        application/json:
          schema:                          # fully resolved!
            type: object
            properties:
              id:
                type: string
              name:
                type: string
              email:
                type: string
```

---

## Before vs After — Visual Summary

```
BEFORE THE FIX
══════════════

  $ref: 'https://.../v1#/responses/sampleError'
                │
                ▼
  ┌──────────────────────────────────┐
  │ Data Store                       │
  │                                  │
  │ key: "url#/responses/sampleError"│──── stored with fragment
  │ val: { full file content }       │
  └──────────────────────────────────┘
                │
      DFS finds internal ref:
      #/schemas/sampleUser
                │
                ▼
      builds lookup key:
      "url#/responses/sampleError#/schemas/sampleUser"
              ▲                   ▲
          first #             second #
                │
                ▼
      lookup uses startsWith():
      does "url#/responses/sampleError"
      start with
      "url#/responses/sampleError#/schemas/sampleUser" ?
                │
                ▼
            NO → LOOKUP FAILS ✗
                │
                ▼
      Output: unresolved double-# $ref


AFTER THE FIX
═════════════

  $ref: 'https://.../v1#/responses/sampleError'
                │
                ▼
  ┌──────────────────────────────────┐
  │ Data Store                       │
  │                                  │
  │ key: "url"                       │──── stored WITHOUT fragment
  │ val: { full file content }       │
  └──────────────────────────────────┘
                │
      DFS finds internal ref:
      #/schemas/sampleUser
                │
                ▼
      builds lookup key:
      "url#/schemas/sampleUser"
          ▲
      single #
                │
                ▼
      strips # → looks up "url"
          LOOKUP SUCCEEDS ✓
                │
                ▼
      extracts /schemas/sampleUser
      from file content
                │
                ▼
      Output: fully resolved content
```

---

## Key Takeaway

The fix aligns remote file storage with local file storage — **one entry per file, keyed by its location (without fragment)**. The fragment is only used at extraction time to pull out the specific piece of content needed. This prevents key corruption when a remote file contains internal cross-references.

