### PR TITLE
ci: add NPM trusted-publish release workflow

### DIFF
--- a/.github/workflows/pkg-release.yml
+++ b/.github/workflows/pkg-release.yml
@@ -1,0 +1,30 @@
+# This filename is associated with the respective NPM package's trusted publish config.
+# If required, update both together.
+
+name: Package Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v1.2.3 or v1.2.3-rc.1)'
+        required: true
+        type: string
+
+# required for OIDC-based NPM publish
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  call-npm-release:
+    uses: postmanlabs/gh-security-scan-workflow/.github/workflows/security-npm-publish.yml@main
+    with:
+      tag: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag }}
+      node_version: '20'
+    secrets:
+      POSTMAN_NPM_TOKEN: ${{ secrets.POSTMAN_NPM_TOKEN }}


### PR DESCRIPTION
## What
Adds `.github/workflows/pkg-release.yml` — an NPM release workflow that publishes to the registry via **OIDC trusted publishing** (Postman's shared `gh-security-scan-workflow/security-npm-publish.yml`).

## Triggers
- `push` of a `v*.*.*` tag (auto — the existing `publish-new-release.yml` already creates this tag when a `release/*` PR merges to master)
- Manual `workflow_dispatch` with an explicit tag

## Notes
- Follows the AppSec runbook: Setting up NPM Release Workflow (Confluence, APPSEC/7150829657)
- No `skip_tests` — this repo has a real test suite (`scripts/test.sh`), so the security workflow's test gate runs as intended.
- **Out of band (repo admins):** trusted-publisher config on npm + confirming the `POSTMAN_NPM_TOKEN` org secret (runbook steps 1-2) must be in place for the publish job to succeed.