### PR TITLE
fix(relatedFiles): prevent duplicate adjacent node extraction from different local refs

### DIFF
--- a/lib/relatedFiles.js
+++ b/lib/relatedFiles.js
@@ -93,8 +93,9 @@ function getReferences (currentNode, refTypeResolver, pathSolver) {
           }
         );
       if (hasReferenceTypeKey) {
-        if (!added(property.$ref, referencesInNode)) {
-          referencesInNode.push({ path: pathSolver(property) });
+        let resolvedPath = pathSolver(property);
+        if (!added(resolvedPath, referencesInNode)) {
+          referencesInNode.push({ path: resolvedPath });
         }
       }
     }

--- a/test/unit/relatedFiles.test.js
+++ b/test/unit/relatedFiles.test.js
@@ -52,6 +52,21 @@ describe('getAdjacentAndMissing function', function () {
     expect(missingNodes[0].path).to.equal('/common/Error.yaml');
 
   });
+
+  it('should filter out duplicate adjacent files when referenced with different local pointers', function () {
+    const inputNode = {
+      fileName: '/main.yaml',
+      content: 'openapi: 3.0.0\npaths:\n  /pets:\n    post:\n      requestBody:\n        content:\n          application/json:\n            schema:\n              $ref: "./Pet.yaml#/components/schemas/NewPet"\n      responses:\n        200:\n          description: success\n          content:\n            application/json:\n              schema:\n                $ref: "./Pet.yaml#/components/schemas/Pet"'
+    },
+    inputData = [{
+      fileName: '/Pet.yaml',
+      content: 'openapi: 3.0.0\ncomponents:\n  schemas:\n    Pet:\n      type: object\n    NewPet:\n      type: object'
+    }],
+    { graphAdj, missingNodes } = getAdjacentAndMissing(inputNode, inputData, inputNode);
+    expect(graphAdj.length).to.equal(1);
+    expect(graphAdj[0].fileName).to.equal('/Pet.yaml');
+    expect(missingNodes.length).to.equal(0);
+  });
 });
 
 describe('getRelatedFiles function ', function () {


### PR DESCRIPTION
Ensure we use the resolved path when determining if a referenced file has already been added to the adjacent references array. This prevents parsing/extracting duplicate nodes when multiple components or objects in the same external file are referenced (e.g. via different local pointers).