### PR TITLE
ci: add NPM trusted-publish release workflow (master)

### DIFF
--- a/.github/workflows/pkg-release.yml
+++ b/.github/workflows/pkg-release.yml
@@ -1,0 +1,30 @@
+# This filename is associated with the respective NPM package's trusted publish config.
+# If required, update both together.
+
+name: Package Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v1.2.3 or v1.2.3-rc.1)'
+        required: true
+        type: string
+
+# required for OIDC-based NPM publish
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  call-npm-release:
+    uses: postmanlabs/gh-security-scan-workflow/.github/workflows/security-npm-publish.yml@main
+    with:
+      tag: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag }}
+      node_version: '20'
+    secrets:
+      POSTMAN_NPM_TOKEN: ${{ secrets.POSTMAN_NPM_TOKEN }}


### PR DESCRIPTION
## What
Brings `.github/workflows/pkg-release.yml` onto `master`. The same file was already merged to `develop` in #964.

## Why on master
Tag-triggered workflows run the workflow file **as it exists in the tagged commit's tree**. Releases are tagged on `master` (via `publish-new-release.yml`), so the file must be present on `master` for the tag-triggered NPM publish to fire.

## Scope
Isolated change — this branch contains only the workflow file (cherry-picked off current `master`), no unreleased `develop` work.

## Out of band (repo admins)
npm trusted-publisher config + `POSTMAN_NPM_TOKEN` org secret must be in place for the publish job to authenticate.