### PR TITLE
Recognize path variables followed by `:verb` (AIP-136 custom methods)

### DIFF
--- a/lib/schemaUtils.js
+++ b/lib/schemaUtils.js
@@ -2392,8 +2392,11 @@ module.exports = {
   findPathVariablesFromPath: function (path) {
 
     // /{{path}}/{{file}}.{{format}}/{{hello}} return [ '{{path}}', '{{hello}}' ]
+    // /tasks/{{id}}:cancel returns [ '/{{id}}' ] — `:` is the boundary used by
+    // AIP-136 custom methods and is not expected inside a path-segment literal
+    // in OpenAPI path templates, so it's a safe lookahead.
     // https://regex101.com/r/XGL4Gh/1
-    return path.match(/(\/\{\{[^\/\{\}]+\}\})(?=\/|$)/g);
+    return path.match(/(\/\{\{[^\/\{\}]+\}\})(?=\/|$|:)/g);
   },
 
   /** Finds all the possible collection variables in a given path string

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -2821,6 +2821,13 @@ describe('SCHEMA UTILITY FUNCTION TESTS ', function () {
 
       pathVars = SchemaUtils.findPathVariablesFromPath('/send-sms.{{format}}');
       expect(pathVars).to.equal(null);
+
+      pathVars = SchemaUtils.findPathVariablesFromPath('/tasks/{{id}}:cancel');
+      expect(pathVars[0]).to.equal('/{{id}}');
+
+      pathVars = SchemaUtils.findPathVariablesFromPath('/users/{{userId}}:archive/items/{{itemId}}');
+      expect(pathVars[0]).to.equal('/{{userId}}');
+      expect(pathVars[1]).to.equal('/{{itemId}}');
       done();
     });
   });


### PR DESCRIPTION
## Summary

`findPathVariablesFromPath` requires every `{{name}}` placeholder to be followed by `/` or end-of-string. Paths shaped like `/tasks/{{id}}:cancel` — **AIP-136 custom methods** — therefore fall through to `findCollectionVariablesFromPath` and are demoted to collection variables instead of path variables. Extend the lookahead to also accept `:`.

## Repro

```yaml
paths:
  /tasks/{id}:cancel:
    post:
      parameters:
        - name: id
          in: path
          required: true
          schema: { type: string }
```

**Expected**: `:id` is emitted as a path variable on the resulting Postman item.
**Actual**: `{{id}}` is emitted as a collection (environment) variable; the item has no path variable for `id`.

## Fix

One-character regex change in `lib/schemaUtils.js`:

```diff
- return path.match(/(\/\{\{[^\/\{\}]+\}\})(?=\/|$)/g);
+ return path.match(/(\/\{\{[^\/\{\}]+\}\})(?=\/|$|:)/g);
```

`:` is the AIP-136 boundary character. It is not expected inside a path-segment literal in an OpenAPI path template, so it's a safe lookahead. Existing behavior for `/{{file}}.{{format}}` and similar literal-with-templates is unchanged.

## Tests

Two assertions added to `test/unit/util.test.js` in the `findPathVariablesFromPath function` block, covering a single-placeholder custom method and a placeholder + custom method + trailing placeholder.

## References

- [Google AIP-136 — Custom methods](https://google.aip.dev/136)
