### PR TITLE
feat(auth): expose auth placeholders as empty collection variables on import (closes #894)

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -535,6 +535,58 @@ module.exports = {
   },
 
   /**
+   * Given a Postman auth helper produced by `getAuthHelper`, returns an array of
+   * collection-level Variable objects (empty values) for every `{{variable}}`
+   * placeholder the helper references. This lets users of an imported collection
+   * see / fill the auth credentials in the Variables tab alongside `baseUrl`,
+   * instead of hitting unresolved-variable warnings the first time they send a
+   * request.
+   *
+   * Only variables that are clearly credential placeholders are emitted — the
+   * helper values are scanned for `{{<identifier>}}` substrings and each unique
+   * identifier becomes an empty Variable. No-op for `noauth`.
+   *
+   * @param {object} authHelper - the object returned by `getAuthHelper`.
+   * @returns {Variable[]} collection variables for credential placeholders.
+   */
+  getAuthCollectionVariables: function(authHelper) {
+    if (!_.isObject(authHelper) || !authHelper.type || authHelper.type === 'noauth') {
+      return [];
+    }
+
+    const placeholderKeys = new Set();
+    const placeholderRegex = /\{\{\s*([A-Za-z0-9_]+)\s*\}\}/g;
+
+    const scan = (value) => {
+      if (_.isString(value)) {
+        let match;
+        while ((match = placeholderRegex.exec(value)) !== null) {
+          placeholderKeys.add(match[1]);
+        }
+      }
+      else if (_.isArray(value)) {
+        value.forEach(scan);
+      }
+      else if (_.isObject(value)) {
+        _.forEach(value, scan);
+      }
+    };
+
+    // Only scan the helper payload, not the top-level `type`.
+    _.forEach(authHelper, (value, key) => {
+      if (key !== 'type') {
+        scan(value);
+      }
+    });
+
+    return Array.from(placeholderKeys).map((key) => new Variable({
+      key: key,
+      value: '',
+      type: 'string'
+    }));
+  },
+
+  /**
    * Returns params applied to specific operation with resolved references. Params from parent
    * blocks (collection/folder) are merged, so that the request has a flattened list of params needed.
    * OperationParams take precedence over pathParams

--- a/lib/schemapack.js
+++ b/lib/schemapack.js
@@ -364,6 +364,17 @@ class SchemaPack {
           generatedStore.collection.variables.add(element);
         });
 
+        // Mirror the baseUrl treatment for auth credentials — when the spec uses
+        // a security scheme, expose empty placeholders (basicAuthUsername /
+        // basicAuthPassword / bearerToken / apiKey / …) in the Variables tab so
+        // users can fill them in one place instead of hitting unresolved-variable
+        // warnings on first send. See #894.
+        if (authHelper) {
+          schemaUtils.getAuthCollectionVariables(authHelper).forEach((element) => {
+            generatedStore.collection.variables.add(element);
+          });
+        }
+
         generatedStore.collection.describe(schemaUtils.getCollectionDescription(openapi));
 
         // Only change the stack limit if the optimizeConversion option is true

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -1523,6 +1523,22 @@ describe('The convert v2 Function', function() {
         expect(conversionResult.output[0].data.item.length).to.equal(1);
         expect(conversionResult.output[0].data.auth.basic[0].value).to.equal('{{basicAuthUsername}}');
         expect(conversionResult.output[0].data.auth.basic[1].value).to.equal('{{basicAuthPassword}}');
+
+        // Empty collection-level variables for the auth placeholders should be
+        // pushed alongside `baseUrl` so users can fill them in the Variables
+        // tab. See #894.
+        const variableKeys = conversionResult.output[0].data.variable.map((v) => v.key);
+        expect(variableKeys).to.include('basicAuthUsername');
+        expect(variableKeys).to.include('basicAuthPassword');
+        const basicAuthUsername = conversionResult.output[0].data.variable.find(
+          (v) => v.key === 'basicAuthUsername'
+        );
+        const basicAuthPassword = conversionResult.output[0].data.variable.find(
+          (v) => v.key === 'basicAuthPassword'
+        );
+        expect(basicAuthUsername.value).to.equal('');
+        expect(basicAuthPassword.value).to.equal('');
+
         done();
       });
     });


### PR DESCRIPTION
## Context

Closes #894.

When the imported OpenAPI spec declares a security scheme, \`getAuthHelper\` produces an auth block whose values template Postman variables:

\`\`\`js
{ type: 'basic', basic: [
  { key: 'username', value: '{{basicAuthUsername}}' },
  { key: 'password', value: '{{basicAuthPassword}}' }
]}
\`\`\`

…but those variables were never pushed into \`collection.variable\`. On first send the user hit an *"unresolved variable"* warning and had to hunt for where to put credentials — while \`baseUrl\` (which is treated the same way) already appears in the **Variables** tab waiting to be filled.

## Change

Mirror the existing \`baseUrl\` flow. After \`generatedStore.collection.auth = authHelper\` is set in \`schemapack.js\`, scan the helper for \`{{identifier}}\` placeholders and add an empty collection-level \`Variable\` for each unique one.

\`\`\`js
if (authHelper) {
  schemaUtils.getAuthCollectionVariables(authHelper).forEach((element) => {
    generatedStore.collection.variables.add(element);
  });
}
\`\`\`

New helper \`schemaUtils.getAuthCollectionVariables(authHelper)\` recursively walks the helper payload (skipping the \`type\` field), uses \`/{{\s*([A-Za-z0-9_]+)\s*}}/g\` to extract placeholder names, de-duplicates with a \`Set\`, and returns \`Variable\` objects with empty values.

Design notes:
- Works uniformly for **every** scheme that \`getAuthHelper\` produces — basic, bearer, digest, apiKey, oauth2, oauth1, hawk, awsv4, ntlm, edgegrid — without any per-scheme mapping. Whatever placeholder \`getAuthHelper\` emits is what gets surfaced.
- No-op for \`{ type: 'noauth' }\` and for helpers whose values contain no \`{{…}}\` tokens (e.g. a future helper that inlines literal values).
- Values are intentionally empty strings, matching the baseUrl convention for user-supplied values.

## Test plan

Extended \`test/unit/convertV2.test.js\` → *'Should convert a collection and set basic auth placeholder as variable'* to additionally assert:

\`\`\`js
const variableKeys = conversionResult.output[0].data.variable.map((v) => v.key);
expect(variableKeys).to.include('basicAuthUsername');
expect(variableKeys).to.include('basicAuthPassword');
// both should be empty strings
\`\`\`

- [ ] \`npm test\` — all existing tests pass; the extended basic-auth case now also verifies the new variables.
- [ ] Import an OpenAPI spec with a \`bearer\` scheme → confirm \`bearerToken\` appears in the Variables tab (empty).
- [ ] Import with \`digest\` / \`apiKey\` / \`oauth2\` → confirm the respective placeholders are exposed.
- [ ] Import a spec with **no** security → \`collection.variable\` contains only \`baseUrl\` + any server variables, unchanged.

## Out of scope (for follow-up)

- The 13+ other test cases covering non-basic auth types in \`convertV2.test.js\` could each get the same assertion block. Happy to add those in this PR if preferred — left them untouched to keep the diff surgical, since the new helper is generic and exercised through the basic-auth path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)