### PR TITLE
Release version v6.3.2 → develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [v6.3.2] - 2026-07-31
+
+### Fixed
+
+- Upgraded lodash and js-yaml to patch security advisories (SECINV-136)
+
 ## [v6.3.1] - 2026-07-23
 
 ## [v6.3.0] - 2026-07-07

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openapi-to-postmanv2",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "openapi-to-postmanv2",
-      "version": "6.3.1",
+      "version": "6.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-to-postmanv2",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "description": "Convert a given OpenAPI specification to Postman Collection v2.0",
   "homepage": "https://github.com/postmanlabs/openapi-to-postman",
   "bugs": "https://github.com/postmanlabs/openapi-to-postman/issues",


### PR DESCRIPTION
Back-merge of the v6.3.2 version bump + CHANGELOG into develop (mirrors the repo's draft-new-release automation, which opens PRs to both master and develop). Only touches package.json / package-lock.json / CHANGELOG.md.