### PR TITLE
ci: self-contained OIDC npm publish (develop sync)

### DIFF
--- a/.github/workflows/pkg-release.yml
+++ b/.github/workflows/pkg-release.yml
@@ -1,30 +1,42 @@
-# This filename is associated with the respective NPM package's trusted publish config.
-# If required, update both together.
-
 name: Package Release
 
 on:
   push:
     tags:
       - 'v*.*.*'
-
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to publish (e.g. v1.2.3 or v1.2.3-rc.1)'
+        description: 'Tag to publish (e.g. v1.2.3)'
         required: true
         type: string
 
-# required for OIDC-based NPM publish
+# OIDC trusted publishing — no NPM token needed
 permissions:
   contents: read
   id-token: write
 
 jobs:
-  call-npm-release:
-    uses: postmanlabs/gh-security-scan-workflow/.github/workflows/security-npm-publish.yml@main
-    with:
-      tag: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag }}
-      node_version: '20'
-    secrets:
-      POSTMAN_NPM_TOKEN: ${{ secrets.POSTMAN_NPM_TOKEN }}
+  npm-publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (the tag being released)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm for OIDC trusted publishing (needs npm >= 11.5.1)
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish to npm
+        run: npm publish   # authenticates via OIDC; provenance added automatically


### PR DESCRIPTION
## What
Syncs `develop`'s `pkg-release.yml` to the same **self-contained OIDC publish** workflow already merged to `master` in #968.

## Why
This is a public repo, so it cannot call the private reusable workflow `postmanlabs/gh-security-scan-workflow/...`. Replaces that call with a self-contained job (`checkout@v4` → `setup-node@v4` + `registry-url` → upgrade npm ≥ 11.5.1 → `npm ci` → `npm publish`) authenticating via OIDC trusted publishing (`id-token: write`, no token, provenance automatic).

Brings develop in line with master so future release branches inherit the working workflow. Filename unchanged so the npm trusted-publisher config stays bound.

Verified working: `openapi-to-postmanv2@6.3.2` was published from the master copy of this workflow.