### PR TITLE
[AB-2545] Add deleteOrphanedRequests option for collection syncing

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,17 @@ $ openapi2postmanv2 -s spec.yaml --sync collection.json --sync-options-config sy
 **sync-options.json:**
 ```json
 {
-  "syncExamples": true
+  "syncExamples": true,
+  "deleteOrphanedRequests": false
 }
 ```
+
+#### Available Sync Options
+
+| id | type | default | description |
+|---|---|---|---|
+| `syncExamples` | boolean | `false` | Whether to sync response examples from the OpenAPI specification to the collection. When enabled, response examples in the spec are synced with existing collection responses. |
+| `deleteOrphanedRequests` | boolean | `false` | Whether to delete requests and folders that exist in the collection but no longer exist in the OpenAPI specification. When disabled (default), such orphans are preserved to avoid unintentional data loss. |
 
 For a complete list of sync options and their usage, see [SYNC_OPTIONS.md](/SYNC_OPTIONS.md)
 
@@ -314,7 +322,8 @@ const fs = require('fs'),
   existingCollection = JSON.parse(fs.readFileSync('collection.json', {encoding: 'UTF8'}));
 
 const syncOptions = {
-  syncExamples: true
+  syncExamples: true,
+  deleteOrphanedRequests: false
 };
 
 Converter.syncCollection(

--- a/SYNC_OPTIONS.md
+++ b/SYNC_OPTIONS.md
@@ -7,6 +7,7 @@ This document describes the available options for syncing OpenAPI specifications
 | id | type | default | description | version |
 |---|---|---|---|---|
 | syncExamples | boolean | false | Whether to sync response examples from the OpenAPI specification to the collection. When enabled, response examples in the spec will be synced with existing collection responses. | v2 |
+| deleteOrphanedRequests | boolean | false | Whether to delete requests and folders that exist in the collection but no longer exist in the OpenAPI specification. When disabled (default), such orphans are preserved to avoid unintentional data loss. | v2 |
 
 ## Usage
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -486,6 +486,19 @@ module.exports = {
         usage: ['SYNC'],
         supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
         supportedModuleVersion: [MODULE_VERSION.V2]
+      },
+      {
+        name: 'Delete orphaned requests',
+        id: 'deleteOrphanedRequests',
+        type: 'boolean',
+        default: false,
+        description: 'Whether to delete requests and folders that exist in the collection but no longer ' +
+          'exist in the OpenAPI specification. When disabled (default), such orphans are preserved to ' +
+          'avoid unintentional data loss.',
+        external: true,
+        usage: ['SYNC'],
+        supportedIn: [VERSION20, VERSION30, VERSION31, VERSION32],
+        supportedModuleVersion: [MODULE_VERSION.V2]
       }
     ];
 

--- a/libV2/SpecificationCollectionSyncing/shared/constants.ts
+++ b/libV2/SpecificationCollectionSyncing/shared/constants.ts
@@ -43,5 +43,6 @@ export const ALLOWED_AUTH_PARAM_KEYS_BY_TYPE: Record<string, Set<string>> = {
 };
 
 export const DEFAULT_SYNC_OPTIONS: SyncOptions = {
-  syncExamples: false
+  syncExamples: false,
+  deleteOrphanedRequests: false
 };

--- a/libV2/SpecificationCollectionSyncing/shared/types.ts
+++ b/libV2/SpecificationCollectionSyncing/shared/types.ts
@@ -84,4 +84,10 @@ export interface AuthMergeResult {
 
 export type SyncOptions = {
   syncExamples: boolean;
+  /**
+   * When true, requests (and folders) that exist in the collection but no longer exist in the
+   * specification are removed during spec -> collection syncing.
+   * When false (default), such orphans are preserved to avoid unintentional data loss.
+   */
+  deleteOrphanedRequests?: boolean;
 };

--- a/libV2/SpecificationCollectionSyncing/spec-to-collection/index.ts
+++ b/libV2/SpecificationCollectionSyncing/spec-to-collection/index.ts
@@ -164,6 +164,19 @@ export function syncCollection(
     }
   });
 
+  // When opted in, remove orphans: requests and folders that exist in the collection but no longer
+  // exist in the latest spec-derived state. Matched folders are pruned recursively above via the
+  // sync loop (mergedOptions is propagated), so here we only drop unmatched items at this level.
+  if (mergedOptions.deleteOrphanedRequests) {
+    currentCollectionState.items.remove((item: Item | ItemGroup<Item>) => {
+      if (item instanceof ItemGroup) {
+        return !findFolderItemByName(latestCollectionState, item.name);
+      }
+
+      return !findRequestItemByPathAndMethod(latestCollectionState, getRequestIdentifier(item));
+    }, currentCollectionState);
+  }
+
   currentCollectionState.description = latestCollectionState.description;
 
   const existingCollectionAuth = _.cloneDeep(currentCollectionState?.auth?.toJSON()) ?? {},

--- a/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI3/index.js
+++ b/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI3/index.js
@@ -30,6 +30,7 @@ module.exports = {
   shouldSyncRequestToFirstResponseOnly: require('./shouldSyncRequestToFirstResponseOnly'),
   shouldPreserveOtherSameCodeResponsesOnRequestSync: require('./shouldPreserveOtherSameCodeResponsesOnRequestSync'),
   shouldPairSameCodeExamplesPositionallyOnSync: require('./shouldPairSameCodeExamplesPositionallyOnSync'),
+  shouldDeleteOrphanRequestsWhenEnabled: require('./shouldDeleteOrphanRequestsWhenEnabled'),
   // Multi-file specification test cases
   multiFileSpecs: require('./multiFileSpecs')
 };

--- a/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI3/shouldDeleteOrphanRequestsWhenEnabled.js
+++ b/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI3/shouldDeleteOrphanRequestsWhenEnabled.js
@@ -1,0 +1,263 @@
+/*
+  Spec -> collection syncing with `deleteOrphanedRequests` enabled.
+
+  The collection starts with:
+    - GET /pets (kept; still present in the spec)
+    - POST /pets (orphan request; removed from the spec)
+    - a "legacy" folder with GET /legacy (orphan folder; the whole path is gone from the spec)
+
+  After syncing with `deleteOrphanedRequests: true`, the orphan request and the orphan folder are removed,
+  leaving only GET /pets.
+*/
+module.exports = {
+  name: 'should delete orphan requests and folders from collection when deleteOrphanedRequests is enabled',
+  specificationType: 'OPENAPI:3.0',
+  generationOptions: {},
+  syncOptions: {
+    syncExamples: false,
+    deleteOrphanedRequests: true
+  },
+  initialState: {
+    collection: {
+      info: {
+        _postman_id: '398bd1df-02ff-4c2e-9c29-f4296bf2d3b3',
+        name: 'orphan-delete',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+        _exporter_id: '6294718'
+      },
+      item: [
+        {
+          name: 'pets',
+          item: [
+            {
+              name: 'List all pets',
+              request: {
+                method: 'GET',
+                header: [
+                  {
+                    key: 'Accept',
+                    value: 'application/json'
+                  }
+                ],
+                url: {
+                  raw: '{{baseUrl}}/pets',
+                  host: ['{{baseUrl}}'],
+                  path: ['pets']
+                }
+              },
+              response: [
+                {
+                  name: 'unexpected error',
+                  originalRequest: {
+                    method: 'GET',
+                    header: [
+                      {
+                        key: 'Accept',
+                        value: 'application/json'
+                      }
+                    ],
+                    url: {
+                      raw: '{{baseUrl}}/pets',
+                      host: ['{{baseUrl}}'],
+                      path: ['pets']
+                    }
+                  },
+                  status: 'Internal Server Error',
+                  code: 500,
+                  _postman_previewlanguage: 'json',
+                  header: [
+                    {
+                      key: 'Content-Type',
+                      value: 'application/json'
+                    }
+                  ],
+                  cookie: [],
+                  body: '{\n  "code": "<integer>",\n  "message": "<string>"\n}'
+                }
+              ]
+            },
+            {
+              name: 'Create Pet record',
+              request: {
+                method: 'POST',
+                header: [
+                  {
+                    key: 'Content-Type',
+                    value: 'application/json'
+                  },
+                  {
+                    key: 'Accept',
+                    value: 'application/json'
+                  }
+                ],
+                body: {
+                  mode: 'raw',
+                  raw: '{\n  "message": "<string>",\n  "statusCode": "<integer>"\n}',
+                  options: {
+                    raw: {
+                      headerFamily: 'json',
+                      language: 'json'
+                    }
+                  }
+                },
+                url: {
+                  raw: '{{baseUrl}}/pets',
+                  host: ['{{baseUrl}}'],
+                  path: ['pets']
+                }
+              },
+              response: []
+            }
+          ]
+        },
+        {
+          name: 'legacy',
+          item: [
+            {
+              name: 'List legacy items',
+              request: {
+                method: 'GET',
+                header: [],
+                url: {
+                  raw: '{{baseUrl}}/legacy',
+                  host: ['{{baseUrl}}'],
+                  path: ['legacy']
+                }
+              },
+              response: []
+            }
+          ]
+        }
+      ],
+      variable: [
+        {
+          key: 'baseUrl',
+          value: 'http://petstore.swagger.io/v1'
+        }
+      ]
+    },
+    spec: {}
+  },
+  finalState: {
+    collection: {
+      info: {
+        _postman_id: 'd7c6434b-cd79-446a-9158-530a23969024',
+        name: 'orphan-delete',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+        _exporter_id: '6294718'
+      },
+      item: [
+        {
+          name: 'pets',
+          item: [
+            {
+              name: 'List all pets',
+              request: {
+                method: 'GET',
+                header: [
+                  {
+                    key: 'Accept',
+                    value: 'application/json'
+                  }
+                ],
+                url: {
+                  raw: '{{baseUrl}}/pets',
+                  host: ['{{baseUrl}}'],
+                  path: ['pets']
+                }
+              },
+              response: [
+                {
+                  name: 'unexpected error',
+                  originalRequest: {
+                    method: 'GET',
+                    header: [
+                      {
+                        key: 'Accept',
+                        value: 'application/json'
+                      }
+                    ],
+                    url: {
+                      raw: '{{baseUrl}}/pets',
+                      host: ['{{baseUrl}}'],
+                      path: ['pets']
+                    }
+                  },
+                  status: 'Internal Server Error',
+                  code: 500,
+                  _postman_previewlanguage: 'json',
+                  header: [
+                    {
+                      key: 'Content-Type',
+                      value: 'application/json'
+                    }
+                  ],
+                  cookie: [],
+                  body: '{\n  "code": "<integer>",\n  "message": "<string>"\n}'
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      variable: [
+        {
+          key: 'baseUrl',
+          value: 'http://petstore.swagger.io/v1'
+        }
+      ]
+    },
+    spec: {
+      openapi: '3.0.0',
+      info: {
+        version: '1.0.0',
+        title: 'Swagger Petstore',
+        license: {
+          name: 'MI'
+        }
+      },
+      servers: [
+        {
+          url: 'http://petstore.swagger.io/v1'
+        }
+      ],
+      paths: {
+        '/pets': {
+          get: {
+            summary: 'List all pets',
+            operationId: 'listPets',
+            tags: ['pets'],
+            responses: {
+              500: {
+                description: 'unexpected error',
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: '#/components/schemas/Error'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      components: {
+        schemas: {
+          Error: {
+            required: ['code', 'message'],
+            properties: {
+              code: {
+                type: 'integer',
+                format: 'int32'
+              },
+              message: {
+                type: 'string'
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};

--- a/types/index.ts
+++ b/types/index.ts
@@ -180,6 +180,12 @@ export interface SyncOptions {
 
   /** Whether to sync response examples from the OpenAPI specification */
   syncExamples?: boolean;
+
+  /**
+   * Whether to delete requests and folders that exist in the collection but no longer exist in the
+   * OpenAPI specification. Defaults to false, which preserves such orphans.
+   */
+  deleteOrphanedRequests?: boolean;
 }
 
 export interface OptionDefinition {


### PR DESCRIPTION
This update introduces a new sync option, `deleteOrphanedRequests`, which allows users to remove requests and folders from the collection that no longer exist in the OpenAPI specification. The default behavior preserves these orphaned items to prevent data loss. Documentation and tests have been updated accordingly to reflect this change.