### PR TITLE
ci: self-contained OIDC npm publish (public repo can't use private reusable workflow)

### DIFF
--- a/.github/workflows/pkg-release.yml
+++ b/.github/workflows/pkg-release.yml
@@ -1,30 +1,42 @@
-# This filename is associated with the respective NPM package's trusted publish config.
-# If required, update both together.
-
 name: Package Release
 
 on:
   push:
     tags:
       - 'v*.*.*'
-
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to publish (e.g. v1.2.3 or v1.2.3-rc.1)'
+        description: 'Tag to publish (e.g. v1.2.3)'
         required: true
         type: string
 
-# required for OIDC-based NPM publish
+# OIDC trusted publishing — no NPM token needed
 permissions:
   contents: read
   id-token: write
 
 jobs:
-  call-npm-release:
-    uses: postmanlabs/gh-security-scan-workflow/.github/workflows/security-npm-publish.yml@main
-    with:
-      tag: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag }}
-      node_version: '20'
-    secrets:
-      POSTMAN_NPM_TOKEN: ${{ secrets.POSTMAN_NPM_TOKEN }}
+  npm-publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (the tag being released)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm for OIDC trusted publishing (needs npm >= 11.5.1)
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish to npm
+        run: npm publish   # authenticates via OIDC; provenance added automatically


### PR DESCRIPTION
## What
Replaces the reusable-workflow call in `pkg-release.yml` with a **self-contained npm publish job** using OIDC trusted publishing.

## Why
This is a **public** repo, so it cannot call the reusable workflow `postmanlabs/gh-security-scan-workflow/.github/workflows/security-npm-publish.yml` — that repo is **private**, and public repos can't resolve private reusable workflows. The previous file would fail at workflow resolution.

## Change
- Drops the `uses: postmanlabs/gh-security-scan-workflow/...` job and the `POSTMAN_NPM_TOKEN` secret (not needed).
- Adds a self-contained job: `actions/checkout@v4` (the tag) → `actions/setup-node@v4` with `registry-url` → upgrade npm to >= 11.5.1 → `npm ci` → `npm publish`.
- `permissions: id-token: write` — authenticates via OIDC trusted publishing; provenance is added automatically. No token.
- Filename **unchanged** (`pkg-release.yml`) so the npm trusted-publisher config stays bound.

Pattern per npm trusted-publishers docs and postmanlabs/grpc-reflection-js#9.

## After merge
Re-run **Actions → Package Release → Run workflow** (tag `v6.3.2` for openapi / `v1.1.3` for swagger1) to publish.

> Master-only for now, as requested; develop will be synced separately.