### PR TITLE
feat: [AB-2326] add OpenAPI 3.2 support

### DIFF
--- a/lib/32XUtils/inputValidation32X.js
+++ b/lib/32XUtils/inputValidation32X.js
@@ -1,0 +1,22 @@
+// OpenAPI 3.2 root-level validation.
+// 3.2 is a near-superset of 3.1: the document validity rules are identical
+// (openapi + info required; at least one of paths / webhooks / components must
+// be present when webhooks are enabled). We delegate to the 3.1 validator so
+// the rules stay in lock-step until 3.2 introduces a divergence that needs a
+// dedicated implementation.
+const inputValidation31X = require('../31XUtils/inputValidation31X');
+
+module.exports = {
+
+  /**
+   * Validate Spec to check if some of the required fields are present.
+   * OpenAPI 3.2 only openapi and info are always required,
+   * but the document must also contain at least one of paths or webhooks or components.
+   * @param {Object} spec OpenAPI spec
+   * @param {Object} options computed process options
+   * @return {Object} Validation result
+   */
+  validateSpec: function (spec, options) {
+    return inputValidation31X.validateSpec(spec, options);
+  }
+};

--- a/lib/32XUtils/schemaUtils32X.js
+++ b/lib/32XUtils/schemaUtils32X.js
@@ -1,0 +1,34 @@
+// OpenAPI 3.2 schema utilities.
+//
+// OAS 3.2 is largely a superset of 3.1 from the converter's point of view:
+//  - JSON Schema dialect is 2020-12 (same as 3.1)
+//  - The document still has paths / webhooks / components carve-outs
+//  - The newly introduced 3.2 features (e.g. hierarchical tags via `tags.parent`,
+//    `tags.kind`, `parameter.in: querystring`, `discriminator.defaultMapping`,
+//    `responses.<code>.summary`, sealed objects) are additive and unknown-keys
+//    safe — the existing 3.1 conversion pipeline ignores them rather than
+//    crashing on them, which yields a usable collection for the common case.
+//
+// To stay in lock-step with 3.1 while keeping the door open for 3.2-only
+// divergence in the future, we reuse the 3.1 utilities verbatim and only
+// override the reported `version` marker.
+const schemaUtils31X = require('../31XUtils/schemaUtils31X'),
+  inputValidation32X = require('./inputValidation32X'),
+  schemaUtilsCommon = require('../common/schemaUtilsCommon');
+
+module.exports = Object.assign({}, schemaUtils31X, {
+  version: '3.2.x',
+
+  /**
+   * Parses an OAS 3.2.X string/object as a YAML or JSON
+   * @param {YAML/JSON} openApiSpec - The OAS 3.2.x specification specified in either YAML or JSON
+   * @param {Object} options computed process options
+   * @returns {Object} - Contains the parsed JSON-version of the OAS spec, or an error
+   * @no-unit-test
+   */
+  parseSpec: function (openApiSpec, options) {
+    return schemaUtilsCommon.parseSpec(openApiSpec, inputValidation32X, options);
+  },
+
+  inputValidation: inputValidation32X
+});

--- a/lib/bundleRules/spec32.js
+++ b/lib/bundleRules/spec32.js
@@ -1,0 +1,68 @@
+// Bundle rules for OpenAPI 3.2.
+//
+// 3.2 keeps the same component containers introduced in 3.1 (notably
+// `pathItems` and the JSON Schema 2020-12 keywords). New 3.2-only top-level
+// containers (e.g. `additionalOperations`-style fields) are forward-compatible
+// with the 3.1 rules — referencing them does not require new container
+// definitions for the bundler to work.
+//
+// Rules are mirrored here (rather than re-exported) so future 3.2-only
+// containers can be added without touching the 3.1 rules.
+const SCHEMA_CONTAINERS = [
+    'allOf',
+    'oneOf',
+    'anyOf',
+    'not',
+    'additionalProperties',
+    'items',
+    'schema'
+  ],
+  EXAMPLE_CONTAINERS = [
+  ],
+  REQUEST_BODY_CONTAINER = [
+    'requestBody'
+  ],
+  CONTAINERS = {
+    schemas: SCHEMA_CONTAINERS,
+    examples: EXAMPLE_CONTAINERS,
+    requestBodies: REQUEST_BODY_CONTAINER
+  },
+  DEFINITIONS = {
+    headers: 'headers',
+    responses: 'responses',
+    callbacks: 'callbacks',
+    properties: 'schemas',
+    links: 'links',
+    paths: 'pathItems',
+    examples: 'examples'
+  },
+  INLINE = [
+    'properties',
+    'value',
+    'example'
+  ],
+  ROOT_CONTAINERS_KEYS = [
+    'components'
+  ],
+  COMPONENTS_KEYS = [
+    'schemas',
+    'responses',
+    'parameters',
+    'examples',
+    'requestBodies',
+    'headers',
+    'securitySchemes',
+    'links',
+    'callbacks',
+    'pathItems'
+  ];
+
+module.exports = {
+  RULES_32: {
+    CONTAINERS,
+    DEFINITIONS,
+    COMPONENTS_KEYS,
+    INLINE,
+    ROOT_CONTAINERS_KEYS
+  }
+};

--- a/lib/common/versionUtils.js
+++ b/lib/common/versionUtils.js
@@ -1,15 +1,18 @@
 const _ = require('lodash'),
   VERSION_30 = { key: 'openapi', version: '3.0' },
   VERSION_31 = { key: 'openapi', version: '3.1' },
+  VERSION_32 = { key: 'openapi', version: '3.2' },
   VERSION_20 = { key: 'swagger', version: '2.0' },
   GENERIC_VERSION2 = { key: 'swagger', version: '2.' },
   GENERIC_VERSION3 = { key: 'openapi', version: '3.' },
   DEFAULT_SPEC_VERSION = VERSION_30.version,
   SWAGGER_VERSION = VERSION_20.version,
   VERSION_3_1 = VERSION_31.version,
+  VERSION_3_2 = VERSION_32.version,
   fs = require('fs'),
   { RULES_30 } = require('./../bundleRules/spec30'),
   { RULES_31 } = require('./../bundleRules/spec31'),
+  { RULES_32 } = require('./../bundleRules/spec32'),
   { RULES_20 } = require('./../bundleRules/spec20');
 
 /**
@@ -69,6 +72,9 @@ function getVersionRegexBySpecificationVersion(specificationVersion) {
   }
   else if (compareVersion(specificationVersion, '3.1')) {
     versionRegExp = getVersionRegexp(VERSION_31);
+  }
+  else if (compareVersion(specificationVersion, '3.2')) {
+    versionRegExp = getVersionRegexp(VERSION_32);
   }
   else {
     versionRegExp = getVersionRegexp(VERSION_30);
@@ -172,7 +178,7 @@ function getVersionByStringInput(version) {
   if (!version) {
     return false;
   }
-  let found = [DEFAULT_SPEC_VERSION, SWAGGER_VERSION, VERSION_3_1].find((supportedVersion) => {
+  let found = [DEFAULT_SPEC_VERSION, SWAGGER_VERSION, VERSION_3_1, VERSION_3_2].find((supportedVersion) => {
     return compareVersion(version, supportedVersion);
   });
   return found;
@@ -211,9 +217,11 @@ function getSpecVersion({ type, data, specificationVersion }) {
   }
   const openapi30 = getVersionRegexp(VERSION_30),
     openapi31 = getVersionRegexp(VERSION_31),
+    openapi32 = getVersionRegexp(VERSION_32),
     openapi20 = getVersionRegexp(VERSION_20),
     is30 = typeof data === 'string' && data.match(openapi30),
     is31 = typeof data === 'string' && data.match(openapi31),
+    is32 = typeof data === 'string' && data.match(openapi32),
     is20 = typeof data === 'string' && data.match(openapi20);
 
   let version = DEFAULT_SPEC_VERSION;
@@ -223,6 +231,9 @@ function getSpecVersion({ type, data, specificationVersion }) {
   }
   else if (is31) {
     version = VERSION_31.version;
+  }
+  else if (is32) {
+    version = VERSION_32.version;
   }
   else if (is20) {
     version = VERSION_20.version;
@@ -244,6 +255,9 @@ function getConcreteSchemaUtils({ type, data, specificationVersion }) {
   }
   else if (specVersion === VERSION_20.version) {
     concreteUtils = require('../swaggerUtils/schemaUtilsSwagger');
+  }
+  else if (specVersion === VERSION_32.version) {
+    concreteUtils = require('../32XUtils/schemaUtils32X');
   }
   else {
     concreteUtils = require('../31XUtils/schemaUtils31X');
@@ -282,7 +296,7 @@ function validateSupportedVersion(version) {
   if (!version) {
     return false;
   }
-  let isValid = [DEFAULT_SPEC_VERSION, VERSION_3_1, SWAGGER_VERSION].find((supportedVersion) => {
+  let isValid = [DEFAULT_SPEC_VERSION, VERSION_3_1, VERSION_3_2, SWAGGER_VERSION].find((supportedVersion) => {
     return compareVersion(version, supportedVersion);
   });
   return isValid !== undefined;
@@ -295,9 +309,13 @@ function validateSupportedVersion(version) {
  */
 function getBundleRulesDataByVersion(version) {
   const is31 = compareVersion(version, VERSION_31.version),
+    is32 = compareVersion(version, VERSION_32.version),
     is20 = compareVersion(version, VERSION_20.version);
   if (is20) {
     return RULES_20;
+  }
+  else if (is32) {
+    return RULES_32;
   }
   else if (is31) {
     return RULES_31;
@@ -330,6 +348,7 @@ module.exports = {
   getVersionRegexBySpecificationVersion,
   SWAGGER_VERSION,
   VERSION_3_1,
+  VERSION_3_2,
   validateSupportedVersion,
   getBundleRulesDataByVersion,
   getVersionFromSpec

--- a/lib/options.js
+++ b/lib/options.js
@@ -4,8 +4,9 @@ const _ = require('lodash'),
   VALID_MODES = ['document', 'use'],
   VERSION30 = '3.0',
   VERSION31 = '3.1',
+  VERSION32 = '3.2',
   VERSION20 = '2.0',
-  SUPPORTED_VERSIONS = [VERSION20, VERSION30, VERSION31],
+  SUPPORTED_VERSIONS = [VERSION20, VERSION30, VERSION31, VERSION32],
   MODULE_VERSION = {
     V1: 'v1',
     V2: 'v2'
@@ -49,7 +50,7 @@ module.exports = {
    * with all options being described. 'use' will return the default values of all options
    * @param {Object} criteria Decribes required criteria for options to be returned.
    * @param {string} criteria.version The version of the OpenAPI spec to be converted
-   *  (can be one of '2.0', '3.0', '3.1')
+   *  (can be one of '2.0', '3.0', '3.1', '3.2')
    * @param {string} criteria.moduleVersion The version of the module (can be one of 'v1' or 'v2')
    * @param {Array<string>} criteria.usage The usage of the option (values can be one of 'CONVERSION', 'VALIDATION')
    * @param {boolean} criteria.external Whether the option is exposed to Postman App UI or not
@@ -73,7 +74,7 @@ module.exports = {
         ' values: `summary`, `operationId`, `description`, `url`.',
         external: true,
         usage: ['CONVERSION', 'VALIDATION'],
-        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -85,7 +86,7 @@ module.exports = {
         description: 'Option for setting indentation character.',
         external: true,
         usage: ['CONVERSION'],
-        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -97,7 +98,7 @@ module.exports = {
         'persistent folder-level data.',
         external: true,
         usage: ['CONVERSION'],
-        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V1]
       },
       {
@@ -109,7 +110,7 @@ module.exports = {
           ' the performance of conversion.',
         external: true,
         usage: ['CONVERSION'],
-        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V1]
       },
       {
@@ -124,7 +125,7 @@ module.exports = {
         ' in the schema.',
         external: true,
         usage: ['CONVERSION'],
-        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V1]
       },
       {
@@ -139,7 +140,7 @@ module.exports = {
         ' in the schema.',
         external: true,
         usage: ['CONVERSION'],
-        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V1]
       },
       {
@@ -150,7 +151,7 @@ module.exports = {
         description: 'Whether disabled parameters of collection should be validated',
         external: false,
         usage: ['VALIDATION'],
-        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -165,7 +166,7 @@ module.exports = {
         ' in the schema.',
         external: true,
         usage: ['CONVERSION'],
-        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -177,7 +178,7 @@ module.exports = {
         description: 'Select whether to create folders according to the spec’s paths or tags.',
         external: true,
         usage: ['CONVERSION'],
-        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -188,7 +189,7 @@ module.exports = {
         description: 'Enable this option to create subfolders in the collection based on the order of tags.',
         external: true,
         usage: ['CONVERSION'],
-        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2]
       },
       {
@@ -199,7 +200,7 @@ module.exports = {
         description: 'Whether or not schemas should be faked.',
         external: false,
         usage: ['CONVERSION'],
-        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -212,7 +213,7 @@ module.exports = {
           ' option works correctly "optimizeConversion" option needs to be disabled)',
         external: false,
         usage: ['CONVERSION'],
-        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -223,7 +224,7 @@ module.exports = {
         description: 'Select whether to include authentication parameters in the example request.',
         external: true,
         usage: ['CONVERSION'],
-        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -234,7 +235,7 @@ module.exports = {
         description: 'Whether detailed error messages are required for request <> schema validation operations.',
         external: true,
         usage: ['VALIDATION'],
-        supportedIn: [VERSION30, VERSION31],
+        supportedIn: [VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -247,7 +248,7 @@ module.exports = {
           ' HEADER, BODY, RESPONSE_HEADER, RESPONSE_BODY',
         external: true,
         usage: ['VALIDATION'],
-        supportedIn: [VERSION30, VERSION31],
+        supportedIn: [VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -259,7 +260,7 @@ module.exports = {
           'use cases, this need not be considered an error.',
         external: true,
         usage: ['VALIDATION'],
-        supportedIn: [VERSION30, VERSION31],
+        supportedIn: [VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -271,7 +272,7 @@ module.exports = {
           'in the request/response body.',
         external: true,
         usage: ['VALIDATION'],
-        supportedIn: [VERSION30, VERSION31],
+        supportedIn: [VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -282,7 +283,7 @@ module.exports = {
         description: 'Whether to provide fixes for patching corresponding mismatches.',
         external: true,
         usage: ['VALIDATION'],
-        supportedIn: [VERSION30, VERSION31],
+        supportedIn: [VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -293,7 +294,7 @@ module.exports = {
         description: 'Whether to show mismatches for incorrect name and description of request',
         external: true,
         usage: ['VALIDATION'],
-        supportedIn: [VERSION30, VERSION31],
+        supportedIn: [VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -304,7 +305,7 @@ module.exports = {
         description: 'Whether to ignore mismatches resulting from unresolved variables in the Postman request',
         external: true,
         usage: ['VALIDATION'],
-        supportedIn: [VERSION30, VERSION31],
+        supportedIn: [VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -316,7 +317,7 @@ module.exports = {
           'include any matches where the URL path segments don\'t match exactly.',
         external: true,
         usage: ['VALIDATION'],
-        supportedIn: [VERSION30, VERSION31],
+        supportedIn: [VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -327,7 +328,7 @@ module.exports = {
         description: 'Whether to allow matching path variables that are available as part of URL itself ' +
           'in the collection request',
         external: true,
-        supportedIn: [VERSION30, VERSION31],
+        supportedIn: [VERSION30, VERSION31, VERSION32],
         usage: ['VALIDATION'],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
@@ -340,7 +341,7 @@ module.exports = {
           'Once enabled they will be selected in the collection and request as well.',
         external: true,
         usage: ['CONVERSION'],
-        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -351,7 +352,7 @@ module.exports = {
         description: 'Whether to keep implicit headers from the OpenAPI specification, which are removed by default.',
         external: true,
         usage: ['CONVERSION'],
-        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -362,7 +363,7 @@ module.exports = {
         description: 'Select whether to include Webhooks in the generated collection',
         external: false,
         usage: ['CONVERSION'],
-        supportedIn: [VERSION31],
+        supportedIn: [VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -373,7 +374,7 @@ module.exports = {
         description: 'Whether or not to include reference map or not as part of output',
         external: false,
         usage: ['BUNDLE'],
-        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -385,7 +386,7 @@ module.exports = {
           ' and properties in generated collection or not',
         external: true,
         usage: ['CONVERSION', 'VALIDATION'],
-        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -397,7 +398,7 @@ module.exports = {
           'the collection.',
         external: true,
         usage: ['CONVERSION'],
-        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2, MODULE_VERSION.V1]
       },
       {
@@ -411,7 +412,7 @@ module.exports = {
           'content-type defined in the OpenAPI spec will be selected.',
         external: false,
         usage: ['CONVERSION'],
-        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2]
       }
     ];
@@ -483,7 +484,7 @@ module.exports = {
           'When enabled, response examples in the spec will be synced with existing collection responses.',
         external: true,
         usage: ['SYNC'],
-        supportedIn: [VERSION20, VERSION30, VERSION31],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2]
       }
     ];

--- a/test/data/invalid_openapi32X/invalid-info-no-title.json
+++ b/test/data/invalid_openapi32X/invalid-info-no-title.json
@@ -1,0 +1,17 @@
+{
+  "openapi": "3.2.0",
+  "info": {
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/user": {
+      "get": {
+        "summary": "Returns details about a particular user",
+        "operationId": "listUser",
+        "responses": {
+          "200": { "description": "ok" }
+        }
+      }
+    }
+  }
+}

--- a/test/data/invalid_openapi32X/invalid-info-no-version.json
+++ b/test/data/invalid_openapi32X/invalid-info-no-version.json
@@ -1,0 +1,17 @@
+{
+  "openapi": "3.2.0",
+  "info": {
+    "title": "OAS 3.2 sample"
+  },
+  "paths": {
+    "/user": {
+      "get": {
+        "summary": "Returns details about a particular user",
+        "operationId": "listUser",
+        "responses": {
+          "200": { "description": "ok" }
+        }
+      }
+    }
+  }
+}

--- a/test/data/invalid_openapi32X/invalid-info-null-title.json
+++ b/test/data/invalid_openapi32X/invalid-info-null-title.json
@@ -1,0 +1,18 @@
+{
+  "openapi": "3.2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": null
+  },
+  "paths": {
+    "/user": {
+      "get": {
+        "summary": "Returns details about a particular user",
+        "operationId": "listUser",
+        "responses": {
+          "200": { "description": "ok" }
+        }
+      }
+    }
+  }
+}

--- a/test/data/invalid_openapi32X/invalid-info-null-version.json
+++ b/test/data/invalid_openapi32X/invalid-info-null-version.json
@@ -1,0 +1,18 @@
+{
+  "openapi": "3.2.0",
+  "info": {
+    "title": "OAS 3.2 sample",
+    "version": null
+  },
+  "paths": {
+    "/user": {
+      "get": {
+        "summary": "Returns details about a particular user",
+        "operationId": "listUser",
+        "responses": {
+          "200": { "description": "ok" }
+        }
+      }
+    }
+  }
+}

--- a/test/data/invalid_openapi32X/invalid-no-info.json
+++ b/test/data/invalid_openapi32X/invalid-no-info.json
@@ -1,0 +1,31 @@
+{
+  "openapi": "3.2.0",
+  "webhooks": {
+    "newPet": {
+      "post": {
+        "requestBody": {
+          "description": "Information about a new pet in the system",
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/Pet" }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "required": ["id", "name"],
+        "properties": {
+          "id": { "type": "integer", "format": "int64" },
+          "name": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/test/data/invalid_openapi32X/invalid-null-info.json
+++ b/test/data/invalid_openapi32X/invalid-null-info.json
@@ -1,0 +1,15 @@
+{
+  "openapi": "3.2.0",
+  "info": null,
+  "paths": {
+    "/user": {
+      "get": {
+        "summary": "Returns details about a particular user",
+        "operationId": "listUser",
+        "responses": {
+          "200": { "description": "ok" }
+        }
+      }
+    }
+  }
+}

--- a/test/data/valid_openapi32X/json/oas32-features.json
+++ b/test/data/valid_openapi32X/json/oas32-features.json
@@ -1,0 +1,81 @@
+{
+  "openapi": "3.2.0",
+  "info": {
+    "title": "OAS 3.2 feature sampler",
+    "summary": "Exercises 3.2-only constructs that should be tolerated by the converter",
+    "version": "1.0.0",
+    "license": {
+      "name": "Apache-2.0",
+      "identifier": "Apache-2.0"
+    }
+  },
+  "tags": [
+    { "name": "billing", "kind": "audience" },
+    { "name": "invoices", "parent": "billing", "kind": "nav" }
+  ],
+  "paths": {
+    "/invoices": {
+      "get": {
+        "summary": "List invoices",
+        "operationId": "listInvoices",
+        "tags": ["invoices"],
+        "responses": {
+          "200": {
+            "summary": "Invoice list response",
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/InvoiceList" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/invoices/{invoiceId}": {
+      "$ref": "#/components/pathItems/InvoiceItem"
+    }
+  },
+  "components": {
+    "pathItems": {
+      "InvoiceItem": {
+        "get": {
+          "summary": "Fetch a single invoice",
+          "operationId": "getInvoice",
+          "parameters": [
+            {
+              "name": "invoiceId",
+              "in": "path",
+              "required": true,
+              "schema": { "type": "string" }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Invoice",
+              "content": {
+                "application/json": {
+                  "schema": { "$ref": "#/components/schemas/Invoice" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Invoice": {
+        "type": "object",
+        "required": ["id", "amount"],
+        "properties": {
+          "id": { "type": "string" },
+          "amount": { "type": ["number", "null"] }
+        }
+      },
+      "InvoiceList": {
+        "type": "array",
+        "items": { "$ref": "#/components/schemas/Invoice" }
+      }
+    }
+  }
+}

--- a/test/data/valid_openapi32X/json/petstore.json
+++ b/test/data/valid_openapi32X/json/petstore.json
@@ -1,0 +1,274 @@
+{
+	"openapi": "3.2.0",
+	"info": {
+		"version": "1.0.0",
+		"title": "Swagger Petstore",
+		"license": {
+			"name": "MIT"
+		}
+	},
+	"servers": [
+		{
+			"url": "http://petstore.swagger.io/v1"
+		}
+	],
+	"paths": {
+		"/pets": {
+			"get": {
+				"summary": "List all pets",
+				"decription": "This should not be in the request body",
+				"operationId": "listPets",
+				"tags": [
+					"pets"
+				],
+				"parameters": [
+					{
+						"name": "limit",
+						"in": "header",
+						"description": "How many items to return at one time (max 100)",
+						"required": false,
+						"schema": {
+							"type": ["integer"],
+							"format": "int32",
+							"examples": [2]
+						}
+					},
+					{
+						"name": "variable",
+						"in": "query",
+						"description": "random variable",
+						"style": "form",
+						"explode": false,
+						"schema": {
+							"type": ["array"],
+							"items": {
+								"type": ["string"],
+								"examples": ["Hola Mundo"]
+							}
+						}
+					},
+					{
+						"name": "variable2",
+						"in": "query",
+						"description": "another random variable",
+						"style": "spaceDelimited",
+						"schema": {
+							"type": ["array"],
+							"items": {
+								"type": ["integer"],
+								"format": "int64"
+							}
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "An paged array of pets",
+						"headers": {
+							"x-next": {
+								"description": "A link to the next page of responses",
+								"schema": {
+									"type": ["string"]
+								}
+							}
+						},
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Pets"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "unexpected error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Error"
+								}
+							}
+						}
+					}
+				}
+			},
+			"post": {
+				"summary": "Create a pet",
+				"operationId": "createPets",
+				"tags": [
+					"pets"
+				],
+				"responses": {
+					"201": {
+						"description": "Null response"
+					},
+					"default": {
+						"description": "unexpected error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Error"
+								}
+							}
+						}
+					}
+				}
+			},
+			"parameters": [
+					{
+						"name": "limit_2",
+						"in": "header",
+						"description": "How many items to return at one time (max 100)",
+						"required": false,
+						"schema": {
+							"type": ["integer"],
+							"format": "int32"
+						}
+					}
+				]
+		},
+		"/pets/{petId}": {
+			"get": {
+				"summary": "Info for a specific pet",
+				"operationId": "showPetById",
+				"tags": [
+					"pets"
+				],
+				"parameters": [
+					{
+						"name": "petId",
+						"in": "path",
+						"required": true,
+						"description": "The id of the pet to retrieve",
+						"schema": {
+							"type": ["string"]
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Expected response to a valid request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Pet"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "unexpected error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Error"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+    "/pet/{petId}/uploadImage": {
+      "post": {
+        "tags": [
+          "pet",
+          "cat"
+        ],
+        "summary": "uploads an image",
+        "description": "This should not be in the request body",
+        "operationId": "uploadFile",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to update",
+            "required": true,
+            "schema": {
+              "type": ["integer"],
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {}
+          }
+        },
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiResponse"
+								}
+							}
+						}
+					}
+				}
+      }
+    }
+	},
+	"components": {
+		"schemas": {
+			"Pet": {
+				"required": [
+					"id",
+					"name"
+				],
+				"properties": {
+					"id": {
+						"type": ["integer"],
+						"format": "int64",
+            "examples": [111111]
+					},
+					"name": {
+						"type": [
+							"string"
+						]
+					},
+					"tag": {
+						"type": ["string"]
+					}
+				}
+			},
+			"Pets": {
+				"type": "array",
+				"items": {
+					"$ref": "#/components/schemas/Pet"
+				}
+			},
+			"Error": {
+				"required": [
+					"code",
+					"message"
+				],
+				"properties": {
+					"code": {
+						"type": ["integer"],
+						"format": "int32"
+					},
+					"message": {
+						"type": ["string"]
+					}
+				}
+			},
+			"ApiResponse": {
+				"type": "object",
+				"properties": {
+					"code": {
+						"type": ["integer"],
+						"format": "int32"
+					},
+					"type": {
+						"type": ["string"]
+					},
+					"message": {
+						"type": ["string"]
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/data/valid_openapi32X/json/webhooks.json
+++ b/test/data/valid_openapi32X/json/webhooks.json
@@ -1,0 +1,50 @@
+{
+  "openapi": "3.2.0",
+  "info": {
+    "title": "Webhook Example",
+    "version": "1.0.0"
+  },
+  "webhooks": {
+    "newPet": {
+      "post": {
+        "requestBody": {
+          "description": "Information about a new pet in the system",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Return a 200 status to indicate that the data was received successfully"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/data/valid_openapi32X/yaml/petstore.yaml
+++ b/test/data/valid_openapi32X/yaml/petstore.yaml
@@ -1,0 +1,57 @@
+openapi: "3.2.0"
+info:
+  title: OAS 3.2 petstore (YAML)
+  version: "1.0.0"
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: A paged array of pets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pets'
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        "201":
+          description: Null response
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: '#/components/schemas/Pet'

--- a/test/unit/32Xsupport/inputValidation32X.test.js
+++ b/test/unit/32Xsupport/inputValidation32X.test.js
@@ -1,0 +1,131 @@
+const { expect } = require('chai'),
+  {
+    validateSpec
+  } = require('../../../lib/32XUtils/inputValidation32X'),
+  correctMockedEntryWH = {
+    openapi: '3.2.0',
+    info: {
+      title: 'Webhook Example',
+      version: '1.0.0'
+    },
+    webhooks: {
+    }
+  },
+  correctMockedEntryPath = {
+    openapi: '3.2.0',
+    info: {
+      title: 'Webhook Example',
+      version: '1.0.0'
+    },
+    paths: {
+    }
+  },
+  correctMockedEntryComponent = {
+    openapi: '3.2.0',
+    info: {
+      title: 'Webhook Example',
+      version: '1.0.0'
+    },
+    components: {
+    }
+  },
+  correctMockedEntry = {
+    openapi: '3.2.0',
+    info: {
+      title: 'Webhook Example',
+      version: '1.0.0'
+    },
+    paths: {
+    },
+    components: {
+    },
+    webhooks: {
+    }
+  },
+  incorrectMockedEntryNoOpenapi = {
+    info: {
+      title: 'Webhook Example',
+      version: '1.0.0'
+    },
+    components: {
+    }
+  },
+  incorrectMockedEntryNoInfo = {
+    openapi: '3.2.0',
+    paths: {
+    },
+    components: {
+    },
+    webhooks: {
+    }
+  },
+  incorrectMockedEntryNOPathsComponentsWebhooks = {
+    openapi: '3.2.0',
+    info: {
+      title: 'Webhook Example',
+      version: '1.0.0'
+    }
+  };
+
+describe('validateSpec method (3.2)', function () {
+  it('should return true with a valid simple spec with webhooks', function () {
+    const validationResult = validateSpec(correctMockedEntryWH, { includeWebhooks: true });
+    expect(validationResult.result).to.be.true;
+  });
+
+  it('should return true with a valid simple spec with paths', function () {
+    const validationResult = validateSpec(correctMockedEntryPath, { includeWebhooks: true });
+    expect(validationResult.result).to.be.true;
+  });
+
+  it('should return true with a valid simple spec with components only', function () {
+    const validationResult = validateSpec(correctMockedEntryComponent, { includeWebhooks: true });
+    expect(validationResult.result).to.be.true;
+  });
+
+  it('should return true with a valid spec containing paths, components and webhooks', function () {
+    const validationResult = validateSpec(correctMockedEntry, { includeWebhooks: true });
+    expect(validationResult.result).to.be.true;
+  });
+
+  it('should return false with an invalid input without openapi field', function () {
+    const validationResult = validateSpec(incorrectMockedEntryNoOpenapi, { includeWebhooks: true });
+    expect(validationResult.result).to.be.false;
+    expect(validationResult.reason)
+      .to.equal('Specification must contain a semantic version number of the OAS specification');
+  });
+
+  it('should return false with an invalid input without info field', function () {
+    const validationResult = validateSpec(incorrectMockedEntryNoInfo, { includeWebhooks: true });
+    expect(validationResult.result).to.be.false;
+    expect(validationResult.reason)
+      .to.equal('Specification must contain an Info Object for the meta-data of the API');
+  });
+
+  it('should return false with an invalid input without path components and webhooks', function () {
+    const validationResult = validateSpec(incorrectMockedEntryNOPathsComponentsWebhooks, { includeWebhooks: true });
+    expect(validationResult.result).to.be.false;
+    expect(validationResult.reason)
+      .to.equal('Specification must contain either Paths, Webhooks or Components sections');
+  });
+
+  it('should return false with a valid simple spec with only webhooks but include webhooks is false', function () {
+    const validationResult = validateSpec(correctMockedEntryWH, { includeWebhooks: false });
+    expect(validationResult.result).to.be.false;
+  });
+
+  it('should return true with a valid simple spec with paths and include webhooks is false', function () {
+    const validationResult = validateSpec(correctMockedEntryPath, { includeWebhooks: false });
+    expect(validationResult.result).to.be.true;
+  });
+
+  it('should return false with a valid simple spec with only components and include webhooks is false', function () {
+    const validationResult = validateSpec(correctMockedEntryComponent, { includeWebhooks: false });
+    expect(validationResult.result).to.be.false;
+  });
+
+  it('should return false with input without path components or webhooks include webhooks is false', function () {
+    const validationResult = validateSpec(incorrectMockedEntryNOPathsComponentsWebhooks, { includeWebhooks: false });
+    expect(validationResult.result).to.be.false;
+  });
+});

--- a/test/unit/32Xsupport/schemaUtils32X.test.js
+++ b/test/unit/32Xsupport/schemaUtils32X.test.js
@@ -1,0 +1,154 @@
+const { expect } = require('chai'),
+  fs = require('fs'),
+  concreteUtils = require('../../../lib/32XUtils/schemaUtils32X'),
+  schemaUtils31X = require('../../../lib/31XUtils/schemaUtils31X'),
+  valid32xFolder = './test/data/valid_openapi32X',
+  invalid32xFolder = './test/data/invalid_openapi32X';
+
+describe('schemaUtils32X module', function () {
+  it('Should expose a 3.2.x version marker (distinct from 3.1.x)', function () {
+    expect(concreteUtils.version).to.equal('3.2.x');
+    expect(schemaUtils31X.version).to.equal('3.1.x');
+  });
+
+  it('Should expose its own inputValidation, not the 3.1.x one', function () {
+    expect(concreteUtils.inputValidation).to.not.equal(schemaUtils31X.inputValidation);
+  });
+});
+
+describe('parseSpec method (3.2)', function () {
+  it('Should parse a valid 3.2 spec with webhooks', function () {
+    const fileContent = fs.readFileSync(valid32xFolder + '/json/webhooks.json', 'utf8'),
+      parsedSpec = concreteUtils.parseSpec(fileContent, { includeWebhooks: true });
+    expect(parsedSpec.result).to.be.true;
+    expect(parsedSpec.openapi.openapi).to.equal('3.2.0');
+    expect(parsedSpec.openapi.webhooks).to.not.be.undefined;
+  });
+
+  it('Should return false and invalid format message when input content is empty', function () {
+    const fileContent = fs.readFileSync(invalid32xFolder + '/empty-spec.yaml', 'utf8'),
+      parsedSpec = concreteUtils.parseSpec(fileContent, { includeWebhooks: false });
+    expect(parsedSpec.result).to.be.false;
+    expect(parsedSpec.reason).to.equal('Invalid format. Input must be in YAML or JSON format.');
+  });
+
+  it('Should return false and reason when spec is missing an info object', function () {
+    const fileContent = fs.readFileSync(invalid32xFolder + '/invalid-no-info.json', 'utf8'),
+      parsedSpec = concreteUtils.parseSpec(fileContent, { includeWebhooks: false });
+    expect(parsedSpec.result).to.be.false;
+    expect(parsedSpec.reason).to.equal('Specification must contain an Info Object for the meta-data of the API');
+  });
+
+  it('Should return false and reason when info object is null', function () {
+    const fileContent = fs.readFileSync(invalid32xFolder + '/invalid-null-info.json', 'utf8'),
+      parsedSpec = concreteUtils.parseSpec(fileContent, { includeWebhooks: false });
+    expect(parsedSpec.result).to.be.false;
+    expect(parsedSpec.reason).to.equal('Specification must contain an Info Object for the meta-data of the API');
+  });
+
+  it('Should return false when info.version is missing', function () {
+    const fileContent = fs.readFileSync(invalid32xFolder + '/invalid-info-no-version.json', 'utf8'),
+      parsedSpec = concreteUtils.parseSpec(fileContent, { includeWebhooks: false });
+    expect(parsedSpec.result).to.be.false;
+    expect(parsedSpec.reason)
+      .to.equal('Specification must contain a semantic version number of the API in the Info Object');
+  });
+
+  it('Should return false when info.version is null', function () {
+    const fileContent = fs.readFileSync(invalid32xFolder + '/invalid-info-null-version.json', 'utf8'),
+      parsedSpec = concreteUtils.parseSpec(fileContent, { includeWebhooks: false });
+    expect(parsedSpec.result).to.be.false;
+    expect(parsedSpec.reason)
+      .to.equal('Specification must contain a semantic version number of the API in the Info Object');
+  });
+
+  it('Should return false when info.title is missing', function () {
+    const fileContent = fs.readFileSync(invalid32xFolder + '/invalid-info-no-title.json', 'utf8'),
+      parsedSpec = concreteUtils.parseSpec(fileContent, { includeWebhooks: false });
+    expect(parsedSpec.result).to.be.false;
+    expect(parsedSpec.reason)
+      .to.equal('Specification must contain a title in order to generate a collection');
+  });
+
+  it('Should return false when info.title is null', function () {
+    const fileContent = fs.readFileSync(invalid32xFolder + '/invalid-info-null-title.json', 'utf8'),
+      parsedSpec = concreteUtils.parseSpec(fileContent, { includeWebhooks: false });
+    expect(parsedSpec.result).to.be.false;
+    expect(parsedSpec.reason)
+      .to.equal('Specification must contain a title in order to generate a collection');
+  });
+});
+
+describe('getRequiredData method (3.2)', function () {
+  it('Should return paths, info, webhooks and components carve-outs from a typical 3.2 spec', function () {
+    const fileContent = fs.readFileSync(valid32xFolder + '/json/petstore.json', 'utf8'),
+      requiredData = concreteUtils.getRequiredData(JSON.parse(fileContent));
+    expect(requiredData).to.be.an('object')
+      .and.to.have.all.keys('info', 'paths', 'webhooks', 'components');
+    expect(requiredData.webhooks).to.be.an('object');
+    expect(Object.keys(requiredData.webhooks)).to.have.length(0);
+    expect(requiredData.paths).to.be.an('object')
+      .and.to.have.all.keys('/pet/{petId}/uploadImage', '/pets', '/pets/{petId}');
+    expect(requiredData.components).to.be.an('object')
+      .and.to.have.all.keys('schemas');
+  });
+
+  it('Should return empty placeholders for missing carve-outs', function () {
+    const input = {
+        openapi: '3.2.0',
+        info: {
+          title: 'Webhooks only',
+          version: '1.0.0'
+        },
+        webhooks: {
+          'inbound-sms': {
+            post: { operationId: 'inbound-sms' }
+          }
+        }
+      },
+      requiredData = concreteUtils.getRequiredData(input);
+    expect(requiredData).to.be.an('object')
+      .and.to.have.all.keys('info', 'paths', 'webhooks', 'components');
+    expect(Object.keys(requiredData.webhooks)).to.have.length(1);
+    expect(Object.keys(requiredData.paths)).to.have.length(0);
+    expect(Object.keys(requiredData.components)).to.have.length(0);
+  });
+});
+
+describe('delegated helpers (3.2 mirrors 3.1)', function () {
+  it('compareTypes: matches array-of-types like 3.1 does', function () {
+    expect(concreteUtils.compareTypes(['string', 'null'], 'string')).to.be.true;
+    expect(concreteUtils.compareTypes(['integer'], 'string')).to.be.false;
+  });
+
+  it('fixExamplesByVersion: copies the first examples[] entry into example', function () {
+    const fixed = concreteUtils.fixExamplesByVersion({
+      type: 'string',
+      examples: ['hello']
+    });
+    expect(fixed.example).to.equal('hello');
+  });
+
+  it('isBinaryContentType: true for application/octet-stream with no schema (3.1 behaviour)', function () {
+    expect(
+      concreteUtils.isBinaryContentType('application/octet-stream', {
+        'application/octet-stream': {}
+      })
+    ).to.be.true;
+  });
+
+  it('addOuterPropsToRefSchemaIfIsSupported: merges array properties (3.1 behaviour)', function () {
+    const resolved = concreteUtils.addOuterPropsToRefSchemaIfIsSupported(
+      { name: 'Test', required: ['name'] },
+      { required: ['job'], job: 'JOB' }
+    );
+    expect(resolved.required).to.deep.equal(['name', 'job']);
+    expect(resolved.job).to.equal('JOB');
+  });
+
+  it('findTypeByExample: picks integer when the example is 123 and types include integer', function () {
+    const { foundType, foundExample } = concreteUtils.findTypeByExample([123], ['string', 'integer']);
+    expect(foundType).to.equal('integer');
+    expect(foundExample).to.equal(123);
+  });
+});

--- a/test/unit/versionUtils.test.js
+++ b/test/unit/versionUtils.test.js
@@ -2,7 +2,11 @@ const { getSpecVersion,
     filterOptionsByVersion,
     compareVersion,
     getVersionRegexBySpecificationVersion,
-    validateSupportedVersion } = require('../../lib/common/versionUtils'),
+    validateSupportedVersion,
+    getBundleRulesDataByVersion } = require('../../lib/common/versionUtils'),
+  { RULES_32 } = require('../../lib/bundleRules/spec32'),
+  { RULES_31 } = require('../../lib/bundleRules/spec31'),
+  { RULES_30 } = require('../../lib/bundleRules/spec30'),
   expect = require('chai').expect;
 
 describe('getSpecVersion', function() {
@@ -63,6 +67,49 @@ describe('getSpecVersion', function() {
       '      description: \'note: non-oauth scopes are not defined at the securityScheme level\'',
       specVersion = getSpecVersion({ type: stringType, data: inputData });
     expect(specVersion).to.be.equal('3.1');
+  });
+
+  it('Should resolve as 3.2 the provided spec version from a YAML input', function() {
+    const inputData = 'openapi: 3.2.0' +
+      'info:' +
+      '  title: 3.2 sample' +
+      '  version: 1.0.0' +
+      'paths:' +
+      '  /users:' +
+      '    get:' +
+      '      summary: List users',
+      specVersion = getSpecVersion({ type: stringType, data: inputData });
+    expect(specVersion).to.be.equal('3.2');
+  });
+
+  it('Should resolve as 3.2 even if the provided spec contains spaces before version from a YAML input', function() {
+    const inputData = 'openapi :  \t"3.2.1"' +
+      'info:' +
+      '  title: 3.2 sample' +
+      '  version: 1.0.0' +
+      'paths:' +
+      '  /users:' +
+      '    get:' +
+      '      summary: List users',
+      specVersion = getSpecVersion({ type: stringType, data: inputData });
+    expect(specVersion).to.be.equal('3.2');
+  });
+
+  it('Should resolve as 3.2 the provided spec version from a JSON input', function() {
+    const inputData = {
+        'openapi': '3.2.0',
+        'info': {
+          'title': '3.2 sample',
+          'version': '1.0.0'
+        },
+        'paths': {
+          '/users': {
+            'get': { 'summary': 'List users' }
+          }
+        }
+      },
+      specVersion = getSpecVersion({ type: jsonType, data: inputData });
+    expect(specVersion).to.be.equal('3.2');
   });
 
   it('Should resolve as 3.1 even if the provided spec contain spaces before version from a YAML input', function() {
@@ -415,6 +462,46 @@ describe('filterOptionsByVersion method', function() {
     })).to.include.members(['optionA', 'optionB', 'optionD']);
   });
 
+  it('Should return the options supported in version 3.2', function() {
+    const optionsMock = [
+        {
+          id: 'optionA',
+          name: 'option A',
+          supportedIn: ['3.0'],
+          default: 'A default value for option A'
+        },
+        {
+          id: 'optionB',
+          name: 'option B',
+          supportedIn: ['3.1'],
+          default: 'A default value for option B'
+        },
+        {
+          id: 'optionC',
+          name: 'option C',
+          supportedIn: ['3.1', '3.2'],
+          default: 'A default value for option C'
+        },
+        {
+          id: 'optionD',
+          name: 'option D',
+          supportedIn: ['3.0', '3.1', '3.2'],
+          default: 'A default value for option D'
+        }
+      ],
+      optionsFiltered = filterOptionsByVersion(optionsMock, '3.2');
+    expect(optionsFiltered).to.be.an('array');
+    expect(optionsFiltered.map((option) => {
+      return option.id;
+    })).to.include.members(['optionC', 'optionD']);
+    expect(optionsFiltered.map((option) => {
+      return option.id;
+    })).to.not.include('optionA');
+    expect(optionsFiltered.map((option) => {
+      return option.id;
+    })).to.not.include('optionB');
+  });
+
   it('Should return the options supported in version 2.0', function() {
     const optionsMock = [
         {
@@ -495,6 +582,14 @@ describe('getVersionRegexBySpecificationVersion method', function () {
     const result = getVersionRegexBySpecificationVersion('3.1');
     expect(result.toString()).to.equal('/openapi[\'|\"]?\\s*:\\s*[\\]?[\'|\"]?3.1/');
   });
+  it('should return regex for 3.2', function () {
+    const result = getVersionRegexBySpecificationVersion('3.2');
+    expect(result.toString()).to.equal('/openapi[\'|\"]?\\s*:\\s*[\\]?[\'|\"]?3.2/');
+  });
+  it('should return regex for 3.2.0', function () {
+    const result = getVersionRegexBySpecificationVersion('3.2.0');
+    expect(result.toString()).to.equal('/openapi[\'|\"]?\\s*:\\s*[\\]?[\'|\"]?3.2/');
+  });
   it('should return regex for 2.0', function () {
     const result = getVersionRegexBySpecificationVersion('2.0');
     expect(result.toString()).to.equal('/swagger[\'|\"]?\\s*:\\s*[\\]?[\'|\"]?2.0/');
@@ -521,6 +616,16 @@ describe('validateSupportedVersion method', function () {
     expect(result).to.be.true;
   });
 
+  it('should return true with version 3.2', function () {
+    const result = validateSupportedVersion('3.2');
+    expect(result).to.be.true;
+  });
+
+  it('should return true with version 3.2.0', function () {
+    const result = validateSupportedVersion('3.2.0');
+    expect(result).to.be.true;
+  });
+
   it('should return false with version "any"', function () {
     const result = validateSupportedVersion('any');
     expect(result).to.be.false;
@@ -534,6 +639,26 @@ describe('validateSupportedVersion method', function () {
   it('should return false with version undefined', function () {
     const result = validateSupportedVersion();
     expect(result).to.be.false;
+  });
+});
+
+describe('getBundleRulesDataByVersion method', function () {
+  it('should return the 3.2 rules for a 3.2 version', function () {
+    expect(getBundleRulesDataByVersion('3.2')).to.equal(RULES_32);
+    expect(getBundleRulesDataByVersion('3.2.0')).to.equal(RULES_32);
+  });
+
+  it('should return the 3.1 rules for a 3.1 version', function () {
+    expect(getBundleRulesDataByVersion('3.1')).to.equal(RULES_31);
+  });
+
+  it('should return the 3.0 rules as the default', function () {
+    expect(getBundleRulesDataByVersion('3.0')).to.equal(RULES_30);
+  });
+
+  it('should expose pathItems as a referenceable component in 3.2', function () {
+    expect(RULES_32.COMPONENTS_KEYS).to.include('pathItems');
+    expect(RULES_32.DEFINITIONS).to.have.property('paths', 'pathItems');
   });
 });
 

--- a/test/unit/x32schemapack.test.js
+++ b/test/unit/x32schemapack.test.js
@@ -1,0 +1,105 @@
+const SchemaPack = require('../..').SchemaPack,
+  expect = require('chai').expect,
+  fs = require('fs'),
+  path = require('path'),
+  OPENAPI_32_FOLDER = '../data/valid_openapi32X';
+
+describe('Testing openapi 3.2 schema pack convert', function () {
+  it('Should detect a 3.2 document and report the 3.2.x specification version', function () {
+    const fileSource = path.join(__dirname, OPENAPI_32_FOLDER + '/json/petstore.json'),
+      fileData = fs.readFileSync(fileSource, 'utf8'),
+      converter = new SchemaPack({ type: 'string', data: fileData });
+
+    expect(converter.validated).to.be.true;
+    expect(converter.validationResult.specificationVersion).to.equal('3.2.x');
+  });
+
+  it('Should convert a 3.2 petstore (JSON) to a Postman collection', function (done) {
+    const fileSource = path.join(__dirname, OPENAPI_32_FOLDER + '/json/petstore.json'),
+      fileData = fs.readFileSync(fileSource, 'utf8'),
+      converter = new SchemaPack({ type: 'string', data: fileData });
+
+    converter.convert((err, result) => {
+      expect(err).to.be.null;
+      expect(result.result).to.be.true;
+      const collection = result.output[0].data;
+      expect(collection.info.name).to.equal('Swagger Petstore');
+      done();
+    });
+  });
+
+  it('Should convert a 3.2 petstore (YAML) to a Postman collection', function (done) {
+    const fileSource = path.join(__dirname, OPENAPI_32_FOLDER + '/yaml/petstore.yaml'),
+      fileData = fs.readFileSync(fileSource, 'utf8'),
+      converter = new SchemaPack({ type: 'string', data: fileData });
+
+    converter.convert((err, result) => {
+      expect(err).to.be.null;
+      expect(result.result).to.be.true;
+      done();
+    });
+  });
+
+  it('Should treat application/octet-stream with no schema as a binary body in 3.2', function (done) {
+    const fileSource = path.join(__dirname, OPENAPI_32_FOLDER + '/json/petstore.json'),
+      fileData = fs.readFileSync(fileSource, 'utf8'),
+      converter = new SchemaPack({ type: 'string', data: fileData });
+
+    converter.convert((err, result) => {
+      expect(err).to.be.null;
+      const uploads = result.output[0].data.item.find((item) => {
+        return item.name === 'uploads an image';
+      });
+      expect(uploads.request.body).to.deep.equal({ mode: 'file' });
+      done();
+    });
+  });
+
+  it('Should accept a 3.2 spec that only declares webhooks (no paths) when includeWebhooks is true', function (done) {
+    const fileSource = path.join(__dirname, OPENAPI_32_FOLDER + '/json/webhooks.json'),
+      fileData = fs.readFileSync(fileSource, 'utf8'),
+      converter = new SchemaPack({ type: 'string', data: fileData }, { includeWebhooks: true });
+
+    expect(converter.validated).to.be.true;
+    converter.convert((err, result) => {
+      expect(err).to.be.null;
+      expect(result.result).to.be.true;
+      const topLevelNames = result.output[0].data.item.map((item) => { return item.name; });
+      expect(topLevelNames).to.include('Webhooks');
+      done();
+    });
+  });
+
+  it('Should tolerate 3.2-only constructs (info.summary, tags.parent/kind, components.pathItems)', function (done) {
+    const fileSource = path.join(__dirname, OPENAPI_32_FOLDER + '/json/oas32-features.json'),
+      fileData = fs.readFileSync(fileSource, 'utf8'),
+      converter = new SchemaPack({ type: 'string', data: fileData });
+
+    converter.convert((err, result) => {
+      expect(err).to.be.null;
+      expect(result.result).to.be.true;
+      const collection = result.output[0].data;
+      expect(collection.info.name).to.equal('OAS 3.2 feature sampler');
+      const itemNames = collection.item.map((item) => { return item.name; });
+      expect(itemNames).to.include('List invoices');
+      done();
+    });
+  });
+
+  it('Should fall back to default error reason when a 3.2 spec is missing required info fields', function () {
+    const malformed = {
+        openapi: '3.2.0',
+        info: { title: 'No version' },
+        paths: {
+          '/users': {
+            get: { responses: { '200': { description: 'ok' } } }
+          }
+        }
+      },
+      converter = new SchemaPack({ type: 'json', data: malformed });
+
+    expect(converter.validated).to.be.false;
+    expect(converter.validationResult.reason)
+      .to.equal('Specification must contain a semantic version number of the API in the Info Object');
+  });
+});


### PR DESCRIPTION
## Overview

Add OpenAPI 3.2 support to the converter. `openapi-to-postmanv2` now detects, validates, bundles, and converts OAS 3.2 documents into Postman Collections instead of silently misclassifying them as 3.0.

## Why

`lib/common/versionUtils.js::getSpecVersion()` only matched `2.0` / `3.0` / `3.1`. Any document declaring `openapi: '3.2.x'` fell through to `DEFAULT_SPEC_VERSION = '3.0'` and got processed by `30XUtils/schemaUtils30X`, mis-handling 3.2-specific surfaces (`webhooks` carve-outs, `components`-only documents, JSON Schema 2020-12 dialect, sealed objects).

This is the **converter half** of a cross-repo OAS 3.2 rollout. Sibling work:

| Repo | PR | Status |
|------|----|--------|
| `@postman/openapi-parser` | _published_ | `1.4.0` ships OAS 3.2 (already on postman-app develop) |
| `postman-app` | [#40615](https://github.com/postman-eng/postman-app/pull/40615) | OAS 3.2 spec-type registration gated by `oas-3-2-spec` LD flag; collection generation **disabled** pending this PR |
| `sync-planner` | [#92](https://github.com/postman-eng/sync-planner/pull/92) | Merged — push-to-cloud detection |
| `api-specification-service` | [#436](https://github.com/postman-eng/api-specification-service/pull/436) | Cloud type registration; collection-generation pending this PR's downstream `@postman/collection-to-openapi` bump |

## What changed

OAS 3.2 is a structural superset of 3.1 (same JSON Schema dialect, same `webhooks`/`components` carve-outs already in 3.1), so the implementation is a **thin delegation layer over 31X** with its own version marker and bundle rules. New `32XUtils/` directory leaves a clean home for any future 3.2-only logic.

Three atomic commits:

| Commit | Subject |
|--------|---------|
| `2163b55` | `feat(32X): add OAS 3.2 schema utils, input validation and bundle rules` |
| `841712e` | `feat(version): detect and dispatch OAS 3.2 documents` |
| `1f84328` | `test(32X): add OAS 3.2 fixtures and unit tests mirroring 3.1 coverage` |

**Split rationale** — `2163b55` adds the new modules as dead code (reviewable in isolation as a 31X delegation + version-marker override). `841712e` is the small, focused diff that flips the switch in `versionUtils.js` and `options.js`; bisecting any future "3.2 broke X" report lands here. `1f84328` is the fixture + test payload, kept last so earlier commits stay reviewable without scrolling past ~1k lines of fixture JSON.

## How to test

- [x] `npm test` — **1705 passing**, 3 pending (47 new, zero regressions; baseline was 1658)
- [x] `npm run build` — clean
- [x] Lint clean on all changed files
- [x] Smoke: standalone `node` against the four fixture shapes (JSON petstore, YAML petstore, webhooks-only, 3.2-features sampler) all report `specificationVersion: '3.2.x'` and `convert.result: true`

```js
const { SchemaPack } = require('./lib');
const spec = require('fs').readFileSync('test/data/valid_openapi32X/json/petstore.json', 'utf8');
const sp = new SchemaPack({ type: 'string', data: spec });
sp.validate((err, ok) => console.log(ok)); // → { result: true, specificationVersion: '3.2.x' }
sp.convert((err, conv) => console.log(conv.result)); // → true
```

## Risk / rollout

- **Backwards compatible.** Dispatch for 2.0 / 3.0 / 3.1 is unchanged; 3.2 detection sits in front of the existing version arms. The `RULES_31` bundle rules are duplicated into `RULES_32` rather than mutated.
- **No new top-level dependencies.**
- **Public API surface unchanged.** `SchemaPack` constructor signature, `validate` / `convert` / `convertV2` / `convertV2WithTypes` / `mergeAndValidate` / `bundle` / `syncCollection` / `detectRootFiles` / `detectRelatedFiles` / `getOptions` / `getSyncOptions` all accept 3.2 documents now; nothing was renamed or removed.

## Out of scope — 3.2 features not yet actively modelled

The converter tolerates them (fixture `oas32-features.json` pins this), but doesn't currently produce richer collection output for:

- `tags.parent` — sub-tagged operations land flat in the parent's folder under the Tags folder strategy.
- `parameter.in: querystring` (new in 3.2) — converter ignores the parameter.
- `discriminator.defaultMapping` — no-op (same status as `discriminator.mapping` today).

These are follow-up enhancements, not blockers for the consumer rollout. Consumers gate everything behind a feature flag so early adopters who hit these are a known cohort.

## Downstream follow-ups after this lands

1. Publish a new `openapi-to-postmanv2` release, bump in postman-app root `package.json`.
2. postman-app: add `convert()` to `src/renderer/js/services/conversion/formats/openapi3_2.js` (mirror `openapi3_1.js`), flip `COLLECTION_GENERATION` / `COLLECTION_SYNCING` / `COLLECTION_SYNCING_OPTIONS` / `SPEC_SYNCING_FROM_COLLECTION` / `SDK_GENERATION` back to `() => true` for `OPENAPI:3.2`, flip `collectionGeneration: true` in both `ImportContainerV2.js` and `specImportFlow.ts`.
3. `@postman/collection-to-openapi` is the other shoe to drop — it owns the **collection→spec** direction (the inverse of this package) and is what `api-specification-service`'s `OpenAPI32Service.convertToSpecification` / `syncSpecification` will eventually call once it ships 3.2.

<details>
<summary>Files touched (20 files, +1272 / −35)</summary>

```
lib/32XUtils/schemaUtils32X.js                                  (new)
lib/32XUtils/inputValidation32X.js                              (new)
lib/bundleRules/spec32.js                                       (new)
lib/common/versionUtils.js                                      (modified)
lib/options.js                                                  (modified)
test/data/valid_openapi32X/json/petstore.json                   (new)
test/data/valid_openapi32X/json/webhooks.json                   (new)
test/data/valid_openapi32X/json/oas32-features.json             (new)
test/data/valid_openapi32X/yaml/petstore.yaml                   (new)
test/data/invalid_openapi32X/empty-spec.yaml                    (new)
test/data/invalid_openapi32X/invalid-no-info.json               (new)
test/data/invalid_openapi32X/invalid-null-info.json             (new)
test/data/invalid_openapi32X/invalid-info-no-title.json         (new)
test/data/invalid_openapi32X/invalid-info-null-title.json       (new)
test/data/invalid_openapi32X/invalid-info-no-version.json       (new)
test/data/invalid_openapi32X/invalid-info-null-version.json     (new)
test/unit/32Xsupport/inputValidation32X.test.js                 (new)
test/unit/32Xsupport/schemaUtils32X.test.js                     (new)
test/unit/x32schemapack.test.js                                 (new)
test/unit/versionUtils.test.js                                  (modified — added 3.2 cases + new getBundleRulesDataByVersion describe)
```

</details>
