### PR TITLE
Enhance parameter example mapping handling in schemaUtils and response merging

### DIFF
--- a/libV2/CollectionGeneration/schemaUtils.js
+++ b/libV2/CollectionGeneration/schemaUtils.js
@@ -1138,7 +1138,7 @@ let QUERYPARAM = 'query',
    * @returns {*} Value of the parameter
    */
   resolveValueOfParameter = (context, param,
-    { schemaFormat = SCHEMA_FORMATS.DEFAULT, isResponseSchema = false } = {}
+    { schemaFormat = SCHEMA_FORMATS.DEFAULT, isResponseSchema = false, exampleKey } = {}
   ) => {
     if (!param || !param.hasOwnProperty('schema')) {
       return '';
@@ -1157,8 +1157,25 @@ let QUERYPARAM = 'query',
       /**
        * Here it could be example or examples (plural)
        * For examples, we'll pick the first example
+       *
+       * When an `exampleKey` is supplied (multi-example matching-key pairing), we resolve the
+       * parameter value with the same fallback precedence used for request bodies:
+       *   1. param.examples[exampleKey] (case-insensitive)
+       *   2. else param.example (singular)
+       *   3. else param.examples[firstKey] (first by key order)
+       *   4. else schema-derived default (handled by the faker below)
        */
       let example;
+
+      if (exampleKey !== undefined && _.isObject(param.examples)) {
+        const matchedKey = _.findKey(param.examples, (exampleValue, key) => {
+          return _.toLower(key) === _.toLower(exampleKey);
+        });
+
+        if (matchedKey !== undefined) {
+          return getExampleData(context, { [matchedKey]: param.examples[matchedKey] });
+        }
+      }
 
       if (param.example !== undefined) {
         example = param.example;
@@ -1461,12 +1478,17 @@ let QUERYPARAM = 'query',
    * @param {Object} requestBodyExamples - Examples defined in the request body
    * @param {Object} responseBodySchema - Schema of the response body
    * @param {Boolean} isXMLExample - Whether the example is XML example
+   * @param {Array<String>} parameterExampleKeys - Parameter example keys (set P) for matching-key pairing
    * @returns {Array} Examples for corresponding operation
    */
-  generateExamples = (context, responseExamples, requestBodyExamples, responseBodySchema, isXMLExample) => {
+  generateExamples = (context, responseExamples, requestBodyExamples, responseBodySchema, isXMLExample,
+    parameterExampleKeys = []) => {
     const pmExamples = [],
       responseExampleKeys = _.map(responseExamples, 'key'),
       requestBodyExampleKeys = _.map(requestBodyExamples, 'key'),
+      // The request side is the union of request body example keys (B) and parameter example
+      // keys (P). Matching ANY request-side component key anchors a saved-response pair.
+      requestSideExampleKeys = _.concat(requestBodyExampleKeys, parameterExampleKeys),
       exampleKeyComparator = (example, key) => {
         return _.toLower(example.key) === _.toLower(key);
       };
@@ -1481,9 +1503,10 @@ let QUERYPARAM = 'query',
         (!_.isNil(responseExample.responseCode) ? String(responseExample.responseCode) : undefined);
     };
 
-    // pair strictly by matching example key names between request and response
-    // examples. falls back to first-only if no matching keys are found.
-    const matchedKeys = _.intersectionBy(responseExampleKeys, requestBodyExampleKeys, _.toLower);
+    // pair strictly by matching example key names between the response examples (R) and the
+    // union of request body (B) and parameter (P) example keys. falls back to first-only if no
+    // matching keys are found. matchedKeys are returned in R's key order.
+    const matchedKeys = _.intersectionBy(responseExampleKeys, requestSideExampleKeys, _.toLower);
 
     // Do keys matching first and ignore any leftover req/res body for which matching is not found
     if (matchedKeys.length) {
@@ -1502,6 +1525,13 @@ let QUERYPARAM = 'query',
           requestExample = _.head(matchedRequestExamples);
         }
 
+        // The matched key may belong to a parameter only (not the request body). In that case the
+        // body falls back to its first example (matching-key precedence), or is omitted entirely
+        // when the operation defines no request body examples at all.
+        if (!requestExample) {
+          requestExample = _.head(requestBodyExamples);
+        }
+
         responseExampleData = getExampleData(context, { [responseExample.key]: responseExample.value });
 
         if (isXMLExample) {
@@ -1509,9 +1539,14 @@ let QUERYPARAM = 'query',
         }
 
         pmExamples.push({
-          request: getExampleData(context, { [requestExample.key]: requestExample.value }),
+          request: requestExample ?
+            getExampleData(context, { [requestExample.key]: requestExample.value }) :
+            undefined,
           response: responseExampleData,
-          name: getResponseExampleName(responseExample) || 'Example'
+          name: getResponseExampleName(responseExample) || 'Example',
+          // carries the OAS example key so callers can resolve per-key parameter values for the
+          // saved response's originalRequest (query/path/header).
+          exampleKey: responseExample.key
         });
       });
 
@@ -1559,10 +1594,11 @@ let QUERYPARAM = 'query',
    * @param {Boolean} isExampleBody - Whether the body is example body
    * @param {String} responseCode - Response code
    * @param {Object} requestBodyExamples - Examples defined in the request body
+   * @param {Array<String>} parameterExampleKeys - Parameter example keys (set P) for matching-key pairing
    * @returns {Array} Request / Response body data
    */
   resolveBodyData = (context, requestBodySchema, bodyType, isExampleBody = false,
-    responseCode = null, requestBodyExamples = {}
+    responseCode = null, requestBodyExamples = {}, parameterExampleKeys = []
   ) => {
     let { parametersResolution, indentCharacter } = context.computedOptions,
       headerFamily = getHeaderFamily(bodyType),
@@ -1756,7 +1792,8 @@ let QUERYPARAM = 'query',
       }
 
       const generatedBody = generateExamples(
-        context, responseExamples, matchedRequestBodyExamples, requestBodySchema, isBodyTypeXML);
+        context, responseExamples, matchedRequestBodyExamples, requestBodySchema, isBodyTypeXML,
+        parameterExampleKeys);
 
       return {
         generatedBody,
@@ -2165,7 +2202,7 @@ let QUERYPARAM = 'query',
     };
   },
 
-  resolveQueryParamsForPostmanRequest = (context, operationItem, method) => {
+  resolveQueryParamsForPostmanRequest = (context, operationItem, method, { exampleKey } = {}) => {
     const params = resolvePathItemParams(context, operationItem[method].parameters, operationItem.parameters),
       pmParams = [],
       queryParamTypes = [],
@@ -2194,7 +2231,7 @@ let QUERYPARAM = 'query',
 
       let queryParamTypeInfo = {},
         properties = {},
-        paramValue = resolveValueOfParameter(context, param);
+        paramValue = resolveValueOfParameter(context, param, { exampleKey });
 
       if (param && param.name && param.schema && param.schema.type) {
         properties = createProperties(param);
@@ -2219,7 +2256,7 @@ let QUERYPARAM = 'query',
     return { queryParamTypes, queryParams: pmParams };
   },
 
-  resolvePathParamsForPostmanRequest = (context, operationItem, method) => {
+  resolvePathParamsForPostmanRequest = (context, operationItem, method, { exampleKey } = {}) => {
     const params = resolvePathItemParams(context, operationItem[method].parameters, operationItem.parameters),
       pmParams = [],
       pathParamTypes = [];
@@ -2248,7 +2285,7 @@ let QUERYPARAM = 'query',
 
       let pathParamTypeInfo = {},
         properties = {},
-        paramValue = resolveValueOfParameter(context, param);
+        paramValue = resolveValueOfParameter(context, param, { exampleKey });
 
       if (param && param.name && param.schema && param.schema.type) {
         properties = createProperties(param);
@@ -2300,7 +2337,7 @@ let QUERYPARAM = 'query',
     return reqName;
   },
 
-  resolveHeadersForPostmanRequest = (context, operationItem, method) => {
+  resolveHeadersForPostmanRequest = (context, operationItem, method, { exampleKey } = {}) => {
     const params = resolvePathItemParams(context, operationItem[method].parameters, operationItem.parameters),
       pmParams = [],
       headerTypes = [],
@@ -2333,7 +2370,7 @@ let QUERYPARAM = 'query',
 
       let headerTypeInfo = {},
         properties = {},
-        paramValue = resolveValueOfParameter(context, param);
+        paramValue = resolveValueOfParameter(context, param, { exampleKey });
 
       if (param && param.name && param.schema && param.schema.type) {
         properties = createProperties(param);
@@ -2358,6 +2395,44 @@ let QUERYPARAM = 'query',
   },
 
   /**
+   * Collects the union of plural `examples` keys defined across an operation's query, path and
+   * header parameters (set P in the matching-key model). These keys participate in the
+   * response<->request example pairing: M = R ∩ (B ∪ P).
+   *
+   * Only the parameter-level plural `examples` map contributes keys; a singular `example` (or a
+   * JSON-schema `examples` array) has no stable key and is only used as a fallback value.
+   *
+   * @param {Object} context - Global context object
+   * @param {Object} operationItem - Path item object (contains path-level and method-level params)
+   * @param {String} method - HTTP method
+   * @returns {Array<String>} - Ordered, de-duplicated list of parameter example keys
+   */
+  getParameterExampleKeys = (context, operationItem, method) => {
+    const params = resolvePathItemParams(context, operationItem[method].parameters, operationItem.parameters),
+      keys = [];
+
+    _.forEach(params, (param) => {
+      if (!_.isObject(param)) {
+        return;
+      }
+
+      if (_.has(param, '$ref')) {
+        param = resolveSchema(context, param);
+      }
+
+      if (param.in !== QUERYPARAM && param.in !== PATHPARAM && param.in !== HEADER) {
+        return;
+      }
+
+      if (_.isObject(param.examples)) {
+        keys.push(...Object.keys(param.examples));
+      }
+    });
+
+    return _.uniq(keys);
+  },
+
+  /**
    * Resolve the responses from definition which will be converted to request examples.
    * This includes both request and response body of corresponding example.
    *
@@ -2365,9 +2440,11 @@ let QUERYPARAM = 'query',
    * @param {Object} responseBody - Response body schema
    * @param {Object} requestBodyExamples - Examples defined in the request body of corresponding operation
    * @param {String} code - Response code
+   * @param {Array<String>} parameterExampleKeys - Parameter example keys (set P) for matching-key pairing
    * @returns {Array} - Postman examples
    */
-  resolveResponseBody = (context, responseBody = {}, requestBodyExamples = {}, code = null) => {
+  resolveResponseBody = (context, responseBody = {}, requestBodyExamples = {}, code = null,
+    parameterExampleKeys = []) => {
     let responseContent,
       bodyType,
       allBodyData,
@@ -2397,14 +2474,15 @@ let QUERYPARAM = 'query',
     headerFamily = getHeaderFamily(bodyType);
 
     resolvedResponseBodyResult = resolveBodyData(
-      context, responseContent[bodyType], bodyType, true, code, requestBodyExamples);
+      context, responseContent[bodyType], bodyType, true, code, requestBodyExamples, parameterExampleKeys);
     allBodyData = resolvedResponseBodyResult.generatedBody;
     resolvedResponseBodyTypes = resolvedResponseBodyResult.resolvedSchemaType;
 
     return _.map(allBodyData, (bodyData) => {
       let requestBodyData = bodyData.request,
         responseBodyData = bodyData.response,
-        exampleName = bodyData.name;
+        exampleName = bodyData.name,
+        exampleKey = bodyData.exampleKey;
 
       if ((bodyType === TEXT_XML || bodyType === APP_XML || headerFamily === HEADER_TYPE.XML)) {
         responseBodyData && (responseBodyData = getXmlVersionContent(responseBodyData));
@@ -2437,6 +2515,7 @@ let QUERYPARAM = 'query',
           value: bodyType
         }],
         name: exampleName,
+        exampleKey,
         bodyType,
         acceptHeader,
         resolvedResponseBodyTypes: resolvedResponseBodyTypes
@@ -2603,10 +2682,12 @@ let QUERYPARAM = 'query',
     return responseAuthHelper;
   },
 
-  resolveResponseForPostmanRequest = (context, operationItem, request) => {
+  resolveResponseForPostmanRequest = (context, operationItem, request, paramExamples = {}) => {
     let responses = [],
       requestBodyExamples = [],
       requestAcceptHeader,
+      parameterExampleKeys = _.get(paramExamples, 'keys', []),
+      resolveParamsForExampleKey = _.get(paramExamples, 'resolveForKey'),
       requestBody = operationItem.requestBody,
       requestContent,
       rawBodyType,
@@ -2663,7 +2744,8 @@ let QUERYPARAM = 'query',
           resolveSchema(context, responseObj, { isResponseSchema: true }) : responseObj,
         { includeAuthInfoInExample } = context.computedOptions,
         auth = request.auth,
-        resolvedExamples = resolveResponseBody(context, responseSchema, requestBodyExamples, code) || {},
+        resolvedExamples = resolveResponseBody(context, responseSchema, requestBodyExamples, code,
+          parameterExampleKeys) || {},
         { resolvedHeaderTypes, headers } = resolveResponseHeaders(context, responseSchema.headers),
         responseBodyHeaderObj;
 
@@ -2692,14 +2774,23 @@ let QUERYPARAM = 'query',
           return;
         }
 
-        let { body, contentHeader = [], bodyType, acceptHeader, name } = resolvedExample,
+        let { body, contentHeader = [], bodyType, acceptHeader, name, exampleKey } = resolvedExample,
           resolvedRequestBody = _.get(resolvedExample, 'request.body'),
           originalRequest,
           response,
           responseAuthHelper,
           requestBodyObj = {},
-          reqHeaders = _.clone(request.headers) || [],
-          reqQueryParams = _.clone(_.get(request, 'params.queryParams', []));
+          // Base request-side params/headers for this saved response. When the response example is
+          // paired by a matching key, resolve each parameter (query/path/header) for that key via
+          // the fallback precedence so the saved response's originalRequest reflects the paired
+          // parameter values. Parameters without a matching key fall back to their first
+          // example / schema default, so they contribute a single deterministic value.
+          keyedParams = (exampleKey && _.isFunction(resolveParamsForExampleKey)) ?
+            resolveParamsForExampleKey(exampleKey) : undefined,
+          baseHeaders = keyedParams ? keyedParams.headers : request.headers,
+          basePathParams = keyedParams ? keyedParams.pathParams : _.get(request, 'params.pathParams', []),
+          reqHeaders = _.clone(baseHeaders) || [],
+          reqQueryParams = _.clone(keyedParams ? keyedParams.queryParams : _.get(request, 'params.queryParams', []));
 
         // add Accept header in example's original request headers
         _.isArray(acceptHeader) && (reqHeaders.push(...acceptHeader));
@@ -2719,15 +2810,12 @@ let QUERYPARAM = 'query',
 
           reqHeaders.push(...responseAuthHelper.header);
           reqQueryParams.push(...responseAuthHelper.query);
+        }
 
-          originalRequest = _.assign({}, request, {
-            headers: reqHeaders,
-            params: _.assign({}, request.params, { queryParams: reqQueryParams })
-          }, requestBodyObj);
-        }
-        else {
-          originalRequest = _.assign({}, request, { headers: reqHeaders }, requestBodyObj);
-        }
+        originalRequest = _.assign({}, request, {
+          headers: reqHeaders,
+          params: _.assign({}, request.params, { queryParams: reqQueryParams, pathParams: basePathParams })
+        }, requestBodyObj);
 
         const responseDescription = _.get(responseSchema, 'description'),
           responseDescriptionTrimmed = _.isString(responseDescription) ? responseDescription.trim() : '',
@@ -2794,7 +2882,35 @@ module.exports = {
     pathVariables.push(...baseUrlData.pathVariables);
     collectionVariables.push(...baseUrlData.collectionVariables);
 
+    // url at this point is still the path portion (pre base-url). Capture it so per-example
+    // parameter resolution can filter path variables against the same url as the base request.
+    const preBaseUrl = url;
+
     url = _.get(baseUrlData, 'baseUrl', '') + url;
+
+    // Parameter example keys (set P) and a per-key resolver used for matching-key multi-example
+    // pairing. The resolver mirrors the base query/path/header resolution above but resolves each
+    // parameter's value for a specific example key (fallback: examples[key] -> example ->
+    // examples[firstKey] -> schema default).
+    const parameterExampleKeys = getParameterExampleKeys(context, operationItem, method),
+      resolveParamsForExampleKey = (exampleKey) => {
+        const keyedQueryParams = resolveQueryParamsForPostmanRequest(
+            context, operationItem, method, { exampleKey }).queryParams,
+          keyedHeaders = resolveHeadersForPostmanRequest(
+            context, operationItem, method, { exampleKey }).headers,
+          keyedPathParams = resolvePathParamsForPostmanRequest(
+            context, operationItem, method, { exampleKey }).pathParams,
+          { pathVariables: keyedPathVariables } = filterCollectionAndPathVariables(preBaseUrl, keyedPathParams);
+
+        keyedHeaders.push(..._.get(requestBody, 'headers', []));
+        keyedPathVariables.push(...baseUrlData.pathVariables);
+
+        return {
+          queryParams: keyedQueryParams,
+          headers: keyedHeaders,
+          pathParams: keyedPathVariables
+        };
+      };
 
     request = {
       description: operationItem[method].description,
@@ -2821,7 +2937,10 @@ module.exports = {
         responses,
         acceptHeader,
         responseTypes
-      } = resolveResponseForPostmanRequest(context, operationItem[method], request);
+      } = resolveResponseForPostmanRequest(context, operationItem[method], request, {
+        keys: parameterExampleKeys,
+        resolveForKey: resolveParamsForExampleKey
+      });
 
     const overridesServer = Boolean(baseUrlData.serverObj);
 

--- a/libV2/SpecificationCollectionSyncing/spec-to-collection/index.ts
+++ b/libV2/SpecificationCollectionSyncing/spec-to-collection/index.ts
@@ -106,10 +106,11 @@ export function syncCollection(
         currentResponsesByCode[response.code].push(response);
       });
 
-      // The spec carries a single request example (the live body). It is applied to the originalRequest
-      // of only the first response processed overall (isFirstSyncedResponse); every subsequent response
-      // preserves its existing originalRequest body (see mergeResponseData), so a request change in the
-      // spec updates just that first response rather than every response's originalRequest.
+      // The spec carries a single live request (body + primary parameter values). It is applied to the
+      // originalRequest of only the first response processed overall (isFirstSyncedResponse); every
+      // subsequent response preserves its existing originalRequest request-side data — body, url
+      // (query/path) and headers (see mergeResponseData) — so a request/parameter change in the spec
+      // updates just that first response rather than every response's originalRequest.
       let isFirstSyncedResponse = true;
 
       item.responses.each((response) => {

--- a/libV2/SpecificationCollectionSyncing/spec-to-collection/merge/ResponseMerger.ts
+++ b/libV2/SpecificationCollectionSyncing/spec-to-collection/merge/ResponseMerger.ts
@@ -10,9 +10,12 @@ import { attachImplicitHeaders } from '../header';
 /**
  * Preserve an existing saved response's header PARAMETER values while keeping any
  * implicit/generated headers (e.g. Content-Type, Accept) produced from the spec. Used when
- * preserving a non-first response's originalRequest on multi-example sync: source (existing)
- * values win for shared keys, generated target-only headers are retained, and header params that
- * only exist on the source are appended.
+ * preserving a non-first response's originalRequest on multi-example sync: for a shared key the
+ * spec-generated header metadata (name casing, description, schema-derived flags) is kept and only
+ * the existing header's `value`/`disabled` are copied over; generated target-only headers are
+ * retained, and header params that only exist on the source are appended.
+ *
+ * Header keys are matched case-insensitively (HTTP header names are case-insensitive).
  * @param {HeaderDefinition[] | undefined} targetHeaders - Spec-generated headers (base)
  * @param {HeaderDefinition[] | undefined} sourceHeaders - Existing saved response headers to preserve
  * @returns {HeaderDefinition[] | undefined} Merged header list
@@ -26,25 +29,31 @@ function preserveHeaderParams(
   }
 
   const result: HeaderDefinition[] = Array.isArray(targetHeaders) ? [...targetHeaders] : [],
-    indexByKey = new Map<string, number>();
+    indexByLowerKey = new Map<string, number>();
 
   result.forEach((header, index) => {
-    if (header?.key !== undefined) {
-      indexByKey.set(header.key, index);
+    if (typeof header?.key === 'string') {
+      indexByLowerKey.set(header.key.toLowerCase(), index);
     }
   });
 
-  sourceHeaders.forEach((header) => {
-    if (header?.key === undefined) {
+  sourceHeaders.forEach((sourceHeader) => {
+    if (typeof sourceHeader?.key !== 'string') {
       return;
     }
 
-    if (indexByKey.has(header.key)) {
-      result[indexByKey.get(header.key) as number] = header;
+    const lowerKey = sourceHeader.key.toLowerCase();
+
+    if (indexByLowerKey.has(lowerKey)) {
+      // Keep the spec-generated header (name casing + metadata); copy only the existing header's
+      // value/disabled state onto it.
+      const index = indexByLowerKey.get(lowerKey) as number;
+
+      result[index] = { ...result[index], value: sourceHeader.value, disabled: sourceHeader.disabled };
     }
     else {
-      indexByKey.set(header.key, result.length);
-      result.push(header);
+      indexByLowerKey.set(lowerKey, result.length);
+      result.push(sourceHeader);
     }
   });
 

--- a/libV2/SpecificationCollectionSyncing/spec-to-collection/merge/ResponseMerger.ts
+++ b/libV2/SpecificationCollectionSyncing/spec-to-collection/merge/ResponseMerger.ts
@@ -1,4 +1,4 @@
-import { Response, ResponseDefinition } from 'postman-collection';
+import { HeaderDefinition, Response, ResponseDefinition } from 'postman-collection';
 
 import { mergeRequestAndResponseBodyRaw } from './BodyMerger';
 import { mergeRequestAndResponseHeaders } from './HeaderMerger';
@@ -8,23 +8,68 @@ import { SyncOptions } from '../../shared';
 import { attachImplicitHeaders } from '../header';
 
 /**
+ * Preserve an existing saved response's header PARAMETER values while keeping any
+ * implicit/generated headers (e.g. Content-Type, Accept) produced from the spec. Used when
+ * preserving a non-first response's originalRequest on multi-example sync: source (existing)
+ * values win for shared keys, generated target-only headers are retained, and header params that
+ * only exist on the source are appended.
+ * @param {HeaderDefinition[] | undefined} targetHeaders - Spec-generated headers (base)
+ * @param {HeaderDefinition[] | undefined} sourceHeaders - Existing saved response headers to preserve
+ * @returns {HeaderDefinition[] | undefined} Merged header list
+ */
+function preserveHeaderParams(
+  targetHeaders: HeaderDefinition[] | undefined,
+  sourceHeaders: HeaderDefinition[] | undefined
+): HeaderDefinition[] | undefined {
+  if (!Array.isArray(sourceHeaders)) {
+    return targetHeaders;
+  }
+
+  const result: HeaderDefinition[] = Array.isArray(targetHeaders) ? [...targetHeaders] : [],
+    indexByKey = new Map<string, number>();
+
+  result.forEach((header, index) => {
+    if (header?.key !== undefined) {
+      indexByKey.set(header.key, index);
+    }
+  });
+
+  sourceHeaders.forEach((header) => {
+    if (header?.key === undefined) {
+      return;
+    }
+
+    if (indexByKey.has(header.key)) {
+      result[indexByKey.get(header.key) as number] = header;
+    }
+    else {
+      indexByKey.set(header.key, result.length);
+      result.push(header);
+    }
+  });
+
+  return result;
+}
+
+/**
  * Merges a single response from target with a corresponding response from current.
  * Returns the merged response definition.
  * @param {Response} targetResponse - Response from the target request
  * @param {Response } sourceResponse - Response from the source request
  * @param {SyncOptions} syncOptions - Options to control what should be synced
- * @param {boolean} preserveOriginalRequestBody - When true (and example syncing is enabled), keep
- *   the existing response's `originalRequest.body` instead of overwriting it with the spec's request.
- *   The spec carries a single request example (the live body) that maps to the first saved response;
- *   set this for every response after the first so a request change in the spec doesn't overwrite
- *   every response's originalRequest. Defaults to false (first response takes the spec request).
+ * @param {boolean} preserveOriginalRequest - When true (and example syncing is enabled), keep the
+ *   existing response's `originalRequest` request-side data (body, url query/path variables and
+ *   headers) instead of overwriting it with the spec's request. The spec carries a single live
+ *   request (body + parameter values) that maps to the first saved response; set this for every
+ *   response after the first so a request/parameter change in the spec doesn't overwrite every
+ *   response's originalRequest. Defaults to false (first response takes the spec request).
  * @returns {ResponseDefinition} Merged response definition
  */
 export function mergeResponseData(
   targetResponse: Response,
   sourceResponse: Response,
   syncOptions: SyncOptions,
-  preserveOriginalRequestBody = false
+  preserveOriginalRequest = false
 ): ResponseDefinition {
   const targetRes: ResponseDefinition = targetResponse.toJSON(),
     sourceRes: ResponseDefinition = sourceResponse.toJSON(),
@@ -34,15 +79,32 @@ export function mergeResponseData(
     targetRes.originalRequest = mergeRequestData(targetRes.originalRequest, sourceRes.originalRequest, syncOptions);
 
     /*
-     * The spec carries a single request example (the live request body), which maps to the first
-     * saved response. For the remaining responses, preserve their existing request body so that
-     * editing the request in the spec doesn't overwrite every response's originalRequest on sync-back.
+     * The spec carries a single live request (its body plus the primary parameter values), which
+     * maps to the first saved response. For the remaining responses, preserve their existing
+     * request-side data — body, url (query params + path variables) and headers — so that editing
+     * the request or a parameter in the spec doesn't overwrite every response's originalRequest on
+     * sync-back. Each component is deleted when the source had none, mirroring the body rule.
      * Only applies when example syncing is enabled (the multi-example flow).
      */
-if (preserveOriginalRequestBody && shouldSyncExamples) {
-  if (sourceRes.originalRequest.body === undefined) { delete targetRes.originalRequest.body; }
-  else { targetRes.originalRequest.body = sourceRes.originalRequest.body; }
-}
+    if (preserveOriginalRequest && shouldSyncExamples) {
+      // Cast for the delete-when-source-had-none branches (url/body are not always optional in the type).
+      const targetOriginalRequest = targetRes.originalRequest as unknown as Record<string, unknown>;
+
+      // Body: preserve the existing example's body wholesale (delete when the source had none).
+      if (sourceRes.originalRequest.body === undefined) { delete targetOriginalRequest.body; }
+      else { targetRes.originalRequest.body = sourceRes.originalRequest.body; }
+
+      // URL: preserve the existing example's url (query params + path variable values) wholesale.
+      if (sourceRes.originalRequest.url === undefined) { delete targetOriginalRequest.url; }
+      else { targetRes.originalRequest.url = sourceRes.originalRequest.url; }
+
+      // Headers: preserve the existing example's header PARAMETER values while keeping any
+      // implicit/generated headers (e.g. Content-Type, Accept) the spec produced.
+      targetRes.originalRequest.header = preserveHeaderParams(
+        targetRes.originalRequest.header as HeaderDefinition[] | undefined,
+        sourceRes.originalRequest.header as HeaderDefinition[] | undefined
+      );
+    }
   }
   // Attach implicit headers from the source response to the target response
   // if they are not present in the target response

--- a/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI3/index.js
+++ b/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI3/index.js
@@ -30,6 +30,7 @@ module.exports = {
   shouldSyncRequestToFirstResponseOnly: require('./shouldSyncRequestToFirstResponseOnly'),
   shouldPreserveOtherSameCodeResponsesOnRequestSync: require('./shouldPreserveOtherSameCodeResponsesOnRequestSync'),
   shouldPairSameCodeExamplesPositionallyOnSync: require('./shouldPairSameCodeExamplesPositionallyOnSync'),
+  shouldPairParameterExamplesByMatchingKey: require('./shouldPairParameterExamplesByMatchingKey'),
   shouldDeleteOrphanRequestsWhenEnabled: require('./shouldDeleteOrphanRequestsWhenEnabled'),
   // Multi-file specification test cases
   multiFileSpecs: require('./multiFileSpecs')

--- a/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI3/shouldPairParameterExamplesByMatchingKey.js
+++ b/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI3/shouldPairParameterExamplesByMatchingKey.js
@@ -1,0 +1,150 @@
+// A query parameter whose plural `examples` keys (admin, user) match the response example keys
+// produces one saved response per matched key, each carrying the paired parameter value in its
+// originalRequest url query. This fixture asserts the multi-example parameter pairing round-trips:
+// generation produces the two saved responses, and re-syncing the same spec does not churn them.
+
+const collection = {
+  info: {
+    schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+  },
+  item: [
+    {
+      name: 'users',
+      item: [
+        {
+          name: 'List users by role',
+          request: {
+            method: 'GET',
+            header: [
+              { key: 'Accept', value: 'application/json' }
+            ],
+            url: {
+              raw: '{{baseUrl}}/users?role=admin',
+              host: ['{{baseUrl}}'],
+              path: ['users'],
+              query: [
+                { key: 'role', value: 'admin' }
+              ]
+            }
+          },
+          response: [
+            {
+              name: 'User list',
+              originalRequest: {
+                method: 'GET',
+                header: [
+                  { key: 'Accept', value: 'application/json' }
+                ],
+                url: {
+                  raw: '{{baseUrl}}/users?role=admin',
+                  host: ['{{baseUrl}}'],
+                  path: ['users'],
+                  query: [
+                    { key: 'role', value: 'admin' }
+                  ]
+                }
+              },
+              status: 'OK',
+              code: 200,
+              _postman_previewlanguage: 'json',
+              _postman_previewtype: 'html',
+              header: [
+                { key: 'Content-Type', value: 'application/json' }
+              ],
+              cookie: [],
+              body: '{\n  "role": "admin",\n  "users": [\n    "alice",\n    "bob"\n  ]\n}'
+            },
+            {
+              name: 'User list',
+              originalRequest: {
+                method: 'GET',
+                header: [
+                  { key: 'Accept', value: 'application/json' }
+                ],
+                url: {
+                  raw: '{{baseUrl}}/users?role=user',
+                  host: ['{{baseUrl}}'],
+                  path: ['users'],
+                  query: [
+                    { key: 'role', value: 'user' }
+                  ]
+                }
+              },
+              status: 'OK',
+              code: 200,
+              _postman_previewlanguage: 'json',
+              _postman_previewtype: 'html',
+              header: [
+                { key: 'Content-Type', value: 'application/json' }
+              ],
+              cookie: [],
+              body: '{\n  "role": "user",\n  "users": [\n    "carol"\n  ]\n}'
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  variable: [
+    { key: 'baseUrl', value: 'https://api.example.com', type: 'any' }
+  ]
+};
+
+const spec = {
+  openapi: '3.0.0',
+  info: { title: 'Param Multi-Example API', version: '1.0.0' },
+  servers: [{ url: 'https://api.example.com' }],
+  paths: {
+    '/users': {
+      get: {
+        summary: 'List users by role',
+        parameters: [
+          {
+            name: 'role',
+            in: 'query',
+            required: true,
+            schema: { type: 'string' },
+            examples: {
+              admin: { value: 'admin' },
+              user: { value: 'user' }
+            }
+          }
+        ],
+        responses: {
+          200: {
+            description: 'User list',
+            content: {
+              'application/json': {
+                examples: {
+                  admin: { value: { role: 'admin', users: ['alice', 'bob'] } },
+                  user: { value: { role: 'user', users: ['carol'] } }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+module.exports = {
+  name: 'should pair response examples with matching query parameter examples and round-trip on sync',
+  specificationType: 'OPENAPI:3.0',
+  generationOptions: {
+    parametersResolution: 'Example',
+    requestParametersResolution: 'Example'
+  },
+  syncOptions: {
+    syncExamples: true
+  },
+  shouldAssertGenerationAndSyncing: true,
+  initialState: {
+    spec,
+    collection
+  },
+  finalState: {
+    spec,
+    collection
+  }
+};

--- a/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI31/index.js
+++ b/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI31/index.js
@@ -19,11 +19,13 @@ module.exports = {
   shouldHandlePostmanVariablesInUrl: require('./shouldHandlePostmanVariablesInUrl'),
   generateCollectionWithTypes: require('./shouldGenerateCollectionWithType'),
   shouldPreserveParamValues: require('./shouldPreserveParamValues'),
-  shouldPreserveAttributeValuesWhenSchemaBecomesEmptyObject: require('./shouldPreserveAttributeValuesWhenSchemaBecomesEmptyObject'),
+  shouldPreserveAttributeValuesWhenSchemaBecomesEmptyObject:
+    require('./shouldPreserveAttributeValuesWhenSchemaBecomesEmptyObject'),
   shouldUpdateValueWhenSchemaHasProperties: require('./shouldUpdateValueWhenSchemaHasProperties'),
   handle4xxand5xxAndDefaultResponseCode: require('./handle4xxand5xxAndDefaultResponseCode'),
   shouldSyncExamplesWhenSyncExamplesIsTrue: require('./shouldSyncExamplesWhenSyncExamplesIsTrue'),
   shouldNotSyncExamplesWhenSyncExamplesIsFalse: require('./shouldNotSyncExamplesWhenSyncExamplesIsFalse'),
+  shouldPairParameterExamplesByMatchingKey: require('./shouldPairParameterExamplesByMatchingKey'),
   // Multi-file specification test cases
   multiFileSpecs: require('./multiFileSpecs')
 };

--- a/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI31/shouldPairParameterExamplesByMatchingKey.js
+++ b/test/unit/CollectionGenerationAndSyncing/fixtures/OpenAPI31/shouldPairParameterExamplesByMatchingKey.js
@@ -1,12 +1,12 @@
-// A query parameter whose plural `examples` keys (admin, user, …) match the response example keys
-// produces one saved response per matched key, each carrying the paired parameter value in its
-// originalRequest url query. This fixture asserts the multi-example parameter pairing round-trips
-// AND that a spec-side edit propagates on sync: the final spec adds a third matched example (guest),
-// and the collection must gain a third paired saved response without churning the existing two.
+// OpenAPI 3.1 mirror: a query parameter whose plural `examples` keys (admin, user, …) match the
+// response example keys produces one saved response per matched key, each carrying the paired
+// parameter value in its originalRequest url query. The final spec adds a third matched example
+// (guest), and the collection must gain a third paired saved response on sync without churning the
+// existing two.
 
 module.exports = {
   name: 'should pair response examples with matching query parameter examples and sync an added example',
-  specificationType: 'OPENAPI:3.0',
+  specificationType: 'OPENAPI:3.1',
   generationOptions: {
     parametersResolution: 'Example',
     requestParametersResolution: 'Example'
@@ -17,7 +17,7 @@ module.exports = {
   shouldAssertGenerationAndSyncing: true,
   initialState: {
     spec: {
-      openapi: '3.0.0',
+      openapi: '3.1.0',
       info: { title: 'Param Multi-Example API', version: '1.0.0' },
       servers: [{ url: 'https://api.example.com' }],
       paths: {
@@ -124,7 +124,7 @@ module.exports = {
   },
   finalState: {
     spec: {
-      openapi: '3.0.0',
+      openapi: '3.1.0',
       info: { title: 'Param Multi-Example API', version: '1.0.0' },
       servers: [{ url: 'https://api.example.com' }],
       paths: {

--- a/test/unit/convertV2.test.js
+++ b/test/unit/convertV2.test.js
@@ -2874,6 +2874,240 @@ describe('The convert v2 Function', function() {
             done();
           });
       });
+
+    // Helper: descend the first child at each level to reach the first request item in the collection.
+    const getFirstRequestItem = (conversionResult) => {
+      let item = conversionResult.output[0].data.item[0];
+      while (item && item.item) { item = item.item[0]; }
+      return item;
+    };
+
+    // Helper: map a saved response's original-request query params to `key=value` strings.
+    const originalRequestQuery = (savedResponse) => {
+      return _.map(_.get(savedResponse, 'originalRequest.url.query', []), (q) => { return q.key + '=' + q.value; });
+    };
+
+    // Helper: map a saved response's original-request headers to `key=value` strings.
+    const originalRequestHeaders = (savedResponse) => {
+      return _.map(_.get(savedResponse, 'originalRequest.header', []), (h) => { return h.key + '=' + h.value; });
+    };
+
+    it('response examples pair with matching QUERY + HEADER parameter examples (no request body)', function (done) {
+      // Headline case: GET /users?role=admin|user. Parameter example keys (role, X-Trace) match the
+      // response example keys, so two saved responses are generated, each carrying the paired
+      // query/header value in its originalRequest. M = R ∩ (B ∪ P) = {admin, user}, B = ∅.
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'param examples', version: '1.0.0' },
+        paths: {
+          '/users': {
+            get: {
+              parameters: [
+                {
+                  name: 'role', in: 'query', schema: { type: 'string' },
+                  examples: { admin: { value: 'admin' }, user: { value: 'user' } }
+                },
+                {
+                  name: 'X-Trace', in: 'header', schema: { type: 'string' },
+                  examples: { admin: { value: 'trace-admin' }, user: { value: 'trace-user' } }
+                }
+              ],
+              responses: {
+                200: {
+                  description: 'OK',
+                  content: {
+                    'application/json': {
+                      examples: {
+                        admin: { value: { role: 'admin', users: ['a1', 'a2'] } },
+                        user: { value: { role: 'user', users: ['u1'] } }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      Converter.convertV2({ type: 'json', data: spec }, { parametersResolution: 'Example' },
+        (err, conversionResult) => {
+          expect(err).to.be.null;
+          expect(conversionResult.result).to.equal(true);
+
+          const item = getFirstRequestItem(conversionResult);
+
+          expect(item.response).to.have.lengthOf(2);
+
+          // First matched key: admin
+          expect(originalRequestQuery(item.response[0])).to.eql(['role=admin']);
+          expect(originalRequestHeaders(item.response[0])).to.include('X-Trace=trace-admin');
+          expect(JSON.parse(item.response[0].body)).to.eql({ role: 'admin', users: ['a1', 'a2'] });
+
+          // Second matched key: user
+          expect(originalRequestQuery(item.response[1])).to.eql(['role=user']);
+          expect(originalRequestHeaders(item.response[1])).to.include('X-Trace=trace-user');
+          expect(JSON.parse(item.response[1].body)).to.eql({ role: 'user', users: ['u1'] });
+          done();
+        });
+    });
+
+    it('response examples pair with matching PATH parameter examples', function (done) {
+      // Path parameter example keys match response example keys -> the saved response's
+      // originalRequest url path variable carries the paired value per example.
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'path param examples', version: '1.0.0' },
+        paths: {
+          '/users/{status}': {
+            get: {
+              parameters: [
+                {
+                  name: 'status', in: 'path', required: true, schema: { type: 'string' },
+                  examples: { active: { value: 'active' }, banned: { value: 'banned' } }
+                }
+              ],
+              responses: {
+                200: {
+                  description: 'OK',
+                  content: {
+                    'application/json': {
+                      examples: {
+                        active: { value: { status: 'active' } },
+                        banned: { value: { status: 'banned' } }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      Converter.convertV2({ type: 'json', data: spec }, { parametersResolution: 'Example' },
+        (err, conversionResult) => {
+          expect(err).to.be.null;
+          expect(conversionResult.result).to.equal(true);
+
+          const item = getFirstRequestItem(conversionResult),
+            pathVar = (savedResponse) => {
+              return _.map(_.get(savedResponse, 'originalRequest.url.variable', []), (v) => {
+                return v.key + '=' + v.value;
+              });
+            };
+
+          expect(item.response).to.have.lengthOf(2);
+          expect(pathVar(item.response[0])).to.include('status=active');
+          expect(JSON.parse(item.response[0].body)).to.eql({ status: 'active' });
+          expect(pathVar(item.response[1])).to.include('status=banned');
+          expect(JSON.parse(item.response[1].body)).to.eql({ status: 'banned' });
+          done();
+        });
+    });
+
+    it('a matched key present only in a parameter falls back to the first request body example', function (done) {
+      // The response + query param share keys (admin, user) but the request body has a single,
+      // non-matching example ('default'). The body falls back to its first example for every pair.
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'body fallback', version: '1.0.0' },
+        paths: {
+          '/x': {
+            post: {
+              parameters: [
+                {
+                  name: 'role', in: 'query', schema: { type: 'string' },
+                  examples: { admin: { value: 'admin' }, user: { value: 'user' } }
+                }
+              ],
+              requestBody: { content: { 'application/json': { examples: { default: { value: { a: 1 } } } } } },
+              responses: {
+                200: {
+                  description: 'OK',
+                  content: {
+                    'application/json': {
+                      examples: { admin: { value: { r: 'admin' } }, user: { value: { r: 'user' } } }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      Converter.convertV2({ type: 'json', data: spec }, { parametersResolution: 'Example' },
+        (err, conversionResult) => {
+          expect(err).to.be.null;
+          expect(conversionResult.result).to.equal(true);
+
+          const item = getFirstRequestItem(conversionResult);
+
+          expect(item.response).to.have.lengthOf(2);
+          expect(originalRequestQuery(item.response[0])).to.eql(['role=admin']);
+          expect(JSON.parse(item.response[0].originalRequest.body.raw)).to.eql({ a: 1 });
+          expect(originalRequestQuery(item.response[1])).to.eql(['role=user']);
+          expect(JSON.parse(item.response[1].originalRequest.body.raw)).to.eql({ a: 1 });
+          done();
+        });
+    });
+
+    it('a parameter whose plural keys do not match contributes its first example to every pair', function (done) {
+      // role (+ body + response) match by key (admin, user); the unmatched plural param 'sort'
+      // (asc, desc) contributes its first example (asc) to EVERY saved response without fragmenting
+      // the pairing (still exactly 2 saved responses).
+      const spec = {
+        openapi: '3.0.0',
+        info: { title: 'plural unmatched param', version: '1.0.0' },
+        paths: {
+          '/y': {
+            post: {
+              parameters: [
+                {
+                  name: 'role', in: 'query', schema: { type: 'string' },
+                  examples: { admin: { value: 'admin' }, user: { value: 'user' } }
+                },
+                {
+                  name: 'sort', in: 'query', schema: { type: 'string' },
+                  examples: { asc: { value: 'asc' }, desc: { value: 'desc' } }
+                }
+              ],
+              requestBody: {
+                content: {
+                  'application/json': { examples: { admin: { value: { a: 'A' } }, user: { value: { a: 'U' } } } }
+                }
+              },
+              responses: {
+                200: {
+                  description: 'OK',
+                  content: {
+                    'application/json': {
+                      examples: { admin: { value: { r: 'admin' } }, user: { value: { r: 'user' } } }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      Converter.convertV2({ type: 'json', data: spec }, { parametersResolution: 'Example' },
+        (err, conversionResult) => {
+          expect(err).to.be.null;
+          expect(conversionResult.result).to.equal(true);
+
+          const item = getFirstRequestItem(conversionResult);
+
+          expect(item.response).to.have.lengthOf(2);
+          expect(originalRequestQuery(item.response[0])).to.eql(['role=admin', 'sort=asc']);
+          expect(JSON.parse(item.response[0].originalRequest.body.raw)).to.eql({ a: 'A' });
+          expect(originalRequestQuery(item.response[1])).to.eql(['role=user', 'sort=asc']);
+          expect(JSON.parse(item.response[1].originalRequest.body.raw)).to.eql({ a: 'U' });
+          done();
+        });
+    });
   });
 
   it('[Github #11884] Should not contain duplicate variables created from requests path', function (done) {


### PR DESCRIPTION
Enhance parameter example mapping handling in schemaUtils and response merging

- Added support for `exampleKey` in `resolveValueOfParameter` to match parameter examples with response examples based on case-insensitive keys.
- Updated `generateExamples` to include parameter example keys, allowing for better pairing of request and response examples.
- Modified `mergeResponseData` to preserve existing request-side data (body, URL, headers) for non-first responses during sync, ensuring that changes in the spec do not overwrite all responses.
- Introduced tests to validate the new behavior of pairing parameter examples with response examples, ensuring correct functionality in various scenarios.