### PR TITLE
[AB-2620] feature/added example key matching

### DIFF
--- a/libV2/CollectionGeneration/schemaUtils.js
+++ b/libV2/CollectionGeneration/schemaUtils.js
@@ -1466,7 +1466,6 @@ let QUERYPARAM = 'query',
     const pmExamples = [],
       responseExampleKeys = _.map(responseExamples, 'key'),
       requestBodyExampleKeys = _.map(requestBodyExamples, 'key'),
-      usedRequestExamples = _.fill(Array(requestBodyExamples.length), false),
       exampleKeyComparator = (example, key) => {
         return _.toLower(example.key) === _.toLower(key);
       };
@@ -1481,16 +1480,10 @@ let QUERYPARAM = 'query',
         (!_.isNil(responseExample.responseCode) ? String(responseExample.responseCode) : undefined);
     };
 
-    let matchedKeys = _.intersectionBy(responseExampleKeys, requestBodyExampleKeys, _.toLower),
+    // pair strictly by matching example key names between request and response
+    // examples. falls back to first-only if no matching keys are found.
+    const matchedKeys = _.intersectionBy(responseExampleKeys, requestBodyExampleKeys, _.toLower),
       isResponseCodeMatching = false;
-
-    // Only match in case of default response example matching with any request body example
-    if (!matchedKeys.length && responseExamples.length === 1 && responseExamples[0].key === '_default') {
-      const responseCodes = _.map(responseExamples, 'responseCode');
-
-      matchedKeys = _.intersectionBy(responseCodes, requestBodyExampleKeys, _.toLower);
-      isResponseCodeMatching = matchedKeys.length > 0;
-    }
 
     // Do keys matching first and ignore any leftover req/res body for which matching is not found
     if (matchedKeys.length) {
@@ -1530,67 +1523,33 @@ let QUERYPARAM = 'query',
       return pmExamples;
     }
 
-    // No key matching between req and res were found, so perform positional matching now
-    _.forEach(responseExamples, (responseExample, index) => {
+    // No matching keys were found between request and response examples.
+    // MVP scope (matching-key pairing only): fall back to the legacy behavior of using the
+    // first request example and the first response example. No positional matching is done.
+    const firstResponseExample = _.find(responseExamples, _.isObject);
 
-      if (!_.isObject(responseExample)) {
-        return;
-      }
-
-      let responseExampleData = getExampleData(context, { [responseExample.key]: responseExample.value }),
-        requestExample;
+    if (firstResponseExample) {
+      let firstResponseExampleData = getExampleData(context,
+        { [firstResponseExample.key]: firstResponseExample.value });
 
       if (isXMLExample) {
-        responseExampleData = getXMLExampleData(context, responseExampleData, responseBodySchema);
+        firstResponseExampleData = getXMLExampleData(context, firstResponseExampleData, responseBodySchema);
       }
 
-      if (_.isEmpty(requestBodyExamples)) {
-        pmExamples.push({
-          response: responseExampleData,
-          name: getResponseExampleName(responseExample) || 'Example'
-        });
-        return;
+      const firstExample = {
+        response: firstResponseExampleData,
+        name: getResponseExampleName(firstResponseExample) || 'Example'
+      };
+
+      const firstRequestExample = _.head(requestBodyExamples);
+
+      // Only attach a request body if the operation actually defines request examples
+      if (firstRequestExample) {
+        firstExample.request = getExampleData(context,
+          { [firstRequestExample.key]: firstRequestExample.value });
       }
 
-      if (requestBodyExamples[index] && !usedRequestExamples[index]) {
-        requestExample = requestBodyExamples[index];
-        usedRequestExamples[index] = true;
-      }
-      else {
-        requestExample = requestBodyExamples[0];
-      }
-
-      pmExamples.push({
-        request: getExampleData(context, { [requestExample.key]: requestExample.value }),
-        response: responseExampleData,
-        name: getResponseExampleName(responseExample) || 'Example'
-      });
-    });
-
-    let responseExample,
-      responseExampleData;
-
-    // Add any left over request body examples with first response body as matching
-    for (let i = 0; i < requestBodyExamples.length; i++) {
-
-      if (!usedRequestExamples[i] || pmExamples.length === 0) {
-        if (!responseExample) {
-          responseExample = _.head(responseExamples);
-
-          if (responseExample) {
-            responseExampleData = getExampleData(context, { [responseExample.key]: responseExample.value });
-          }
-
-          if (isXMLExample) {
-            responseExampleData = getXMLExampleData(context, responseExampleData, responseBodySchema);
-          }
-        }
-        pmExamples.push({
-          request: getExampleData(context, { [requestBodyExamples[i].key]: requestBodyExamples[i].value }),
-          response: responseExampleData,
-          name: getResponseExampleName(responseExample) || 'Example'
-        });
-      }
+      pmExamples.push(firstExample);
     }
 
     return pmExamples;
@@ -1783,15 +1742,15 @@ let QUERYPARAM = 'query',
       }];
 
       if (!_.isEmpty(examples)) {
-        // Only use the first example from the examples object
-        const firstExampleKey = Object.keys(examples)[0];
-        const firstExample = examples[firstExampleKey];
-
-        responseExamples = [{
-          key: firstExampleKey,
-          value: firstExample,
-          contentType: bodyType
-        }];
+        // Pass every named response example through; generateExamples decides how they
+        // pair with request examples (matching-key pairing, else first-only fallback).
+        responseExamples = _.map(Object.keys(examples), (exampleKey) => {
+          return {
+            key: exampleKey,
+            value: examples[exampleKey],
+            contentType: bodyType
+          };
+        });
       }
 
       let matchedRequestBodyExamples = _.filter(requestBodyExamples, ['contentType', bodyType]);
@@ -1799,11 +1758,6 @@ let QUERYPARAM = 'query',
       // If content-types are not matching, match with any present content-types
       if (_.isEmpty(matchedRequestBodyExamples)) {
         matchedRequestBodyExamples = requestBodyExamples;
-      }
-
-      // Only use the first request body example if multiple exist
-      if (matchedRequestBodyExamples.length > 1) {
-        matchedRequestBodyExamples = [matchedRequestBodyExamples[0]];
       }
 
       const generatedBody = generateExamples(
@@ -2681,10 +2635,9 @@ let QUERYPARAM = 'query',
 
         _.forEach(requestContent, (content, contentType) => {
           if (_.has(content, 'examples')) {
-            // Only use the first example from the examples object
-            const exampleKeys = Object.keys(content.examples);
-            if (exampleKeys.length > 0) {
-              const name = exampleKeys[0];
+            // Collect every request example so it can be paired with a response example
+            // by matching key (generateExamples). Non-matching ones fall back to first-only.
+            _.forEach(Object.keys(content.examples), (name) => {
               const example = content.examples[name];
               const exampleObj = example;
 
@@ -2704,7 +2657,7 @@ let QUERYPARAM = 'query',
                 key: name,
                 value: example
               });
-            }
+            });
           }
         });
       }
@@ -2737,9 +2690,13 @@ let QUERYPARAM = 'query',
 
       Object.assign(responseTypes, { [code || DEFAULT_RESPONSE_CODE_IN_OAS]: responseBodyHeaderObj });
 
-      // Only use the first example from resolvedExamples
-      const resolvedExample = resolvedExamples[0];
-      if (resolvedExample) {
+      // Emit one saved response per resolved example. With matching-key pairing there may be
+      // multiple examples for a single status code; without a match there is exactly one.
+      _.forEach(resolvedExamples, (resolvedExample) => {
+        if (!resolvedExample) {
+          return;
+        }
+
         let { body, contentHeader = [], bodyType, acceptHeader, name } = resolvedExample,
           resolvedRequestBody = _.get(resolvedExample, 'request.body'),
           originalRequest,
@@ -2781,11 +2738,13 @@ let QUERYPARAM = 'query',
           responseDescriptionTrimmed = _.isString(responseDescription) ? responseDescription.trim() : '',
           codeName = String(!_.isNil(code) ? code : DEFAULT_RESPONSE_CODE_IN_OAS);
 
-        // response-name priority:
+        // response-name priority (unchanged from legacy, including for matching-key multi-example):
         // 1) response-level description
-        // 2) example-level description/summary (already baked into `name` by generateExamples)
-        // 3) example key (already baked into `name` by generateExamples)
-        // 4) response code
+        // 2) example-level description/summary/key (baked into `name` by generateExamples)
+        // 3) response code
+        // The saved-response name maps back to the OAS response `description` during
+        // collection -> spec sync, so it MUST stay tied to the response description to keep
+        // two-way sync deterministic. Per-example identity is carried by the example key, not the name.
         name = responseDescriptionTrimmed || name || codeName;
 
         // set accept header value as first found response content's media type
@@ -2803,7 +2762,7 @@ let QUERYPARAM = 'query',
         };
 
         responses.push(response);
-      }
+      });
     });
     return {
       responses,

--- a/libV2/CollectionGeneration/schemaUtils.js
+++ b/libV2/CollectionGeneration/schemaUtils.js
@@ -1482,8 +1482,7 @@ let QUERYPARAM = 'query',
 
     // pair strictly by matching example key names between request and response
     // examples. falls back to first-only if no matching keys are found.
-    const matchedKeys = _.intersectionBy(responseExampleKeys, requestBodyExampleKeys, _.toLower),
-      isResponseCodeMatching = false;
+    const matchedKeys = _.intersectionBy(responseExampleKeys, requestBodyExampleKeys, _.toLower);
 
     // Do keys matching first and ignore any leftover req/res body for which matching is not found
     if (matchedKeys.length) {
@@ -1492,11 +1491,6 @@ let QUERYPARAM = 'query',
             return exampleKeyComparator(example, key);
           }),
           responseExample = _.find(responseExamples, (example) => {
-            // If there is a response code key-matching, then only match with keys based on response code
-            if (isResponseCodeMatching) {
-              return example.responseCode === key;
-            }
-
             return exampleKeyComparator(example, key);
           });
 

--- a/libV2/SpecificationCollectionSyncing/spec-to-collection/index.ts
+++ b/libV2/SpecificationCollectionSyncing/spec-to-collection/index.ts
@@ -96,13 +96,27 @@ export function syncCollection(
 
       const currentResponses: Record<number, Response> = {};
 
+      // Index existing responses by status code, keeping the FIRST occurrence per code so the
+      // request example maps to the first saved response of a code; the rest are left untouched.
       currentRequest.responses.each((response) => {
-        currentResponses[response.code] = response;
+        if (!currentResponses[response.code]) {
+          currentResponses[response.code] = response;
+        }
       });
+
+      // The spec has a single request example (the live body) that maps to the first saved response.
+      // Subsequent responses preserve their existing request body (see mergeResponseData) so a
+      // request change in the spec only updates the first response, not every response's originalRequest.
+      let isFirstSyncedResponse = true;
 
       item.responses.each((response) => {
         if (currentResponses[response.code]) {
-          const mergedResponseData = mergeResponseData(response, currentResponses[response.code], mergedOptions);
+          const mergedResponseData = mergeResponseData(
+            response,
+            currentResponses[response.code],
+            mergedOptions,
+            !isFirstSyncedResponse
+          );
 
           currentResponses[response.code].update(mergedResponseData);
 
@@ -131,6 +145,8 @@ export function syncCollection(
             }
           }
         }
+
+        isFirstSyncedResponse = false;
       });
     }
     else {

--- a/libV2/SpecificationCollectionSyncing/spec-to-collection/index.ts
+++ b/libV2/SpecificationCollectionSyncing/spec-to-collection/index.ts
@@ -94,42 +94,52 @@ export function syncCollection(
         currentRequest.request.authorizeUsing(authToApply.type, authToApply.params);
       }
 
-      const currentResponses: Record<number, Response> = {};
+      const currentResponsesByCode: Record<number, Response[]> = {};
 
-      // Index existing responses by status code, keeping the FIRST occurrence per code so the
-      // request example maps to the first saved response of a code; the rest are left untouched.
+      // Index existing responses by status code into a per-code queue, preserving order, so multiple
+      // saved responses sharing a status code each get their own slot instead of collapsing into one.
       currentRequest.responses.each((response) => {
-        if (!currentResponses[response.code]) {
-          currentResponses[response.code] = response;
+        if (!currentResponsesByCode[response.code]) {
+          currentResponsesByCode[response.code] = [];
         }
+
+        currentResponsesByCode[response.code].push(response);
       });
 
-      // The spec has a single request example (the live body) that maps to the first saved response.
-      // Subsequent responses preserve their existing request body (see mergeResponseData) so a
-      // request change in the spec only updates the first response, not every response's originalRequest.
+      // The spec carries a single request example (the live body). It is applied to the originalRequest
+      // of only the first response processed overall (isFirstSyncedResponse); every subsequent response
+      // preserves its existing originalRequest body (see mergeResponseData), so a request change in the
+      // spec updates just that first response rather than every response's originalRequest.
       let isFirstSyncedResponse = true;
 
       item.responses.each((response) => {
-        if (currentResponses[response.code]) {
+        // Pair each incoming response with the next unconsumed existing response of the same code.
+        // This is positional pairing used as a fallback: Postman saved responses don't carry a stable
+        // identity back from the spec example (same-code responses can even share a name), so we can't
+        // reliably key the match. Order is the best deterministic mapping for the generate -> edit -> sync
+        // round-trip. Extra incoming examples are added; surplus existing responses are left untouched.
+        const matchingResponse = currentResponsesByCode[response.code]?.shift();
+
+        if (matchingResponse) {
           const mergedResponseData = mergeResponseData(
             response,
-            currentResponses[response.code],
+            matchingResponse,
             mergedOptions,
             !isFirstSyncedResponse
           );
 
-          currentResponses[response.code].update(mergedResponseData);
+          matchingResponse.update(mergedResponseData);
 
           // SDK converts _postman_previewlanguage to { _: { postman_previewlanguage: '' } }
           // during response construction.
           const previewLanguage = (response as any)._postman_previewlanguage ??
             (response as any)._?.postman_previewlanguage;
-          (currentResponses[response.code] as any)._postman_previewlanguage = previewLanguage;
-          if ((currentResponses[response.code] as any)._?.postman_previewlanguage !== undefined) {
-            delete (currentResponses[response.code] as any)._.postman_previewlanguage;
+          (matchingResponse as any)._postman_previewlanguage = previewLanguage;
+          if ((matchingResponse as any)._?.postman_previewlanguage !== undefined) {
+            delete (matchingResponse as any)._.postman_previewlanguage;
           }
 
-          currentResponses[response.code].name = response.name;
+          matchingResponse.name = response.name;
         }
         else {
           currentRequest.responses.add(response.toJSON());

--- a/libV2/SpecificationCollectionSyncing/spec-to-collection/merge/ResponseMerger.ts
+++ b/libV2/SpecificationCollectionSyncing/spec-to-collection/merge/ResponseMerger.ts
@@ -39,9 +39,10 @@ export function mergeResponseData(
      * editing the request in the spec doesn't overwrite every response's originalRequest on sync-back.
      * Only applies when example syncing is enabled (the multi-example flow).
      */
-    if (preserveOriginalRequestBody && shouldSyncExamples && sourceRes.originalRequest.body !== undefined) {
-      targetRes.originalRequest.body = sourceRes.originalRequest.body;
-    }
+if (preserveOriginalRequestBody && shouldSyncExamples) {
+  if (sourceRes.originalRequest.body === undefined) { delete targetRes.originalRequest.body; }
+  else { targetRes.originalRequest.body = sourceRes.originalRequest.body; }
+}
   }
   // Attach implicit headers from the source response to the target response
   // if they are not present in the target response

--- a/libV2/SpecificationCollectionSyncing/spec-to-collection/merge/ResponseMerger.ts
+++ b/libV2/SpecificationCollectionSyncing/spec-to-collection/merge/ResponseMerger.ts
@@ -13,26 +13,41 @@ import { attachImplicitHeaders } from '../header';
  * @param {Response} targetResponse - Response from the target request
  * @param {Response } sourceResponse - Response from the source request
  * @param {SyncOptions} syncOptions - Options to control what should be synced
+ * @param {boolean} preserveOriginalRequestBody - When true (and example syncing is enabled), keep
+ *   the existing response's `originalRequest.body` instead of overwriting it with the spec's request.
+ *   The spec carries a single request example (the live body) that maps to the first saved response;
+ *   set this for every response after the first so a request change in the spec doesn't overwrite
+ *   every response's originalRequest. Defaults to false (first response takes the spec request).
  * @returns {ResponseDefinition} Merged response definition
  */
 export function mergeResponseData(
   targetResponse: Response,
   sourceResponse: Response,
-  syncOptions: SyncOptions
+  syncOptions: SyncOptions,
+  preserveOriginalRequestBody = false
 ): ResponseDefinition {
   const targetRes: ResponseDefinition = targetResponse.toJSON(),
-    sourceRes: ResponseDefinition = sourceResponse.toJSON();
+    sourceRes: ResponseDefinition = sourceResponse.toJSON(),
+    shouldSyncExamples = syncOptions?.syncExamples;
 
   if (targetRes?.originalRequest && sourceRes?.originalRequest) {
     targetRes.originalRequest = mergeRequestData(targetRes.originalRequest, sourceRes.originalRequest, syncOptions);
+
+    /*
+     * The spec carries a single request example (the live request body), which maps to the first
+     * saved response. For the remaining responses, preserve their existing request body so that
+     * editing the request in the spec doesn't overwrite every response's originalRequest on sync-back.
+     * Only applies when example syncing is enabled (the multi-example flow).
+     */
+    if (preserveOriginalRequestBody && shouldSyncExamples && sourceRes.originalRequest.body !== undefined) {
+      targetRes.originalRequest.body = sourceRes.originalRequest.body;
+    }
   }
   // Attach implicit headers from the source response to the target response
   // if they are not present in the target response
   // Required because the response body and implicit headers are not generated
   // during collection to spec conversion for non json responses.
   attachImplicitHeaders(sourceRes.header, targetRes.header);
-
-  const shouldSyncExamples = syncOptions?.syncExamples;
 
   if (targetRes?.header) {
     targetRes.header = shouldSyncExamples ?

--- a/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI3/index.js
+++ b/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI3/index.js
@@ -27,6 +27,8 @@ module.exports = {
     require('./shouldAttachImplicitHeadersIfNotPresentInLatestCollection'),
   shouldSyncExamplesWhenSyncExamplesIsTrue: require('./shouldSyncExamplesWhenSyncExamplesIsTrue'),
   shouldNotSyncExamplesWhenSyncExamplesIsFalse: require('./shouldNotSyncExamplesWhenSyncExamplesIsFalse'),
+  shouldSyncRequestToFirstResponseOnly: require('./shouldSyncRequestToFirstResponseOnly'),
+  shouldPreserveOtherSameCodeResponsesOnRequestSync: require('./shouldPreserveOtherSameCodeResponsesOnRequestSync'),
   // Multi-file specification test cases
   multiFileSpecs: require('./multiFileSpecs')
 };

--- a/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI3/index.js
+++ b/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI3/index.js
@@ -29,6 +29,7 @@ module.exports = {
   shouldNotSyncExamplesWhenSyncExamplesIsFalse: require('./shouldNotSyncExamplesWhenSyncExamplesIsFalse'),
   shouldSyncRequestToFirstResponseOnly: require('./shouldSyncRequestToFirstResponseOnly'),
   shouldPreserveOtherSameCodeResponsesOnRequestSync: require('./shouldPreserveOtherSameCodeResponsesOnRequestSync'),
+  shouldPairSameCodeExamplesPositionallyOnSync: require('./shouldPairSameCodeExamplesPositionallyOnSync'),
   // Multi-file specification test cases
   multiFileSpecs: require('./multiFileSpecs')
 };

--- a/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI3/shouldPairSameCodeExamplesPositionallyOnSync.js
+++ b/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI3/shouldPairSameCodeExamplesPositionallyOnSync.js
@@ -1,0 +1,231 @@
+/*
+  Regression test for the same-code response "collapse" bug.
+
+  When a spec has multiple examples under one status code (here two `200` examples, `admin` and `user`),
+  generation produces two saved responses sharing code 200. Previously the spec -> collection sync indexed
+  existing responses by status code into a SINGLE slot, so both incoming responses merged into the first
+  saved response (last-wins): `admin`'s edit was lost and the second saved response went stale.
+
+  With per-code positional pairing, each incoming response maps to its own saved response, so editing both
+  `200` examples in the spec correctly updates both saved responses.
+*/
+const spec = {
+  openapi: '3.0.0',
+  info: {
+    title: 'Collapse Repro',
+    version: '1.0.0'
+  },
+  servers: [
+    {
+      url: 'https://api.example.com'
+    }
+  ],
+  paths: {
+    '/users': {
+      post: {
+        summary: 'List users',
+        requestBody: {
+          content: {
+            'application/json': {
+              examples: {
+                admin: { value: { q: 'admin' } },
+                user: { value: { q: 'user' } }
+              }
+            }
+          }
+        },
+        responses: {
+          200: {
+            description: 'OK',
+            content: {
+              'application/json': {
+                examples: {
+                  admin: { value: { role: 'ADMIN-EDITED' } },
+                  user: { value: { role: 'USER-EDITED' } }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+// Same spec shape but with the original (pre-edit) response example values.
+const initialSpec = JSON.parse(JSON.stringify(spec));
+
+initialSpec.paths['/users'].post.responses[200].content['application/json'].examples.admin.value.role = 'old-admin';
+initialSpec.paths['/users'].post.responses[200].content['application/json'].examples.user.value.role = 'old-user';
+
+module.exports = {
+  name: 'should pair multiple same-code response examples positionally instead of collapsing them on sync',
+  specificationType: 'OPENAPI:3.0',
+  generationOptions: {
+    parametersResolution: 'Example'
+  },
+  syncOptions: {
+    syncExamples: true
+  },
+  shouldGenerateCollection: false,
+  initialState: {
+    spec: initialSpec,
+    collection: {
+      info: {
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: 'users',
+          item: [
+            {
+              name: 'List users',
+              request: {
+                method: 'POST',
+                header: [
+                  { key: 'Content-Type', value: 'application/json' },
+                  { key: 'Accept', value: 'application/json' }
+                ],
+                body: {
+                  mode: 'raw',
+                  raw: '{\n  "q": "admin"\n}',
+                  options: { raw: { headerFamily: 'json', language: 'json' } }
+                },
+                url: { raw: '{{baseUrl}}/users', host: ['{{baseUrl}}'], path: ['users'] }
+              },
+              response: [
+                {
+                  name: 'OK',
+                  originalRequest: {
+                    method: 'POST',
+                    header: [
+                      { key: 'Content-Type', value: 'application/json' },
+                      { key: 'Accept', value: 'application/json' }
+                    ],
+                    body: {
+                      mode: 'raw',
+                      raw: '{\n  "q": "admin"\n}',
+                      options: { raw: { headerFamily: 'json', language: 'json' } }
+                    },
+                    url: { raw: '{{baseUrl}}/users', host: ['{{baseUrl}}'], path: ['users'] }
+                  },
+                  status: 'OK',
+                  code: 200,
+                  _postman_previewlanguage: 'json',
+                  _postman_previewtype: 'html',
+                  header: [{ key: 'Content-Type', value: 'application/json' }],
+                  cookie: [],
+                  body: '{\n  "role": "old-admin"\n}'
+                },
+                {
+                  name: 'OK',
+                  originalRequest: {
+                    method: 'POST',
+                    header: [
+                      { key: 'Content-Type', value: 'application/json' },
+                      { key: 'Accept', value: 'application/json' }
+                    ],
+                    body: {
+                      mode: 'raw',
+                      raw: '{\n  "q": "user"\n}',
+                      options: { raw: { headerFamily: 'json', language: 'json' } }
+                    },
+                    url: { raw: '{{baseUrl}}/users', host: ['{{baseUrl}}'], path: ['users'] }
+                  },
+                  status: 'OK',
+                  code: 200,
+                  _postman_previewlanguage: 'json',
+                  _postman_previewtype: 'html',
+                  header: [{ key: 'Content-Type', value: 'application/json' }],
+                  cookie: [],
+                  body: '{\n  "role": "old-user"\n}'
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      variable: [{ key: 'baseUrl', value: 'https://api.example.com', type: 'any' }]
+    }
+  },
+  finalState: {
+    spec,
+    collection: {
+      info: {
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: 'users',
+          item: [
+            {
+              name: 'List users',
+              request: {
+                method: 'POST',
+                header: [
+                  { key: 'Content-Type', value: 'application/json' },
+                  { key: 'Accept', value: 'application/json' }
+                ],
+                body: {
+                  mode: 'raw',
+                  raw: '{\n  "q": "admin"\n}',
+                  options: { raw: { headerFamily: 'json', language: 'json' } }
+                },
+                url: { raw: '{{baseUrl}}/users', host: ['{{baseUrl}}'], path: ['users'] }
+              },
+              response: [
+                {
+                  name: 'OK',
+                  originalRequest: {
+                    method: 'POST',
+                    header: [
+                      { key: 'Content-Type', value: 'application/json' },
+                      { key: 'Accept', value: 'application/json' }
+                    ],
+                    body: {
+                      mode: 'raw',
+                      raw: '{\n  "q": "admin"\n}',
+                      options: { raw: { headerFamily: 'json', language: 'json' } }
+                    },
+                    url: { raw: '{{baseUrl}}/users', host: ['{{baseUrl}}'], path: ['users'] }
+                  },
+                  status: 'OK',
+                  code: 200,
+                  _postman_previewlanguage: 'json',
+                  _postman_previewtype: 'html',
+                  header: [{ key: 'Content-Type', value: 'application/json' }],
+                  cookie: [],
+                  body: '{\n  "role": "ADMIN-EDITED"\n}'
+                },
+                {
+                  name: 'OK',
+                  originalRequest: {
+                    method: 'POST',
+                    header: [
+                      { key: 'Content-Type', value: 'application/json' },
+                      { key: 'Accept', value: 'application/json' }
+                    ],
+                    body: {
+                      mode: 'raw',
+                      raw: '{\n  "q": "user"\n}',
+                      options: { raw: { headerFamily: 'json', language: 'json' } }
+                    },
+                    url: { raw: '{{baseUrl}}/users', host: ['{{baseUrl}}'], path: ['users'] }
+                  },
+                  status: 'OK',
+                  code: 200,
+                  _postman_previewlanguage: 'json',
+                  _postman_previewtype: 'html',
+                  header: [{ key: 'Content-Type', value: 'application/json' }],
+                  cookie: [],
+                  body: '{\n  "role": "USER-EDITED"\n}'
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      variable: [{ key: 'baseUrl', value: 'https://api.example.com', type: 'any' }]
+    }
+  }
+};

--- a/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI3/shouldPreserveOtherSameCodeResponsesOnRequestSync.js
+++ b/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI3/shouldPreserveOtherSameCodeResponsesOnRequestSync.js
@@ -1,0 +1,454 @@
+module.exports = {
+  name: 'should map the request to the first same-code response and preserve the other same-code responses on sync',
+  specificationType: 'OPENAPI:3.0',
+  generationOptions: {
+    parametersResolution: 'Example'
+  },
+  syncOptions: {
+    syncExamples: true
+  },
+  shouldGenerateCollection: false,
+  initialState: {
+    spec: {
+      openapi: '3.0.0',
+      info: {
+        title: 'SyncOptions Test API',
+        version: '1.0.0'
+      },
+      servers: [
+        {
+          url: 'https://api.example.com'
+        }
+      ],
+      paths: {
+        '/users/{id}': {
+          post: {
+            summary: 'Get user by ID',
+            parameters: [
+              {
+                name: 'id',
+                in: 'path',
+                required: true,
+                schema: {
+                  type: 'string'
+                },
+                example: 'user123'
+              }
+            ],
+            requestBody: {
+              content: {
+                'application/json': {
+                  example: {
+                    requestId: 'req-1',
+                    info: 'Initial request body example'
+                  }
+                }
+              }
+            },
+            responses: {
+              200: {
+                description: 'User found',
+                content: {
+                  'application/json': {
+                    example: {
+                      id: 'user123',
+                      name: 'John Doe'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    collection: {
+      info: {
+        _postman_id: '44bed90c-e3f1-45c6-a908-3fdcee92ff8f',
+        name: 'Sync options test',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: 'users',
+          item: [
+            {
+              name: '{id}',
+              item: [
+                {
+                  name: 'Get user by ID',
+                  id: 'dfba2353-7788-4cb2-8a41-06af5416cdbe',
+                  protocolProfileBehavior: {
+                    disableBodyPruning: true
+                  },
+                  request: {
+                    method: 'POST',
+                    header: [
+                      {
+                        key: 'Accept',
+                        value: 'application/json'
+                      }
+                    ],
+                    url: {
+                      raw: '{{baseUrl}}/users/:id',
+                      host: ['{{baseUrl}}'],
+                      path: ['users', ':id'],
+                      variable: [
+                        {
+                          id: '47d45f58-fbf2-40f3-9fa0-85af03d5f87b',
+                          key: 'id',
+                          value: 'user123'
+                        }
+                      ]
+                    },
+                    body: {
+                      mode: 'raw',
+                      raw: '{\n  "requestId": "req-1",\n  "info": "Initial request body example"\n}',
+                      options: {
+                        raw: {
+                          headerFamily: 'json',
+                          language: 'json'
+                        }
+                      }
+                    }
+                  },
+                  response: [
+                    {
+                      id: '4244ec56-8671-4a75-b839-6ea1822e60df',
+                      name: 'User found',
+                      originalRequest: {
+                        method: 'POST',
+                        header: [
+                          {
+                            key: 'Accept',
+                            value: 'application/json'
+                          }
+                        ],
+                        url: {
+                          raw: '{{baseUrl}}/users/:id',
+                          host: ['{{baseUrl}}'],
+                          path: ['users', ':id'],
+                          variable: [
+                            {
+                              key: 'id',
+                              value: 'user123'
+                            }
+                          ]
+                        },
+                        body: {
+                          mode: 'raw',
+                          raw: '{\n  "requestId": "req-A",\n  "info": "First 200 request"\n}',
+                          options: {
+                            raw: {
+                              headerFamily: 'json',
+                              language: 'json'
+                            }
+                          }
+                        }
+                      },
+                      status: 'OK',
+                      code: 200,
+                      _postman_previewlanguage: 'json',
+                      header: [
+                        {
+                          key: 'Content-Type',
+                          value: 'application/json'
+                        }
+                      ],
+                      cookie: [],
+                      responseTime: null,
+                      body: '{\n  "id": "user123",\n  "name": "John Doe"\n}'
+                    },
+                    {
+                      id: '5b3a1d2e-1111-4a75-b839-6ea1822e9999',
+                      name: 'Cached user',
+                      originalRequest: {
+                        method: 'POST',
+                        header: [
+                          {
+                            key: 'Accept',
+                            value: 'application/json'
+                          }
+                        ],
+                        url: {
+                          raw: '{{baseUrl}}/users/:id',
+                          host: ['{{baseUrl}}'],
+                          path: ['users', ':id'],
+                          variable: [
+                            {
+                              key: 'id',
+                              value: 'user123'
+                            }
+                          ]
+                        },
+                        body: {
+                          mode: 'raw',
+                          raw: '{\n  "requestId": "req-B",\n  "info": "Second 200 request"\n}',
+                          options: {
+                            raw: {
+                              headerFamily: 'json',
+                              language: 'json'
+                            }
+                          }
+                        }
+                      },
+                      status: 'OK',
+                      code: 200,
+                      _postman_previewlanguage: 'json',
+                      header: [
+                        {
+                          key: 'Content-Type',
+                          value: 'application/json'
+                        }
+                      ],
+                      cookie: [],
+                      responseTime: null,
+                      body: '{\n  "id": "user999",\n  "name": "Cached User"\n}'
+                    }
+                  ]
+                }
+              ],
+              id: 'b3cf64c3-2f5c-4775-903c-d76e6e07ee2e'
+            }
+          ],
+          id: 'e4f4c657-d786-4660-9217-8257866dd9b3'
+        }
+      ],
+      variable: [
+        {
+          key: 'baseUrl',
+          value: 'https://api.example.com'
+        }
+      ]
+    }
+  },
+  finalState: {
+    spec: {
+      openapi: '3.0.0',
+      info: {
+        title: 'SyncOptions Test API',
+        version: '1.0.0'
+      },
+      servers: [
+        {
+          url: 'https://api.example.com'
+        }
+      ],
+      paths: {
+        '/users/{id}': {
+          post: {
+            summary: 'Get user by ID',
+            parameters: [
+              {
+                name: 'id',
+                in: 'path',
+                required: true,
+                schema: {
+                  type: 'string'
+                },
+                example: 'user123'
+              }
+            ],
+            requestBody: {
+              content: {
+                'application/json': {
+                  example: {
+                    requestId: 'req-2',
+                    info: 'final request body example'
+                  }
+                }
+              }
+            },
+            responses: {
+              200: {
+                description: 'User found',
+                content: {
+                  'application/json': {
+                    example: {
+                      id: 'user123',
+                      name: 'John Doe'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    collection: {
+      info: {
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: 'users',
+          item: [
+            {
+              name: '{id}',
+              item: [
+                {
+                  name: 'Get user by ID',
+                  event: undefined,
+                  request: {
+                    auth: undefined,
+                    method: 'POST',
+                    header: [
+                      {
+                        key: 'Content-Type',
+                        value: 'application/json'
+                      },
+                      {
+                        key: 'Accept',
+                        value: 'application/json'
+                      }
+                    ],
+                    body: {
+                      mode: 'raw',
+                      raw: '{\n  "requestId": "req-2",\n  "info": "final request body example"\n}',
+                      options: {
+                        raw: {
+                          headerFamily: 'json',
+                          language: 'json'
+                        }
+                      }
+                    },
+                    url: {
+                      raw: '{{baseUrl}}/users/:id',
+                      protocol: undefined,
+                      auth: undefined,
+                      host: ['{{baseUrl}}'],
+                      port: undefined,
+                      path: ['users', ':id'],
+                      query: undefined,
+                      hash: undefined,
+                      variable: [
+                        {
+                          key: 'id',
+                          value: 'user123'
+                        }
+                      ]
+                    }
+                  },
+                  response: [
+                    {
+                      name: 'User found',
+                      originalRequest: {
+                        auth: undefined,
+                        method: 'POST',
+                        header: [
+                          {
+                            key: 'Content-Type',
+                            value: 'application/json'
+                          },
+                          {
+                            key: 'Accept',
+                            value: 'application/json'
+                          }
+                        ],
+                        body: {
+                          mode: 'raw',
+                          raw: '{\n  "requestId": "req-2",\n  "info": "final request body example"\n}',
+                          options: {
+                            raw: {
+                              headerFamily: 'json',
+                              language: 'json'
+                            }
+                          }
+                        },
+                        url: {
+                          raw: '{{baseUrl}}/users/:id',
+                          protocol: undefined,
+                          auth: undefined,
+                          host: ['{{baseUrl}}'],
+                          port: undefined,
+                          path: ['users', ':id'],
+                          query: undefined,
+                          hash: undefined,
+                          variable: [
+                            {
+                              key: 'id',
+                              value: 'user123'
+                            }
+                          ]
+                        }
+                      },
+                      status: 'OK',
+                      code: 200,
+                      _postman_previewlanguage: 'json',
+                      _postman_previewtype: 'html',
+                      header: [
+                        {
+                          key: 'Content-Type',
+                          value: 'application/json'
+                        }
+                      ],
+                      cookie: [],
+                      responseTime: null,
+                      body: `{
+  "id": "user123",
+  "name": "John Doe"
+}`
+                    },
+                    {
+                      name: 'Cached user',
+                      originalRequest: {
+                        method: 'POST',
+                        header: [
+                          {
+                            key: 'Accept',
+                            value: 'application/json'
+                          }
+                        ],
+                        url: {
+                          raw: '{{baseUrl}}/users/:id',
+                          host: ['{{baseUrl}}'],
+                          path: ['users', ':id'],
+                          variable: [
+                            {
+                              key: 'id',
+                              value: 'user123'
+                            }
+                          ]
+                        },
+                        body: {
+                          mode: 'raw',
+                          raw: '{\n  "requestId": "req-B",\n  "info": "Second 200 request"\n}',
+                          options: {
+                            raw: {
+                              headerFamily: 'json',
+                              language: 'json'
+                            }
+                          }
+                        }
+                      },
+                      status: 'OK',
+                      code: 200,
+                      _postman_previewlanguage: 'json',
+                      header: [
+                        {
+                          key: 'Content-Type',
+                          value: 'application/json'
+                        }
+                      ],
+                      cookie: [],
+                      responseTime: null,
+                      body: '{\n  "id": "user999",\n  "name": "Cached User"\n}'
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      variable: [
+        {
+          key: 'baseUrl',
+          value: 'https://api.example.com',
+          type: 'any'
+        }
+      ]
+    }
+  }
+};

--- a/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI3/shouldSyncRequestToFirstResponseOnly.js
+++ b/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI3/shouldSyncRequestToFirstResponseOnly.js
@@ -1,0 +1,487 @@
+module.exports = {
+  name: 'should sync the request body to the first response only and preserve other responses originalRequest',
+  specificationType: 'OPENAPI:3.0',
+  generationOptions: {
+    parametersResolution: 'Example'
+  },
+  syncOptions: {
+    syncExamples: true
+  },
+  shouldGenerateCollection: false,
+  initialState: {
+    spec: {
+      openapi: '3.0.0',
+      info: {
+        title: 'SyncOptions Test API',
+        version: '1.0.0'
+      },
+      servers: [
+        {
+          url: 'https://api.example.com'
+        }
+      ],
+      paths: {
+        '/users/{id}': {
+          post: {
+            summary: 'Get user by ID',
+            parameters: [
+              {
+                name: 'id',
+                in: 'path',
+                required: true,
+                schema: {
+                  type: 'string'
+                },
+                example: 'user123'
+              }
+            ],
+            requestBody: {
+              content: {
+                'application/json': {
+                  example: {
+                    requestId: 'req-1',
+                    info: 'Initial request body example'
+                  }
+                }
+              }
+            },
+            responses: {
+              200: {
+                description: 'User found',
+                content: {
+                  'application/json': {
+                    example: {
+                      id: 'user123',
+                      name: 'John Doe'
+                    }
+                  }
+                }
+              },
+              400: {
+                description: 'Bad request',
+                content: {
+                  'application/json': {
+                    example: {
+                      error: 'invalid'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    collection: {
+      info: {
+        _postman_id: '44bed90c-e3f1-45c6-a908-3fdcee92ff8f',
+        name: 'Sync options test',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: 'users',
+          item: [
+            {
+              name: '{id}',
+              item: [
+                {
+                  name: 'Get user by ID',
+                  id: 'dfba2353-7788-4cb2-8a41-06af5416cdbe',
+                  protocolProfileBehavior: {
+                    disableBodyPruning: true
+                  },
+                  request: {
+                    method: 'POST',
+                    header: [
+                      {
+                        key: 'Accept',
+                        value: 'application/json'
+                      }
+                    ],
+                    url: {
+                      raw: '{{baseUrl}}/users/:id',
+                      host: ['{{baseUrl}}'],
+                      path: ['users', ':id'],
+                      variable: [
+                        {
+                          id: '47d45f58-fbf2-40f3-9fa0-85af03d5f87b',
+                          key: 'id',
+                          value: 'user123'
+                        }
+                      ]
+                    },
+                    body: {
+                      mode: 'raw',
+                      raw: '{\n  "requestId": "req-1",\n  "info": "Initial request body example"\n}',
+                      options: {
+                        raw: {
+                          headerFamily: 'json',
+                          language: 'json'
+                        }
+                      }
+                    }
+                  },
+                  response: [
+                    {
+                      id: '4244ec56-8671-4a75-b839-6ea1822e60df',
+                      name: 'User found',
+                      originalRequest: {
+                        method: 'POST',
+                        header: [
+                          {
+                            key: 'Accept',
+                            value: 'application/json'
+                          }
+                        ],
+                        url: {
+                          raw: '{{baseUrl}}/users/:id',
+                          host: ['{{baseUrl}}'],
+                          path: ['users', ':id'],
+                          variable: [
+                            {
+                              key: 'id',
+                              value: 'user123'
+                            }
+                          ]
+                        },
+                        body: {
+                          mode: 'raw',
+                          raw: '{\n  "requestId": "req-1",\n  "info": "Initial request body example"\n}',
+                          options: {
+                            raw: {
+                              headerFamily: 'json',
+                              language: 'json'
+                            }
+                          }
+                        }
+                      },
+                      status: 'OK',
+                      code: 200,
+                      _postman_previewlanguage: 'json',
+                      header: [
+                        {
+                          key: 'Content-Type',
+                          value: 'application/json'
+                        }
+                      ],
+                      cookie: [],
+                      responseTime: null,
+                      body: '{\n  "id": "user123",\n  "name": "John Doe"\n}'
+                    },
+                    {
+                      id: '5b3a1d2e-1111-4a75-b839-6ea1822e9999',
+                      name: 'Bad request',
+                      originalRequest: {
+                        method: 'POST',
+                        header: [
+                          {
+                            key: 'Accept',
+                            value: 'application/json'
+                          }
+                        ],
+                        url: {
+                          raw: '{{baseUrl}}/users/:id',
+                          host: ['{{baseUrl}}'],
+                          path: ['users', ':id'],
+                          variable: [
+                            {
+                              key: 'id',
+                              value: 'user123'
+                            }
+                          ]
+                        },
+                        body: {
+                          mode: 'raw',
+                          raw: '{\n  "requestId": "req-400",\n  "info": "Bad request specific body"\n}',
+                          options: {
+                            raw: {
+                              headerFamily: 'json',
+                              language: 'json'
+                            }
+                          }
+                        }
+                      },
+                      status: 'Bad Request',
+                      code: 400,
+                      _postman_previewlanguage: 'json',
+                      header: [
+                        {
+                          key: 'Content-Type',
+                          value: 'application/json'
+                        }
+                      ],
+                      cookie: [],
+                      responseTime: null,
+                      body: '{\n  "error": "invalid"\n}'
+                    }
+                  ]
+                }
+              ],
+              id: 'b3cf64c3-2f5c-4775-903c-d76e6e07ee2e'
+            }
+          ],
+          id: 'e4f4c657-d786-4660-9217-8257866dd9b3'
+        }
+      ],
+      variable: [
+        {
+          key: 'baseUrl',
+          value: 'https://api.example.com'
+        }
+      ]
+    }
+  },
+  finalState: {
+    spec: {
+      openapi: '3.0.0',
+      info: {
+        title: 'SyncOptions Test API',
+        version: '1.0.0'
+      },
+      servers: [
+        {
+          url: 'https://api.example.com'
+        }
+      ],
+      paths: {
+        '/users/{id}': {
+          post: {
+            summary: 'Get user by ID',
+            parameters: [
+              {
+                name: 'id',
+                in: 'path',
+                required: true,
+                schema: {
+                  type: 'string'
+                },
+                example: 'user123'
+              }
+            ],
+            requestBody: {
+              content: {
+                'application/json': {
+                  example: {
+                    requestId: 'req-2',
+                    info: 'final request body example'
+                  }
+                }
+              }
+            },
+            responses: {
+              200: {
+                description: 'User found',
+                content: {
+                  'application/json': {
+                    example: {
+                      id: 'user123',
+                      name: 'John Doe'
+                    }
+                  }
+                }
+              },
+              400: {
+                description: 'Bad request',
+                content: {
+                  'application/json': {
+                    example: {
+                      error: 'invalid'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    collection: {
+      info: {
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      item: [
+        {
+          name: 'users',
+          item: [
+            {
+              name: '{id}',
+              item: [
+                {
+                  name: 'Get user by ID',
+                  event: undefined,
+                  request: {
+                    auth: undefined,
+                    method: 'POST',
+                    header: [
+                      {
+                        key: 'Content-Type',
+                        value: 'application/json'
+                      },
+                      {
+                        key: 'Accept',
+                        value: 'application/json'
+                      }
+                    ],
+                    body: {
+                      mode: 'raw',
+                      raw: '{\n  "requestId": "req-2",\n  "info": "final request body example"\n}',
+                      options: {
+                        raw: {
+                          headerFamily: 'json',
+                          language: 'json'
+                        }
+                      }
+                    },
+                    url: {
+                      raw: '{{baseUrl}}/users/:id',
+                      protocol: undefined,
+                      auth: undefined,
+                      host: ['{{baseUrl}}'],
+                      port: undefined,
+                      path: ['users', ':id'],
+                      query: undefined,
+                      hash: undefined,
+                      variable: [
+                        {
+                          key: 'id',
+                          value: 'user123'
+                        }
+                      ]
+                    }
+                  },
+                  response: [
+                    {
+                      name: 'User found',
+                      originalRequest: {
+                        auth: undefined,
+                        method: 'POST',
+                        header: [
+                          {
+                            key: 'Content-Type',
+                            value: 'application/json'
+                          },
+                          {
+                            key: 'Accept',
+                            value: 'application/json'
+                          }
+                        ],
+                        body: {
+                          mode: 'raw',
+                          raw: '{\n  "requestId": "req-2",\n  "info": "final request body example"\n}',
+                          options: {
+                            raw: {
+                              headerFamily: 'json',
+                              language: 'json'
+                            }
+                          }
+                        },
+                        url: {
+                          raw: '{{baseUrl}}/users/:id',
+                          protocol: undefined,
+                          auth: undefined,
+                          host: ['{{baseUrl}}'],
+                          port: undefined,
+                          path: ['users', ':id'],
+                          query: undefined,
+                          hash: undefined,
+                          variable: [
+                            {
+                              key: 'id',
+                              value: 'user123'
+                            }
+                          ]
+                        }
+                      },
+                      status: 'OK',
+                      code: 200,
+                      _postman_previewlanguage: 'json',
+                      _postman_previewtype: 'html',
+                      header: [
+                        {
+                          key: 'Content-Type',
+                          value: 'application/json'
+                        }
+                      ],
+                      cookie: [],
+                      responseTime: null,
+                      body: `{
+  "id": "user123",
+  "name": "John Doe"
+}`
+                    },
+                    {
+                      name: 'Bad request',
+                      originalRequest: {
+                        auth: undefined,
+                        method: 'POST',
+                        header: [
+                          {
+                            key: 'Content-Type',
+                            value: 'application/json'
+                          },
+                          {
+                            key: 'Accept',
+                            value: 'application/json'
+                          }
+                        ],
+                        body: {
+                          mode: 'raw',
+                          raw: '{\n  "requestId": "req-400",\n  "info": "Bad request specific body"\n}',
+                          options: {
+                            raw: {
+                              headerFamily: 'json',
+                              language: 'json'
+                            }
+                          }
+                        },
+                        url: {
+                          raw: '{{baseUrl}}/users/:id',
+                          protocol: undefined,
+                          auth: undefined,
+                          host: ['{{baseUrl}}'],
+                          port: undefined,
+                          path: ['users', ':id'],
+                          query: undefined,
+                          hash: undefined,
+                          variable: [
+                            {
+                              key: 'id',
+                              value: 'user123'
+                            }
+                          ]
+                        }
+                      },
+                      status: 'Bad Request',
+                      code: 400,
+                      _postman_previewlanguage: 'json',
+                      _postman_previewtype: 'html',
+                      header: [
+                        {
+                          key: 'Content-Type',
+                          value: 'application/json'
+                        }
+                      ],
+                      cookie: [],
+                      responseTime: null,
+                      body: `{
+  "error": "invalid"
+}`
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      variable: [
+        {
+          key: 'baseUrl',
+          value: 'https://api.example.com',
+          type: 'any'
+        }
+      ]
+    }
+  }
+};

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -2530,7 +2530,7 @@ describe('The convert v2 Function', function() {
     });
   });
 
-  describe('Should generate only first example when', function() {
+  describe('Should pair examples by matching key (and fall back to first example otherwise) when', function() {
     it('request body contains multiple examples but request body has single example', function(done) {
       var openapi = fs.readFileSync(multiExampleRequest, 'utf8');
       Converter.convertV2({ type: 'string', data: openapi }, { parametersResolution: 'Example' },
@@ -2613,11 +2613,18 @@ describe('The convert v2 Function', function() {
             });
 
             /**
-             * Even though both req and res has 3 examples, only 1 example should be present
-             * as we only use the first example from each
+             * Request and response each have 3 examples. Two keys match across both
+             * (valid-request, missing-required-parameter) so two saved responses are generated,
+             * one per matched key. The non-matching keys (extra-value / extra-value-2) are ignored.
              */
-            expect(item.response).to.have.lengthOf(1);
+            expect(item.response).to.have.lengthOf(2);
+
+            // Saved-response name stays tied to the response-level description (here 'None') so it
+            // round-trips to the OAS response description on collection -> spec sync. Pairing is
+            // carried by the example key, not the name.
+            // First matched key: valid-request
             expect(item.response[0].name).to.eql('None');
+            expect(item.response[0].code).to.eql(200);
             expect(item.response[0]._postman_previewlanguage).to.eql('json');
             expect(JSON.parse(item.response[0].body)).to.eql({
               user: 1,
@@ -2627,11 +2634,22 @@ describe('The convert v2 Function', function() {
             expect(JSON.parse(item.response[0].originalRequest.body.raw)).to.eql({
               includedFields: ['user', 'height', 'weight']
             });
+
+            // Second matched key: missing-required-parameter
+            expect(item.response[1].name).to.eql('None');
+            expect(item.response[1].code).to.eql(200);
+            expect(item.response[1]._postman_previewlanguage).to.eql('json');
+            expect(JSON.parse(item.response[1].body)).to.eql({
+              user: 1
+            });
+            expect(JSON.parse(item.response[1].originalRequest.body.raw)).to.eql({
+              includedFields: ['user']
+            });
             done();
           });
       });
 
-    it('both request and response body contains multiple examples in mentioned order when no matching keys',
+    it('both request and response body contain multiple examples but no matching keys (falls back to first of each)',
       function(done) {
         var openapi = fs.readFileSync(multiExampleRequestResponse, 'utf8');
         Converter.convertV2({ type: 'string', data: openapi }, { parametersResolution: 'Example' },
@@ -2723,10 +2741,12 @@ describe('The convert v2 Function', function() {
           expect(JSON.parse(item.response[0].originalRequest.body.raw)).to.eql(reqBody1);
           expect(JSON.parse(item.response[0].body)).to.eql({ user: 1 });
 
+          // Code 400 response example key (missing-required-parameter) matches the request
+          // example of the same key, so its originalRequest pairs to that request example.
           expect(item.response[1].name).to.eql('None');
           expect(item.response[1].code).to.eql(400);
           expect(item.response[1]._postman_previewlanguage).to.eql('json');
-          expect(JSON.parse(item.response[1].originalRequest.body.raw)).to.eql(reqBody1);
+          expect(JSON.parse(item.response[1].originalRequest.body.raw)).to.eql({ includedFields: ['eyeColor'] });
           expect(JSON.parse(item.response[1].body)).to.eql({ eyeColor: 'gray' });
 
           expect(item.response[2].name).to.eql('None');
@@ -2738,7 +2758,8 @@ describe('The convert v2 Function', function() {
         });
     });
 
-    it('request body and responses contain examples with matching keys as response codes', function(done) {
+    it('request body and responses contain examples with keys matching response codes ' +
+      '(out of scope, falls back to first of each)', function(done) {
       const openapi = fs.readFileSync(multiExampleResponseCodeMatching, 'utf8');
       Converter.convertV2({ type: 'string', data: openapi }, { parametersResolution: 'Example' },
         (err, conversionResult) => {
@@ -2799,6 +2820,60 @@ describe('The convert v2 Function', function() {
           done();
         });
     });
+
+    it('falls back to first request and first response example when no request/response keys match',
+      function(done) {
+        const noMatchSpec = {
+          openapi: '3.0.0',
+          info: { title: 'No match', version: '1.0.0' },
+          paths: {
+            '/v1': {
+              post: {
+                requestBody: {
+                  content: {
+                    'application/json': {
+                      schema: { type: 'object', properties: { name: { type: 'string' } } },
+                      examples: {
+                        'req-a': { value: { name: 'first-req' } },
+                        'req-b': { value: { name: 'second-req' } }
+                      }
+                    }
+                  }
+                },
+                responses: {
+                  200: {
+                    description: 'None',
+                    content: {
+                      'application/json': {
+                        schema: { type: 'object', properties: { id: { type: 'integer' } } },
+                        examples: {
+                          'res-x': { value: { id: 1 } },
+                          'res-y': { value: { id: 2 } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        Converter.convertV2({ type: 'json', data: noMatchSpec }, { parametersResolution: 'Example' },
+          (err, conversionResult) => {
+            expect(err).to.be.null;
+            expect(conversionResult.result).to.equal(true);
+
+            const item = conversionResult.output[0].data.item[0].item[0];
+
+            // No keys match -> single saved response using the first request and first response example.
+            expect(item.response).to.have.lengthOf(1);
+            expect(JSON.parse(item.request.body.raw)).to.eql({ name: 'first-req' });
+            expect(JSON.parse(item.response[0].body)).to.eql({ id: 1 });
+            expect(JSON.parse(item.response[0].originalRequest.body.raw)).to.eql({ name: 'first-req' });
+            done();
+          });
+      });
   });
 
   it('[Github #11884] Should not contain duplicate variables created from requests path', function (done) {

--- a/test/unit/convertV2WithTypes.test.js
+++ b/test/unit/convertV2WithTypes.test.js
@@ -679,6 +679,108 @@ describe('convertV2WithTypes', function() {
       });
     });
 
+    it('should pair request/response examples by matching key and still extract types ' +
+      '(multiExampleMatchingRequestResponse)', function(done) {
+      const openapi = fs.readFileSync(
+        path.join(__dirname, VALID_OPENAPI_PATH, '/multiExampleMatchingRequestResponse.yaml'), 'utf8');
+
+      Converter.convertV2WithTypes({ type: 'string', data: openapi }, { parametersResolution: 'Example' },
+        (err, conversionResult) => {
+          expect(err).to.be.null;
+          expect(conversionResult.result).to.equal(true);
+
+          const item = conversionResult.output[0].data.item[0].item[0];
+
+          // Two keys match across request and response examples (valid-request,
+          // missing-required-parameter) -> two paired saved responses. Non-matching keys
+          // (extra-value / extra-value-2) are ignored.
+          expect(item.response).to.have.lengthOf(2);
+
+          // Saved-response name stays tied to the response description ('None') for deterministic
+          // collection -> spec sync; pairing is carried by the example key, not the name.
+          expect(item.response[0].name).to.eql('None');
+          expect(JSON.parse(item.response[0].body)).to.eql({ user: 1, height: 168, weight: 44 });
+          expect(JSON.parse(item.response[0].originalRequest.body.raw)).to.eql({
+            includedFields: ['user', 'height', 'weight']
+          });
+
+          expect(item.response[1].name).to.eql('None');
+          expect(JSON.parse(item.response[1].body)).to.eql({ user: 1 });
+          expect(JSON.parse(item.response[1].originalRequest.body.raw)).to.eql({
+            includedFields: ['user']
+          });
+
+          // Types are still extracted (keyed per status code, shared across that code's examples).
+          expect(conversionResult.extractedTypes).to.be.an('object').that.is.not.empty;
+
+          const responseTypes = conversionResult.extractedTypes['post/v1'].response['200'];
+
+          expect(responseTypes).to.have.property('body');
+          expect(JSON.parse(responseTypes.body)).to.be.an('object');
+
+          done();
+        });
+    });
+
+    it('should fall back to first request and response example and still extract types ' +
+      'when no request/response keys match', function(done) {
+      const noMatchSpec = {
+        openapi: '3.0.0',
+        info: { title: 'No match', version: '1.0.0' },
+        paths: {
+          '/v1': {
+            post: {
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: { type: 'object', properties: { name: { type: 'string' } } },
+                    examples: {
+                      'req-a': { value: { name: 'first-req' } },
+                      'req-b': { value: { name: 'second-req' } }
+                    }
+                  }
+                }
+              },
+              responses: {
+                200: {
+                  description: 'None',
+                  content: {
+                    'application/json': {
+                      schema: { type: 'object', properties: { id: { type: 'integer' } } },
+                      examples: {
+                        'res-x': { value: { id: 1 } },
+                        'res-y': { value: { id: 2 } }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      Converter.convertV2WithTypes({ type: 'json', data: noMatchSpec }, { parametersResolution: 'Example' },
+        (err, conversionResult) => {
+          expect(err).to.be.null;
+          expect(conversionResult.result).to.equal(true);
+
+          const item = conversionResult.output[0].data.item[0].item[0];
+
+          // No keys match -> single saved response using the first request and first response example.
+          expect(item.response).to.have.lengthOf(1);
+          expect(JSON.parse(item.request.body.raw)).to.eql({ name: 'first-req' });
+          expect(JSON.parse(item.response[0].body)).to.eql({ id: 1 });
+          expect(JSON.parse(item.response[0].originalRequest.body.raw)).to.eql({ name: 'first-req' });
+
+          // Type data is still extracted for the status code.
+          expect(conversionResult.extractedTypes).to.be.an('object').that.is.not.empty;
+          expect(conversionResult.extractedTypes['post/v1'].response['200']).to.have.property('body');
+
+          done();
+        });
+    });
+
     it('should extract allOf schemas in request and response bodies', function(done) {
       const openApiWithAllOf = {
         openapi: '3.0.0',


### PR DESCRIPTION
## Summary

When converting a spec to a collection, pair a request example with a response example **when they share the same example key name**, and emit one Postman saved response per matched key — instead of collapsing everything to the first example. When nothing matches, fall back to the legacy first-request + first-response behavior (zero regression).

## Problem 
An OpenAPI operation can define multiple named examples for a request body and for each response (e.g. an admin example and a user example). Today, when we convert a spec to a Postman collection — and sync it back — we keep only the first example and drop the rest.

This was an intentional earlier decision: OpenAPI doesn't define any relationship or ordering between a request example and a response example, so automatically pairing them was a guess that could change between runs and broke 2-way sync. To stay safe, we collapsed everything to the first example.

A customer now needs all of their examples to come through. So we need to surface multiple examples without reintroducing that non-determinism — the spec ↔ collection round trip must stay deterministic and lossless (syncing one direction and back must reconstruct the original).

## Approach: 
pair a request example with a response example only when they share the same example key name (e.g. both called admin). Matched pairs become separate saved responses in the collection; anything unmatched falls back to today's "first example" behavior. This keeps the mapping explicit and reversible.

This is the forward (spec → collection) half of multi-example round-trip support; the reverse half lives in `@postman/collection-to-openapi` [PR](https://github.com/postman-eng/collection-to-openapi/pull/9).

## What changed (`libV2/CollectionGeneration/schemaUtils.js`)

- For each `(operation, statusCode)`: compute the matching keys between the request examples and that code's response examples. For each matched key, emit a saved response with `response.body` = the response example and `originalRequest.body` = the matched request example.
- **No matching keys for a code → fall back to the first request example + first response example** (single saved response) — unchanged legacy path.
- **Removed response-code-as-key matching** (out of MVP scope; it now falls back to first).
- The saved-response **name stays tied to the response-level description**, so it round-trips to the OAS response `description` on sync. Pairing identity rides on the example key, not the name.

## Scope / non-goals

- Matching-key pairing only (Option A). Differing-key pairing via a vendor extension, many-to-many (N×N), and partial-pairing materialization are out of scope.
- The request item's live body remains a single example; per-example request bodies are reflected only in each saved response's `originalRequest`.

## Tests

- `test/unit/convertV2.test.js` — updated the multi-example cases to the matching-key behavior; added **"falls back to first request and first response example when no request/response keys match"**.
- `test/unit/convertV2WithTypes.test.js` — added a matching-key test and a fallback test (also asserting type extraction).

## Fixes: 
[AB-2620] https://postmanlabs.atlassian.net/browse/AB-2620


## Test plan

- [x] `npm run test-unit` (convertV2, convertV2WithTypes, CollectionGenerationAndSyncing) — green
- [x] lint

[AB-2620]: https://postmanlabs.atlassian.net/browse/AB-2620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ